### PR TITLE
Added support for the Atlassian Fugue Option class

### DIFF
--- a/cases/pom.xml
+++ b/cases/pom.xml
@@ -52,6 +52,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.atlassian.fugue</groupId>
+      <artifactId>fugue</artifactId>
+      <version>2.2.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.atlassian.fugue</groupId>
+      <artifactId>fugue</artifactId>
+      <version>3.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <!-- Test only for moshi -->
       <groupId>com.squareup.moshi</groupId>
       <artifactId>moshi</artifactId>

--- a/cases/test/org/immutables/moshi/Adapt.java
+++ b/cases/test/org/immutables/moshi/Adapt.java
@@ -1,5 +1,6 @@
 package org.immutables.moshi;
 
+import com.atlassian.fugue.Option;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.SetMultimap;
@@ -19,6 +20,12 @@ public interface Adapt {
 
   @Value.Parameter
   Multiset<Nst> bag();
+
+  @Value.Parameter
+  Option<String> optionFugue2();
+
+  @Value.Parameter
+  io.atlassian.fugue.Option<String> optionFugue3();
 
   @Value.Immutable
   public interface Inr {

--- a/cases/test/org/immutables/trees/ast/SampleTree.java
+++ b/cases/test/org/immutables/trees/ast/SampleTree.java
@@ -1,5 +1,6 @@
 package org.immutables.trees.ast;
 
+import com.atlassian.fugue.Option;
 import com.google.common.base.Optional;
 import java.util.List;
 import org.immutables.trees.Trees;
@@ -30,6 +31,10 @@ public class SampleTree {
     List<Integer> cardinalities();
 
     Optional<String> position();
+
+    Option<String> fugue2Option();
+
+    io.atlassian.fugue.Option<String> fugue3Option();
 
     enum Kind {
       PLUS,

--- a/value-fixture/pom.xml
+++ b/value-fixture/pom.xml
@@ -76,6 +76,16 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.atlassian.fugue</groupId>
+      <artifactId>fugue</artifactId>
+      <version>2.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.atlassian.fugue</groupId>
+      <artifactId>fugue</artifactId>
+      <version>3.0.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/value-fixture/src/org/immutables/fixture/SillyStructureWithId.java
+++ b/value-fixture/src/org/immutables/fixture/SillyStructureWithId.java
@@ -15,6 +15,7 @@
  */
 package org.immutables.fixture;
 
+import com.atlassian.fugue.Option;
 import com.google.common.base.Optional;
 import java.util.List;
 import org.immutables.fixture.subpack.SillySubstructure;
@@ -35,6 +36,10 @@ public interface SillyStructureWithId {
   boolean flag2();
 
   Optional<Integer> opt3();
+
+  Option<Integer> opt4();
+
+  io.atlassian.fugue.Option<Integer> opt5();
 
   long very4();
 

--- a/value-fixture/src/org/immutables/fixture/jdkonly/UsingAllOptionals.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/UsingAllOptionals.java
@@ -15,6 +15,7 @@
  */
 package org.immutables.fixture.jdkonly;
 
+import com.atlassian.fugue.Option;
 import com.google.common.base.Optional;
 import java.util.Objects;
 import java.util.OptionalDouble;
@@ -35,6 +36,10 @@ public interface UsingAllOptionals {
   OptionalLong l1();
 
   OptionalDouble d1();
+
+  Option<String> fo2();
+
+  io.atlassian.fugue.Option<String> fo3();
 
   class Use {
     void use() {

--- a/value-fixture/src/org/immutables/fixture/modifiable/Companion.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/Companion.java
@@ -1,5 +1,6 @@
 package org.immutables.fixture.modifiable;
 
+import com.atlassian.fugue.Option;
 import com.google.common.base.Optional;
 import com.google.common.collect.*;
 import org.immutables.value.Value;
@@ -86,6 +87,10 @@ interface Companion {
     OptionalLong l1();
 
     OptionalDouble d1();
+
+    Option<Integer> fugue2();
+
+    io.atlassian.fugue.Option<Integer> fugue3();
 
     @Value.Default
     default int def() {

--- a/value-processor/src/org/immutables/value/processor/Gsons.generator
+++ b/value-processor/src/org/immutables/value/processor/Gsons.generator
@@ -201,7 +201,7 @@ if ([a.name]Value != null) {
 }
   [else if a.optionalType]
 [a.type] [a.name]Optional = instance.[a.names.get]();
-if ([a.name]Optional.isPresent()) {
+if ([a.name]Optional.[optionalPresent a]) {
   [a.unwrappedElementType] [a.name]Value = [a.name]Optional.[optionalGet a];
   [generateWriteAttributeValue type a (a.name 'Value') false]
 } else {
@@ -268,7 +268,7 @@ if ([a.name]Value != null) {
 }
   [else if a.optionalType]
 [a.type] [a.name]Optional = instance.[a.names.get]();
-if ([a.name]Optional.isPresent()) {
+if ([a.name]Optional.[optionalPresent a]) {
   out.name([serializedName a]);
   [a.unwrappedElementType] [a.name]Value = [a.name]Optional.[optionalGet a];
   [generateWriteAttributeValue type a (a.name 'Value') false]
@@ -692,4 +692,6 @@ out.value([variableName]);
 
 [template optionalGet Attribute a][if a.jdkSpecializedOptional]getAs[toUpper a.elementType][else]get[/if]()[/template]
 
-[template optionalEmpty Attribute a][a.rawType].[if a.jdkOptional]empty[else]absent[/if]()[/template]
+[template optionalEmpty Attribute a][a.rawType].[if a.jdkOptional]empty[else if a.fugueOptional]none[else]absent[/if]()[/template]
+
+[template optionalPresent Attribute a][if a.fugueOptional]isDefined[else]isPresent[/if]()[/template]

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -210,7 +210,7 @@ private static class SerialForm implements java.io.Serializable {
       values.add(toArray(instance.[v.names.get]().[if v.multimapType]entries[else]entrySet[/if]()));
     }
     [else if v.optionalType]
-    if (instance.[v.names.get]().isPresent()) {
+    if (instance.[v.names.get]().[optionalPresent v]) {
       names.add("[v.name]");
       values.add(instance.[v.names.get]().[optionalGet v]);
     }
@@ -1219,7 +1219,7 @@ if ([for l in positions.longs][if not for.first]
 [v.names.putAll](instance.[v.names.get]());
   [else if v.optionalType]
 [v.type] [v.name]Optional = instance.[v.names.get]();
-if ([v.name]Optional.isPresent()) {
+if ([v.name]Optional.[optionalPresent v]) {
   [v.names.init]([v.name]Optional);
 }
   [else if v.nullable]
@@ -2458,9 +2458,11 @@ return [if type.innerBuilder.isExtending]([type.typeBuilder]) [/if]this;
 
 [template optionalGet Attribute a][if a.jdkSpecializedOptional]getAs[toUpper a.elementType][else]get[/if]()[/template]
 
-[template optionalEmpty Attribute a][a.rawType].[if a.jdkOptional]empty[else]absent[/if]()[/template]
+[template optionalEmpty Attribute a][a.rawType].[if a.jdkOptional]empty[else if a.fugueOptional]none[else]absent[/if]()[/template]
 
-[template optionalOf Attribute a][a.rawType].[if not a.optionalAcceptNullable]of[else if a.jdkOptional]ofNullable[else]fromNullable[/if][/template]
+[template optionalOf Attribute a][a.rawType].[if not a.optionalAcceptNullable][if a.fugueOptional]some[else]of[/if][else if a.jdkOptional]ofNullable[else if a.fugueOptional]option[else]fromNullable[/if][/template]
+
+[template optionalPresent Attribute a][if a.fugueOptional]isDefined[else]isPresent[/if]()[/template]
 
 [template atNullableAccept Attribute a][if a.optionalType and a.optionalAcceptNullable][atNullable][/if][/template]
 

--- a/value-processor/src/org/immutables/value/processor/Modifiables.generator
+++ b/value-processor/src/org/immutables/value/processor/Modifiables.generator
@@ -635,7 +635,7 @@ private [v.atNullability][v.type] [v.name];
 [v.names.putAll](instance.[v.names.get]());
   [else if v.optionalType]
 [v.type] [v.name]Optional = instance.[v.names.get]();
-if ([v.name]Optional.isPresent()) {
+if ([v.name]Optional.[optionalPresent v]) {
   [v.names.set]([v.name]Optional);
 }
   [else if v.nullable]
@@ -845,9 +845,11 @@ import [starImport];
 
 [template optionalGet Attribute a][if a.jdkSpecializedOptional]getAs[toUpper a.elementType][else]get[/if]()[/template]
 
-[template optionalEmpty Attribute a][a.rawType].[if a.jdkOptional]empty[else]absent[/if]()[/template]
+[template optionalEmpty Attribute a][a.rawType].[if a.jdkOptional]empty[else if a.fugueOptional]none[else]absent[/if]()[/template]
 
-[template optionalOf Attribute a][a.rawType].[if not a.optionalAcceptNullable]of[else if a.jdkOptional]ofNullable[else]fromNullable[/if][/template]
+[template optionalOf Attribute a][a.rawType].[if not a.optionalAcceptNullable][if a.fugueOptional]some[else]of[/if][else if a.jdkOptional]ofNullable[else if a.fugueOptional]option[else]fromNullable[/if][/template]
+
+[template optionalPresent Attribute a][if a.fugueOptional]isDefined[else]isPresent[/if]()[/template]
 
 [template atNullableAccept Attribute a][if a.optionalType and a.optionalAcceptNullable][atNullable][/if][/template]
 

--- a/value-processor/src/org/immutables/value/processor/OkJsons.generator
+++ b/value-processor/src/org/immutables/value/processor/OkJsons.generator
@@ -185,7 +185,7 @@ if ([a.name]Value != null) {
 }
   [else if a.optionalType]
 [a.type] [a.name]Optional = instance.[a.names.get]();
-if ([a.name]Optional.isPresent()) {
+if ([a.name]Optional.[optionalPresent a]) {
   [a.unwrappedElementType] [a.name]Value = [a.name]Optional.[optionalGet a];
   [generateWriteAttributeValue type a (a.name 'Value') false]
 } else {
@@ -252,7 +252,7 @@ if ([a.name]Value != null) {
 }
   [else if a.optionalType]
 [a.type] [a.name]Optional = instance.[a.names.get]();
-if ([a.name]Optional.isPresent()) {
+if ([a.name]Optional.[optionalPresent a]) {
   out.name([serializedName a]);
   [a.unwrappedElementType] [a.name]Value = [a.name]Optional.[optionalGet a];
   [generateWriteAttributeValue type a (a.name 'Value') false]
@@ -409,12 +409,12 @@ if (t == JsonReader.Token.NULL) {
   return [optionalEmpty a];
 }
     [if a.jdkSpecializedOptional]
-return [a.rawType].of([simpleTypeNext a.unwrappedElementType]);
+return [a.rawType].of([simpleTypeNext a.unwrappedElementType]);kmo
     [else if a.unwrappedElementPrimitiveType or (a.unwrappedElementType eq 'java.lang.String')]
-return [a.rawType].<[a.elementType]>of([simpleTypeNext a.unwrappedElementType]);
+return [optionalOf a]([simpleTypeNext a.unwrappedElementType]);
     [else]
 [generateReadAttributeValue type a a.wrappedElementType a.unwrapperOrRawElementType false]
-return [a.rawType].of(value);
+return [optionalOf a](value);
     [/if]
   [else if a.mapType]
 [createBuilderForCollection type a 'mappings']
@@ -667,4 +667,8 @@ out.value([variableName]);
 
 [template optionalGet Attribute a][if a.jdkSpecializedOptional]getAs[toUpper a.elementType][else]get[/if]()[/template]
 
-[template optionalEmpty Attribute a][a.rawType].[if a.jdkOptional]empty[else]absent[/if]()[/template]
+[template optionalEmpty Attribute a][a.rawType].[if a.jdkOptional]empty[else if a.fugueOptional]none[else]absent[/if]()[/template]
+
+[template optionalOf Attribute a][a.rawType].[if a.fugueOptional]some[else]of[/if][/template]
+
+[template optionalPresent Attribute a][if a.fugueOptional]isDefined[else]isPresent[/if]()[/template]

--- a/value-processor/src/org/immutables/value/processor/Transformers.generator
+++ b/value-processor/src/org/immutables/value/processor/Transformers.generator
@@ -55,10 +55,10 @@ package [transformerType.package];
     [else if a.optionalType]
 
   protected [a.rawType]<[a.wrappedElementType]> as[s][transformAttributeSuffix a]([t] value, [a.type] optional) {
-    if (optional.isPresent()) {
+    if (optional.[optionalPresent a]) {
       [a.unwrappedElementType] original = optional.[optionalGet a];
       [a.unwrappedElementType] changed = as[s][toUpper a.name](value, original);
-      return changed != original ? [a.rawType].of(changed) : optional;
+      return changed != original ? [optionalOf a](changed) : optional;
     }
     return [optionalEmpty a];
   }
@@ -135,6 +135,7 @@ package [transformerType.package];
 
 [template transformAttributeSuffix Attribute a][toUpper a.name][output.trim]
 [if a.nullable]Nullable
+[else if a.fugueOptional]Option
 [else if a.optionalType]Optional
 [else if a.mapType]Entries
 [else if a.collectionType]Elements
@@ -143,4 +144,8 @@ package [transformerType.package];
 
 [template optionalGet Attribute a][if a.jdkSpecializedOptional]getAs[toUpper a.elementType][else]get[/if]()[/template]
 
-[template optionalEmpty Attribute a][a.rawType].[if a.jdkOptional]empty[else]absent[/if]()[/template]
+[template optionalEmpty Attribute a][a.rawType].[if a.jdkOptional]empty[else if a.fugueOptional]none[else]absent[/if]()[/template]
+
+[template optionalOf Attribute a][a.rawType].[if a.fugueOptional]some[else]of[/if][/template]
+
+[template optionalPresent Attribute a][if a.fugueOptional]isDefined[else]isPresent[/if]()[/template]

--- a/value-processor/src/org/immutables/value/processor/meta/AttributeTypeKind.java
+++ b/value-processor/src/org/immutables/value/processor/meta/AttributeTypeKind.java
@@ -75,7 +75,12 @@ public enum AttributeTypeKind {
       "java.util.OptionalDouble"),
   OPTIONAL_GUAVA(
       "Optional",
-      UnshadeGuava.typeString("base.Optional"));
+      UnshadeGuava.typeString("base.Optional")),
+  OPTION_FUGUE(
+      "Option",
+      "com.atlassian.fugue.Option",
+      "io.atlassian.fugue.Option"),
+  ;
 
   private final String[] rawTypes;
   private final String rawSimpleName;
@@ -234,6 +239,10 @@ public enum AttributeTypeKind {
     return this == OPTIONAL_GUAVA;
   }
 
+  public boolean isOptionFugue() {
+    return this == OPTION_FUGUE;
+  }
+
   public boolean isOptionalKind() {
     switch (this) {
     case OPTIONAL_GUAVA:
@@ -241,6 +250,7 @@ public enum AttributeTypeKind {
     case OPTIONAL_INT_JDK:
     case OPTIONAL_LONG_JDK:
     case OPTIONAL_DOUBLE_JDK:
+    case OPTION_FUGUE:
       return true;
     default:
       return false;

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -18,7 +18,6 @@ package org.immutables.value.processor.meta;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -248,7 +247,7 @@ public final class ValueAttribute extends TypeIntrospectionBase {
         Collections.singleton(JsonPropertyMirror.qualifiedName()),
         false,
         elementType).isEmpty();
-    
+
     if (dontHaveJsonPropetyAnnotationAlready) {
       allAnnotations.add("@" + JsonPropertyMirror.qualifiedName());
     }
@@ -364,6 +363,10 @@ public final class ValueAttribute extends TypeIntrospectionBase {
 
   public boolean isJdkOptional() {
     return typeKind.isOptionalKind() && typeKind.isJdkOnlyContainerKind();
+  }
+
+  public boolean isFugueOptional() {
+    return typeKind.isOptionFugue();
   }
 
   public boolean isJdkSpecializedOptional() {


### PR DESCRIPTION
Atlasssian Fugue is a nice little library that is an functional extension of Guava and/or Java 8. Fugue contains an Option class which is an alternative to the Optional type class of Guava and/or Java 8.

This pull request adds the same support for the Fugue Option class as the other Optional classes.

Atlassian just released Fugue 3 which uses a different package (io.atlassian.fugue) then Fugue 2 and older (com.atlassion.fugue). This pull requests add support for both versions.