### PR TITLE
SuppressWarnings "nullness" no longer needed

### DIFF
--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -20,7 +20,7 @@ package [type.packageName];
  * @see [v.immutableReferenceName]
 [/for]
  */
-@SuppressWarnings({"all", "nullness"})
+@SuppressWarnings("all")
 @javax.annotation.ParametersAreNonnullByDefault
 @javax.annotation.Generated({"Immutables.generator", "[type.name]"})
 [type.accessPrefix]final class [type.defName] {
@@ -48,7 +48,7 @@ package [type.packageName];
  * Use static factory methods to create instances: {@code of()} or
  * {@code builder()}.
  */
-@SuppressWarnings({"all", "nullness"})
+@SuppressWarnings("all")
 @javax.annotation.ParametersAreNonnullByDefault
 @javax.annotation.Generated({"Immutables.generator", "[type.name]"})
 @javax.annotation.concurrent.Immutable


### PR DESCRIPTION
Checker Framework 1.8.8 was just released and supports `@SuppressWarnings("all")`.  I'm good with removing my earlier change.  Thanks.
