### PR TITLE
Fix build on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# never use crlf for templates
+*.generator  eol=lf


### PR DESCRIPTION
I was getting build failures due to carriage returns in the templates (I'm using default git setup on windows where it checks out files using \r\n, and checks them in using \n).
