### PR TITLE
#396 Fix for constructor annotations with @Target(CONSTRUCTOR)

### DIFF
--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -260,7 +260,7 @@ public final class ValueType extends TypeIntrospectionBase {
                   Collections.<String>emptySet(),
                   true,
                   false,
-                  ElementType.METHOD,
+                  ElementType.CONSTRUCTOR,
                   newTypeStringResolver());
         }
       }


### PR DESCRIPTION
Fixed the generation of constructor annotations by using the element type CONSTRUCTOR instead of METHOD.