### PR TITLE
Correct spelling mistake in warning message

### DIFF
--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -1068,7 +1068,7 @@ public final class ValueAttribute extends TypeIntrospectionBase {
       typeKind = AttributeTypeKind.REGULAR;
       report()
           .annotationNamed(DefaultMirror.simpleName())
-          .warning("Generic wildcards are not supported, so the container attribute loosing its special treatment");
+          .warning("Generic wildcards are not supported, so the container attribute losing its special treatment");
     }
 
     if (isNullable()) {


### PR DESCRIPTION
I've corrected the use of "loosing" to "losing" in this warning message:

> Generic wildcards are not supported, so the container attribute _loosing_ its special treatment