### PR TITLE
Deploy snapshots to from master travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: java
 install: true
-script: "mvn package"
+script: if [[ "$TRAVIS_REPO_SLUG" == "immutables/immutables" && "$TRAVIS_BRANCH" == "master" ]]; then mvn deploy -DdeployAtEnd=true --settings settings.xml; else mvn package; fi
 jdk:
   - oraclejdk7
+env:
+  global:
+    - SONATYPE_USERNAME=<username>
+    # SONATYPE_PASSWORD, only used for mvn deploy from immutables/immutables master branch
+    - secure: "<encrypted password>"

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>sonatype-nexus-snapshots</id>
+      <username>${env.SONATYPE_USERNAME}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>


### PR DESCRIPTION
You would need to update attached .travis.yml with your sonatype username and encrypted password (I see you've posted some snapshots in the past).  For encrypting, see http://docs.travis-ci.com/user/environment-variables/#Secure-Variables.  I've done similar here: https://github.com/glowroot/glowroot/blob/master/.travis.yml.

I need to consume the latest immutables jars in my own travis build, so if you can deploy snapshot, I can just point to that until you are ready for next maven central release.  Thanks.
