### PR TITLE
Added support for optional generation of a private noarg default constructor

### DIFF
--- a/value-fixture/src/org/immutables/fixture/PrivateNoArgConstructor.java
+++ b/value-fixture/src/org/immutables/fixture/PrivateNoArgConstructor.java
@@ -1,0 +1,63 @@
+package org.immutables.fixture;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Style;
+
+@Value.Immutable
+@Style(privateNoargConstructor = true)
+interface PrivateNoargConstructorNominal {
+  boolean is();
+  byte b();
+  short s();
+  int i();
+  long l();
+  char c();
+  float f();
+  double d();
+  Object o();
+}
+
+@Value.Immutable(prehash=true)
+@Style(privateNoargConstructor = true)
+interface PrivateNoargConstructorOverridePrehash {
+
+  boolean is();
+  byte b();
+  short s();
+  int i();
+  long l();
+  char c();
+  float f();
+  double d();
+  Object o();
+}
+
+@Value.Immutable(prehash=true)
+@Style(privateNoargConstructor = false)
+interface PrivateNoargConstructorOptionFalseDoNotAffectPrehash {
+
+  boolean is();
+  byte b();
+  short s();
+  int i();
+  long l();
+  char c();
+  float f();
+  double d();
+  Object o();
+}
+
+
+@Value.Immutable(singleton = true)
+@Style(privateNoargConstructor = true)
+interface PrivateNoargConstructorIsOverriddenBySingleton {
+  
+  @Value.Default
+  default int test() {
+    return 1;
+  }
+  
+  default void use() {
+    ImmutablePrivateNoargConstructorIsOverriddenBySingleton.of();
+  }
+}

--- a/value-fixture/test/org/immutables/fixture/PrivateDefaultConstructorTest.java
+++ b/value-fixture/test/org/immutables/fixture/PrivateDefaultConstructorTest.java
@@ -1,0 +1,31 @@
+package org.immutables.fixture;
+
+import static org.junit.Assert.assertEquals;
+import java.lang.reflect.Field;
+import org.junit.Test;
+
+public class PrivateDefaultConstructorTest {
+
+  @Test
+  public void testNominal() throws Exception {
+    ImmutablePrivateNoargConstructorNominal.class.getDeclaredConstructor();
+  }
+
+  @Test(expected = NoSuchMethodException.class)
+  public void testOverridePrehash() throws Exception {
+    ImmutablePrivateNoargConstructorOverridePrehash.class.getDeclaredMethod("computeHashCode");
+  }
+  
+  @Test
+  public void testDoesNotOverridePrehashWhenOff() throws Exception {
+    ImmutablePrivateNoargConstructorOptionFalseDoNotAffectPrehash.class.getDeclaredMethod("computeHashCode");
+  }
+
+  @Test
+  public void testOverridenBySingleton() throws Exception {
+    ImmutablePrivateNoargConstructorIsOverriddenBySingleton singleton = ImmutablePrivateNoargConstructorIsOverriddenBySingleton.of();
+    Field test = singleton.getClass().getDeclaredField("test");
+    test.setAccessible(true);
+    assertEquals(singleton.test(), test.get(singleton));
+  }
+}

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1201,6 +1201,20 @@ return [type.factoryOf]([output.linesShortable][for v in type.settableAttributes
 [/if]
 [/output.trim][/template]
 
+[template generateConstructorNoAttributes Type type Attribute... attributes]
+[for v in attributes, n = v.name]
+[if v.primitive]
+  [if v.boolean]
+this.[n] = false;
+  [else]
+this.[n] = 0;
+  [/if]  
+[else]
+this.[n] = null;
+[/if]
+[/for]
+[/template]
+
 [template generateConstructorDefaultAttributes Type type Attribute... attributes]
 [for v in attributes if not (v.generateDefault or v.generateDerived), n = v.name]
 this.[n] = [emptyImmutableInstanceInferred type v];
@@ -1234,6 +1248,12 @@ this.[n] = [if type.generateJdkOnly][objectsUtilRef type]requireNonNull[else][gu
 
   private [type.typeImmutable.simple]() {[output.collapsible]
     [generateConstructorDefaultAttributes type type.implementedAttributes]
+    [generateAfterConstruction type false]
+  [/output.collapsible]}
+[else if type.generatePrivateNoargConstructor]
+
+  private [type.typeImmutable.simple]() {[output.collapsible]
+    [generateConstructorNoAttributes type type.implementedAttributes]
     [generateAfterConstruction type false]
   [/output.collapsible]}
 [/if]

--- a/value-processor/src/org/immutables/value/processor/meta/Proto.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Proto.java
@@ -1054,7 +1054,8 @@ public class Proto {
           ImmutableSet.copyOf(input.additionalJsonAnnotationsName()),
           input.visibility(),
           input.optionalAcceptNullable(),
-          input.generateSuppressAllWarnings());
+          input.generateSuppressAllWarnings(),
+          input.privateNoargConstructor());
     }
   }
 

