### PR TITLE
add ability to pass annotations down to the json layer.

### DIFF
--- a/value-fixture/src/nonimmutables/AdditionalJacksonAnnotation.java
+++ b/value-fixture/src/nonimmutables/AdditionalJacksonAnnotation.java
@@ -1,0 +1,12 @@
+package nonimmutables;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AdditionalJacksonAnnotation {
+  String value() default "";
+}

--- a/value-fixture/src/org/immutables/fixture/jackson/JacksonMappedWithExtraAnnotation.java
+++ b/value-fixture/src/org/immutables/fixture/jackson/JacksonMappedWithExtraAnnotation.java
@@ -1,0 +1,16 @@
+package org.immutables.fixture.jackson;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import nonimmutables.AdditionalJacksonAnnotation;
+
+@Value.Immutable
+@Value.Style(additionalJsonAnnotations = { AdditionalJacksonAnnotation.class})
+@JsonDeserialize(as = ImmutableJacksonMappedWithExtraAnnotation.class)
+public interface JacksonMappedWithExtraAnnotation {
+
+  @AdditionalJacksonAnnotation("not_name")
+  String getName();
+}

--- a/value-fixture/test/org/immutables/fixture/jackson/JsonAnnotationTest.java
+++ b/value-fixture/test/org/immutables/fixture/jackson/JsonAnnotationTest.java
@@ -1,0 +1,14 @@
+package org.immutables.fixture.jackson;
+
+import static org.immutables.check.Checkers.check;
+
+import org.junit.Test;
+
+import nonimmutables.AdditionalJacksonAnnotation;
+
+public class JsonAnnotationTest {
+  @Test
+  public void itPassesJsonAnnotations() throws NoSuchFieldException {
+    check(ImmutableJacksonMappedWithExtraAnnotation.Json.class.getDeclaredField("name").getAnnotation(AdditionalJacksonAnnotation.class)).notNull();
+  }
+}

--- a/value-processor/src/org/immutables/value/processor/meta/Proto.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Proto.java
@@ -1051,6 +1051,7 @@ public class Proto {
           input.headerComments(),
           input.jdkOnly(),
           ImmutableSet.copyOf(input.passAnnotationsName()),
+          ImmutableSet.copyOf(input.additionalJsonAnnotationsName()),
           input.visibility(),
           input.optionalAcceptNullable(),
           input.generateSuppressAllWarnings());

