### PR TITLE
Support Java 8 type annotations

### DIFF
--- a/value-fixture/pom.xml
+++ b/value-fixture/pom.xml
@@ -48,4 +48,17 @@
       <version>1.1.6</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerVersion>1.8</compilerVersion>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/value-fixture/src/org/immutables/fixture/HasTypeAnnotation.java
+++ b/value-fixture/src/org/immutables/fixture/HasTypeAnnotation.java
@@ -1,0 +1,34 @@
+/*
+    Copyright 2014 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.fixture;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.example.TypeA;
+import org.example.TypeB;
+import org.immutables.value.Json;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Json.Marshaled
+public abstract class HasTypeAnnotation {
+  @Nullable
+  public abstract @TypeA @TypeB String str();
+  @Nullable
+  public abstract @TypeA @TypeB Map<String, String> map();
+}

--- a/value-fixture/test/org/immutables/fixture/ValuesTest.java
+++ b/value-fixture/test/org/immutables/fixture/ValuesTest.java
@@ -129,6 +129,12 @@ public class ValuesTest {
   }
 
   @Test
+  public void java8TypeAnnotation() {
+    ImmutableHasTypeAnnotation hasTypeAnnotation = ImmutableHasTypeAnnotation.builder().build();
+    check(hasTypeAnnotation.str()).isNull();
+  }
+
+  @Test
   public void withMethods() {
     ImmutableSillyValidatedBuiltValue value = ImmutableSillyValidatedBuiltValue.builder()
         .value(-10)

--- a/value-processor/src/org/immutables/value/processor/meta/AccessorAttributesCollector.java
+++ b/value-processor/src/org/immutables/value/processor/meta/AccessorAttributesCollector.java
@@ -16,15 +16,20 @@
 package org.immutables.value.processor.meta;
 
 import com.google.common.collect.Lists;
+
+import org.immutables.generator.AnnotationMirrors;
 import org.immutables.generator.SourceOrdering;
 import org.immutables.value.Value;
 import org.immutables.value.processor.meta.Proto.Protoclass;
+
 import javax.annotation.Nullable;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.*;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
+
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
@@ -223,7 +228,17 @@ final class AccessorAttributesCollector {
 
       attribute.reporter = reporter;
       attribute.round = round;
-      attribute.returnTypeName = returnType.toString();
+      String returnTypeString = returnType.toString();
+      if (returnTypeString.startsWith("(")) {
+        // has type annotations, e.g.
+        // (@org.example.TypeA,@org.example.TypeB :: Map<java.lang.String,java.lang.String>)
+        int index = returnTypeString.indexOf(" :: ");
+        String typeAnnotations = returnTypeString.substring(1, index);
+        String type = returnTypeString.substring(index + 4, returnTypeString.length() - 1);
+        attribute.returnTypeName = typeAnnotations.replace(',', ' ') + ' ' + type;
+      } else {
+        attribute.returnTypeName = returnType.toString();
+      }
       attribute.returnType = returnType;
       attribute.names = styles.forAccessor(name.toString());
       attribute.element = attributeMethodCandidate;

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -393,13 +393,7 @@ public class ValueAttribute extends TypeIntrospectionBase {
   }
 
   public String getRawType() {
-    String type = getType();
-    int endIndex = type.length();
-    int firstIndexOfGenerics = type.indexOf('<');
-    if (firstIndexOfGenerics > 0) {
-      endIndex = firstIndexOfGenerics;
-    }
-    return type.substring(0, endIndex);
+    return extractRawType(getType());
   }
 
   public String getConsumedElementType() {
@@ -411,11 +405,16 @@ public class ValueAttribute extends TypeIntrospectionBase {
   }
 
   private String extractRawType(String className) {
-    int indexOfGenerics = className.indexOf('<');
+    String rawType = className;
+    int indexOfGenerics = rawType.indexOf('<');
     if (indexOfGenerics > 0) {
-      return className.substring(0, indexOfGenerics);
+      rawType = rawType.substring(0, indexOfGenerics);
     }
-    return className;
+    int endOfTypeAnnotations = rawType.lastIndexOf(' ');
+    if (endOfTypeAnnotations > 0) {
+      rawType = rawType.substring(endOfTypeAnnotations + 1);
+    }
+    return rawType;
   }
 
   public boolean isUnwrappedElementPrimitiveType() {


### PR DESCRIPTION
The attached code depending on the format of TypeMirror.toString() isn't ideal.  I started down the path of using ((DeclaredType) returnType).getAnnotationMirrors(), which wasn't bad, but then I also needed to deal with ((DeclaredType) returnType).getTypeArguments() and then I started thinking about generic nested types inside of generic types and my head began to spin.