--- a/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
+++ b/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
@@ -154,6 +154,10 @@ public abstract class StyleInfo implements ValueMirrors.Style {
   @Override
   public abstract boolean generateSuppressAllWarnings();
 
+  @Value.Parameter
+  @Override
+  public abstract boolean privateNoargConstructor();
+
   @Override
   public Class<? extends Annotation>[] passAnnotations() {
     throw new UnsupportedOperationException("Use StyleInfo.passAnnotationsNames() instead");

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Sets;
 
 import java.lang.annotation.ElementType;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -138,6 +138,8 @@ public final class ValueMirrors {
     boolean optionalAcceptNullable() default false;
 
     boolean generateSuppressAllWarnings() default true;
+    
+    boolean privateNoargConstructor() default false;
 
     public enum ImplementationVisibility {
       PUBLIC,

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -359,7 +359,8 @@ public final class ValueType extends TypeIntrospectionBase {
   }
 
   public boolean isUsePrehashed() {
-    return immutableFeatures.prehash();
+    return immutableFeatures.prehash() 
+        && !isGeneratePrivateNoargConstructor();
     // || isUseInterned()
     // || isGenerateOrdinalValue()
   }
@@ -659,6 +660,13 @@ public final class ValueType extends TypeIntrospectionBase {
         .styles()
         .style()
         .strictBuilder();
+  }
+  
+  public boolean isGeneratePrivateNoargConstructor() {
+    return constitution.protoclass()
+        .styles()
+        .style()
+        .privateNoargConstructor();    
   }
 
   public List<ValueAttribute> getImplementedAttributes() {

--- a/value-processor/src/org/immutables/value/processor/meta/ValueTypeComposer.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueTypeComposer.java
@@ -117,6 +117,7 @@ public final class ValueTypeComposer {
     checkAttributeNamesIllegalCharacters(type);
     checkAttributeNamesForDuplicates(type, protoclass);
     checkConstructability(type);
+    checkStyleConflicts(protoclass);
     return type;
   }
 
@@ -164,7 +165,16 @@ public final class ValueTypeComposer {
       }
     }
   }
-
+  
+  private void checkStyleConflicts(Protoclass protoclass) {
+    if (protoclass.features().prehash()
+        && protoclass.styles().style().privateNoargConstructor()) {
+      protoclass.report()
+          .annotationNamed(ImmutableMirror.simpleName())
+          .warning("'prehash' feature is automatically disabled when 'privateNoargConstructor' style is turned on");
+    }
+  }
+  
   private void checkForTypeHierarchy(Protoclass protoclass, ValueType type) {
     scanAndReportInvalidInheritance(protoclass, type.element, type.extendedClasses());
     scanAndReportInvalidInheritance(protoclass, type.element, type.implementedInterfaces());

--- a/value/src/org/immutables/value/Value.java
+++ b/value/src/org/immutables/value/Value.java
@@ -68,7 +68,7 @@ public @interface Value {
      * specified parameters. Default is {@literal false}. To access singleton instance use
      * {@code .of()} static accessor method.
      * <p>
-     * This requires that all attributes have default value (includind collections which can be left
+     * This requires that all attributes have default value (including collections which can be left
      * empty). If some required attributes exist it will result in compilation error. Note that in
      * case object do not have attributes, singleton instance will be generated automatically.
      * <p>
@@ -100,6 +100,9 @@ public @interface Value {
      * This could speed up collection lookups for objects with lots of attributes and nested
      * objects.
      * In general, use this when {@code hashCode} computation is expensive and will be used a lot.
+     * 
+     * Note that if {@link Style#privateNoargConstructor()} == <code>true</code> this option will be ignored.
+     * 
      * @return if generate hash code precomputing
      */
     boolean prehash() default false;
@@ -594,6 +597,13 @@ public @interface Value {
      * @return {@code true} if will generate suppress all warnings, enabled by default.
      */
     boolean generateSuppressAllWarnings() default true;
+
+    /**
+     * Generate a default no argument constructor in generated code. Note that this property will 
+     * be ignored if {@link Immutable#singleton()} returns <code>true</code>.
+     * @return {@code true} if will generate a default no argument constructor, disabled by default.
+     */
+    boolean privateNoargConstructor() default false;
 
     /**
      * If implementation visibility is more restrictive than visibility of abstract value type, then


### PR DESCRIPTION
Allows supporting frameworks that build objects reflectively, most notably ORMs.