### PR TITLE
Provide a better experience to Eclipse users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,40 @@
           </compilerArguments>
         </configuration>
       </plugin>
+      <plugin>
+        <!-- This plugin isn't strictly necessary; without it the generated
+        sources are compiled just fine. It's here to make importing the project
+        into Eclipse using M2Eclipse a much smoother process. Thanks to this
+        configuration users won't have to manually add each generated source
+        directory to the build path. -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.12</version>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/annotations</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-source</id>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-test-sources/test-annotations</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
This is a non-functional change that should make it more attractive for users of Eclipse to contribute to this project. As the `pom.xml` comment explains, this change makes explicit that this project heavily relies on two additional build source paths:

* `${project.build.directory}/generated-sources/annotations`
* `${project.build.directory}/generated-test-sources/test-annotations`

By explicitly listing these using the `build-helper-maven-plugin` they'll automatically be picked up by modern versions of Eclipse, so that the user doesn't have to spend several minutes manually adding these directories to the build path. Tested with the latest version of Eclipse and M2Eclipse (4.6.1 and 1.70, respectively).

NB: Perhaps this trick should also be documented on https://immutables.github.io/?