### PR TITLE
Allow non-conflicting primitive "from" attributes and still generate "from" builder

### DIFF
--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -862,7 +862,7 @@ public final class ValueType extends TypeIntrospectionBase {
 
   private boolean noAttributeInitializerIsNamedAsFrom() {
     for (ValueAttribute a : getSettableAttributes()) {
-      if (a.names.init.equals(names().from)) {
+      if (a.names.init.equals(names().from) && !a.isPrimitive()) {
         a.report().warning(
             "Attribute initializer named '%s' clashes with special builder method, "
                 + "which will not be generated to not have ambiguous overload or conflict",


### PR DESCRIPTION
Hi, I get lots of these warnings because I use `from` as an attribute name in several @Value.Immutable classes (e.g. from/to in milliseconds range).  I could change the "from" builder name using @Value.Style, but I like the default "from" builder name (even though I'm not using it yet).  I'm wondering if it's ok to safely allow "from" attributes when they are primitives?  Thanks.