### PR TITLE
add the databind annotation to the json object.

### DIFF
--- a/value-fixture/src/org/immutables/fixture/jackson/JacksonMappedWithExtraAnnotation.java
+++ b/value-fixture/src/org/immutables/fixture/jackson/JacksonMappedWithExtraAnnotation.java
@@ -2,7 +2,10 @@ package org.immutables.fixture.jackson;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
 import nonimmutables.AdditionalJacksonAnnotation;
 
@@ -11,6 +14,8 @@ import nonimmutables.AdditionalJacksonAnnotation;
 @JsonDeserialize(as = ImmutableJacksonMappedWithExtraAnnotation.class)
 public interface JacksonMappedWithExtraAnnotation {
 
-  @AdditionalJacksonAnnotation("not_name")
-  String getName();
+  @AdditionalJacksonAnnotation("some_long")
+  @JsonProperty("some_long_string")
+  @JsonSerialize(using=ToStringSerializer.class)
+  Long getSomeLong();
 }

--- a/value-fixture/test/org/immutables/fixture/jackson/JsonAnnotationTest.java
+++ b/value-fixture/test/org/immutables/fixture/jackson/JsonAnnotationTest.java
@@ -2,13 +2,23 @@ package org.immutables.fixture.jackson;
 
 import static org.immutables.check.Checkers.check;
 
+import java.lang.reflect.Field;
+
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
 import nonimmutables.AdditionalJacksonAnnotation;
 
 public class JsonAnnotationTest {
   @Test
   public void itPassesJsonAnnotations() throws NoSuchFieldException {
-    check(ImmutableJacksonMappedWithExtraAnnotation.Json.class.getDeclaredField("name").getAnnotation(AdditionalJacksonAnnotation.class)).notNull();
+    Field declared = ImmutableJacksonMappedWithExtraAnnotation.Json.class.getDeclaredField("someLong");
+    check(declared.getAnnotation(AdditionalJacksonAnnotation.class).value()).is("some_long");
+    check(declared.getAnnotation(JsonProperty.class).value()).is("some_long_string");
+    check(declared.getAnnotation(JsonSerialize.class).using()).is(CoreMatchers.equalTo(ToStringSerializer.class));
   }
 }

--- a/value-processor/src/org/immutables/value/processor/meta/Annotations.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Annotations.java
@@ -15,16 +15,19 @@
  */
 package org.immutables.value.processor.meta;
 
-import com.google.common.collect.Lists;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import java.util.List;
 import java.util.Set;
+
 import javax.annotation.Nullable;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
+
 import org.immutables.generator.AnnotationMirrors;
+
+import com.google.common.collect.Lists;
 
 final class Annotations {
   private Annotations() {}
@@ -32,6 +35,7 @@ final class Annotations {
   private static final String PREFIX_JAVA_LANG = "java.lang.";
   private static final String PREFIX_IMMUTABLES = "org.immutables.";
   private static final String PREFIX_JACKSON = "com.fasterxml.jackson.annotation.";
+  private static final String PREFIX_JACKSON_DATABIND = "com.fasterxml.jackson.databind.annotation.";
 
   static final String NULLABLE_SIMPLE_NAME = "Nullable";
 
@@ -72,7 +76,7 @@ final class Annotations {
     }
 
     if (includeJacksonAnnotations
-        && qualifiedName.startsWith(PREFIX_JACKSON)) {
+        && (qualifiedName.startsWith(PREFIX_JACKSON) || qualifiedName.startsWith(PREFIX_JACKSON_DATABIND))) {
       return true;
     }
 


### PR DESCRIPTION
We annotate some of our methods with `@JsonSerialize` as the objects need to be serialised a different way, this also needs to be passed down to the json class