### PR TITLE
Call copyOf on add methods if deepImmutablesDetection is enabled

### DIFF
--- a/value-fixture/src/org/immutables/fixture/deep/Canvas.java
+++ b/value-fixture/src/org/immutables/fixture/deep/Canvas.java
@@ -21,6 +21,7 @@ import org.immutables.value.Value;
 @Value.Style(deepImmutablesDetection = true, depluralize = true)
 public interface Canvas {
 
+  @Value.Modifiable
   @Value.Immutable
   public interface Color {
     @Value.Parameter
@@ -33,6 +34,7 @@ public interface Canvas {
     double blue();
   }
 
+  @Value.Modifiable
   @Value.Immutable
   public interface Line {
     List<Point> points();
@@ -40,6 +42,7 @@ public interface Canvas {
     Color color();
   }
 
+  @Value.Modifiable
   @Value.Immutable
   public interface Point {
     @Value.Parameter

--- a/value-fixture/test/org/immutables/fixture/deep/DeepImmutablesDetectionTest.java
+++ b/value-fixture/test/org/immutables/fixture/deep/DeepImmutablesDetectionTest.java
@@ -1,0 +1,70 @@
+package org.immutables.fixture.deep;
+
+import com.google.common.collect.ImmutableList;
+import org.immutables.fixture.deep.Canvas.Line;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.immutables.check.Checkers.check;
+
+public class DeepImmutablesDetectionTest {
+    private static final ModifiableColor MODIFIABLE_COLOR = ModifiableColor.create(0.5, 0.5, 0.5);
+    private static final ImmutableColor IMMUTABLE_COLOR = MODIFIABLE_COLOR.toImmutable();
+    private static final ModifiablePoint MODIFIABLE_POINT = ModifiablePoint.create(1, 2);
+    private static final ImmutablePoint IMMUTABLE_POINT = MODIFIABLE_POINT.toImmutable();
+
+    @Test
+    public void modifiableFieldIsConvertedOnToImmutable() {
+        Line line = ModifiableLine.create().setColor(MODIFIABLE_COLOR).toImmutable();
+
+        check(line.color()).isA(ImmutableColor.class);
+        check(line.color()).is(IMMUTABLE_COLOR);
+    }
+
+    @Test
+    public void modifiableCollectionFieldIsConvertedOnToImmutable() {
+        Line line = ModifiableLine.create()
+                .setColor(MODIFIABLE_COLOR)
+                .setPoints(Collections.singleton(MODIFIABLE_POINT))
+                .addPoint(MODIFIABLE_POINT)
+                .addPoint(MODIFIABLE_POINT, MODIFIABLE_POINT)
+                .addAllPoints(Collections.singleton(MODIFIABLE_POINT))
+                .toImmutable();
+
+        check(line.points()).isA(ImmutableList.class);
+        check(line.points().size()).is(5);
+
+        for (Canvas.Point point : line.points()) {
+            check(point).isA(ImmutablePoint.class);
+            check(point).is(IMMUTABLE_POINT);
+        }
+    }
+
+    @Test
+    public void modifiableFieldIsConvertedInBuilder() {
+        Line line = ImmutableLine.builder().color(MODIFIABLE_COLOR).build();
+
+        check(line.color()).isA(ImmutableColor.class);
+        check(line.color()).is(IMMUTABLE_COLOR);
+    }
+
+    @Test
+    public void modifiableCollectionFieldIsConvertedInBuilder() {
+        Line line = ImmutableLine.builder()
+                .color(MODIFIABLE_COLOR)
+                .points(Collections.singleton(MODIFIABLE_POINT))
+                .addPoint(MODIFIABLE_POINT)
+                .addPoint(MODIFIABLE_POINT, MODIFIABLE_POINT)
+                .addAllPoints(Collections.singleton(MODIFIABLE_POINT))
+                .build();
+
+        check(line.points()).isA(ImmutableList.class);
+        check(line.points().size()).is(5);
+
+        for (Canvas.Point point : line.points()) {
+            check(point).isA(ImmutablePoint.class);
+            check(point).is(IMMUTABLE_POINT);
+        }
+    }
+}

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1293,14 +1293,14 @@ checkNotIsSet([v.names.isSet](), "[v.names.raw]");
     [/if]
     [if v.generateJdkOnly and (not v.primitiveElement)]
       [if v.nullElements.skip]
-    if (element != null) this.[v.name].add(element);
+    if (element != null) this.[v.name].add([elementFactoryCopyOf v](element));
       [else if v.nullElements.allow]
-    this.[v.name].add(element);
+    this.[v.name].add([elementFactoryCopyOf v](element));
       [else]
-    this.[v.name].add([requireNonNull type](element, "[v.name] element"));
+    this.[v.name].add([elementFactoryCopyOf v]([requireNonNull type](element, "[v.name] element")));
       [/if]
     [else]
-    this.[v.name].add(element);
+    this.[v.name].add([elementFactoryCopyOf v](element));
     [/if]
     [nondefaultSetInBuilder v]
     return [builderReturnThis type];
@@ -1339,14 +1339,18 @@ checkNotIsSet([v.names.isSet](), "[v.names.raw]");
       [if v.primitiveElement or v.nullElements.allow]
       this.[v.name].add(element);
       [else if v.nullElements.skip]
-      if (element != null) this.[v.name].add(element);
+      if (element != null) this.[v.name].add([elementFactoryCopyOf v](element));
       [else]
-      this.[v.name].add([requireNonNull type](element, "[v.name] element"));
+      this.[v.name].add([elementFactoryCopyOf v]([requireNonNull type](element, "[v.name] element")));
       [/if]
     }
     [else]
       [if v.wrapArrayToIterable]
     this.[v.name].addAll([arrayAsList v 'elements']);
+      [else if v.hasAttributeValue]
+    for ([v.unwrappedElementType] element : elements) {
+      this.[v.name].add([elementFactoryCopyOf v](element));
+    }
       [else]
     this.[v.name].add(elements);
       [/if]
@@ -1397,10 +1401,14 @@ checkNotIsSet([v.names.isSet](), "[v.names.raw]");
       [if v.nullElements.allow]
       this.[v.name].add(element);
       [else if v.nullElements.skip]
-      if (element != null) this.[v.name].add(element);
+      if (element != null) this.[v.name].add([elementFactoryCopyOf v](element));
       [else]
-      this.[v.name].add([requireNonNull type](element, "[v.name] element"));
+      this.[v.name].add([elementFactoryCopyOf v]([requireNonNull type](element, "[v.name] element")));
       [/if]
+    }
+    [else if v.hasAttributeValue]
+    for ([v.unwrappedElementType] element : elements) {
+      this.[v.name].add([elementFactoryCopyOf v](element));
     }
     [else]
     this.[v.name].addAll(elements);
@@ -1912,6 +1920,13 @@ return [type.factoryOf]([output.linesShortable][for v in type.settableAttributes
   [if v.nullable][expression] == null ? null : [/if][immutableCollectionCopyOf v expression]
 [else]
   [maybeNonNullValue v][maybeCopyOf v expression][/maybeNonNullValue]
+[/if]
+[/output.trim][/template]
+
+[template elementFactoryCopyOf Attribute v][output.trim]
+[if v.hasAttributeValue]
+[v.attributeValueType.factoryCopyOf]
+[else]
 [/if]
 [/output.trim][/template]
 

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -1082,6 +1082,10 @@ public final class ValueAttribute extends TypeIntrospectionBase {
     return getType();
   }
 
+  public boolean hasAttributeValue() {
+    return attributeValueType != null;
+  }
+
   public boolean isAttributeValueKindCopy() {
     return attributeValueType != null
         && typeKind.isRegular()


### PR DESCRIPTION
Fix for #333.

In situations like this:

```
    @Value.Style(deepImmutablesDetection = true)
    @Value.Immutable
    @Value.Modifiable
    public interface Foo {
        List<Bar> getBars();

        // ...
    }

    @Value.Immutable
    @Value.Modifiable
    public interface Bar {
        // ...
    }
```
When the following methods are called:
 `ImmutableFoo.Builder#bars(Iterable<Bar>)`,
 `ImmutableFoo.Builder#addBar(Bar)`,
 `ImmutableFoo.Builder#addBar(Bar ...)`,
 `ImmutableFoo.Builder#addAllBar(Iterable<Bar>)`,
 `ImmutableFoo.Builder#from(Foo)`

then the Bar parameters will be converted with ImmutableBar.copyOf
before being added to the list. This is more consistent with
non-collection @Value fields when deepImmutablesDetection is on, and
prevents cases where you have an ImmutableFoo with ModifiableBars
inside.