--- a/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
+++ b/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
@@ -140,6 +140,9 @@ public abstract class StyleInfo implements ValueMirrors.Style {
   public abstract ImmutableSet<String> passAnnotationsNames();
 
   @Value.Parameter
+  public abstract ImmutableSet<String> additionalJsonAnnotationsNames();
+
+  @Value.Parameter
   @Override
   public abstract ImplementationVisibility visibility();
 
@@ -154,6 +157,11 @@ public abstract class StyleInfo implements ValueMirrors.Style {
   @Override
   public Class<? extends Annotation>[] passAnnotations() {
     throw new UnsupportedOperationException("Use StyleInfo.passAnnotationsNames() instead");
+  }
+
+  @Override
+  public Class<? extends Annotation>[] additionalJsonAnnotations() {
+    throw new UnsupportedOperationException("Use StyleInfo.additionalJsonAnnotationsNames() instead");
   }
 
   @Value.Lazy

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -22,8 +22,11 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
 import java.lang.annotation.ElementType;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -218,14 +221,14 @@ public final class ValueAttribute extends TypeIntrospectionBase {
 
   public List<CharSequence> getAnnotations() {
     return Annotations.getAnnotationLines(element,
-        containingType.constitution.protoclass().styles().style().passAnnotationsNames(),
+        Sets.union(containingType.constitution.protoclass().styles().style().passAnnotationsNames(), containingType.constitution.protoclass().styles().style().additionalJsonAnnotationsNames()),
         false,
         ElementType.METHOD);
   }
 
   public List<CharSequence> getParameterAnnotations() {
     return Annotations.getAnnotationLines(element,
-        containingType.constitution.protoclass().styles().style().passAnnotationsNames(),
+        Sets.union(containingType.constitution.protoclass().styles().style().passAnnotationsNames(), containingType.constitution.protoclass().styles().style().additionalJsonAnnotationsNames()),
         false,
         ElementType.PARAMETER);
   }
@@ -242,6 +245,11 @@ public final class ValueAttribute extends TypeIntrospectionBase {
       appendedJsonPropertyAnnotation.add("@" + JsonPropertyMirror.qualifiedName());
     }
 
+    List<CharSequence> additionalJsonAnnotations = Annotations.getAnnotationLines(element,
+        containingType.constitution.protoclass().styles().style().additionalJsonAnnotationsNames(),
+        false,
+        ElementType.FIELD);
+
     List<CharSequence> allJacksonAnnotations = Annotations.getAnnotationLines(element,
         Collections.<String>emptySet(),
         true,
@@ -249,6 +257,7 @@ public final class ValueAttribute extends TypeIntrospectionBase {
 
     return FluentIterable.from(allJacksonAnnotations)
         .append(appendedJsonPropertyAnnotation)
+        .append(additionalJsonAnnotations)
         .toList();
   }
 

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -131,6 +131,8 @@ public final class ValueMirrors {
 
     Class<? extends Annotation>[] passAnnotations() default {};
 
+    Class<? extends Annotation>[] additionalJsonAnnotations() default {};
+
     ImplementationVisibility visibility() default ImplementationVisibility.SAME;
 
     boolean optionalAcceptNullable() default false;

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -285,7 +285,7 @@ public final class ValueType extends TypeIntrospectionBase {
   public List<CharSequence> passedAnnotations() {
     return Annotations.getAnnotationLines(
         element,
-        constitution.protoclass().styles().style().passAnnotationsNames(),
+        Sets.union(constitution.protoclass().styles().style().passAnnotationsNames(), constitution.protoclass().styles().style().additionalJsonAnnotationsNames()),
         false,
         ElementType.TYPE);
   }

--- a/value/src/org/immutables/value/Value.java
+++ b/value/src/org/immutables/value/Value.java
@@ -198,16 +198,16 @@ public @interface Value {
    * <pre>
    * &#064;Value.Immutable
    * public abstract class Order {
-   * 
+   *
    *   public abstract List&lt;Item&gt; items();
-   * 
+   *
    *   &#064;Value.Lazy
    *   public int totalCost() {
    *     int cost = 0;
-   * 
+   *
    *     for (Item i : items())
    *       cost += i.count() * i.price();
-   * 
+   *
    *     return cost;
    *   }
    * }
@@ -514,7 +514,7 @@ public @interface Value {
      *     allParameters = true,
      *     defaults = {@literal @}Value.Immutable(builder = false))
      * public @interface Tuple {}
-     * 
+     *
      * {@literal @}Tuple
      * {@literal @}Value.Immutable
      * interface Color {
@@ -522,7 +522,7 @@ public @interface Value {
      *   int green();
      *   int blue();
      * }
-     * 
+     *
      * ColorTuple.of(0xFF, 0x00, 0xFE);
      * </pre>
      * @return if all attributes will be considered parameters
@@ -549,7 +549,7 @@ public @interface Value {
 
     /**
      * List type of annotations to copy over from abstract value type to immutable implementation
-     * class. Very often this functionality is not needed when annoatations are declared as
+     * class. Very often this functionality is not needed when annotations are declared as
      * {@link Inherited}, but there are cases where you need to pass specific non-inherited
      * annotations to the implementation class. In general, copying all type-level annotations is
      * not very safe for annotation processing and some other annotation consumers. By default, no
@@ -562,6 +562,12 @@ public @interface Value {
      *         attributes.
      */
     Class<? extends Annotation>[] passAnnotations() default {};
+
+    /**
+     * List of additional annotations to pass through for any jackson json object
+     * @return types of annotations to pass to the json methods on an immutable implemenation class
+     */
+    Class<? extends Annotation>[] additionalJsonAnnotations() default {};
 
     /**
      * Specify the mode in which visibility of generated value type is derived from abstract value


### PR DESCRIPTION
this is for the addition to #150 so we can pass extra annotations down to the Json layer.  The reason we want this is because we use [Rosetta](https://github.com/HubSpot/Rosetta) and need to pass these annotations for the rosetta mapper.