### PR TITLE
Call Modifiable factory on elements in add methods if deepImmutablesDetection is enabled

### DIFF
--- a/value-fixture/test/org/immutables/fixture/deep/DeepImmutablesDetectionTest.java
+++ b/value-fixture/test/org/immutables/fixture/deep/DeepImmutablesDetectionTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import org.immutables.fixture.deep.Canvas.Line;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
 
 import static org.immutables.check.Checkers.check;
@@ -80,6 +81,44 @@ public class DeepImmutablesDetectionTest {
         for (Canvas.Point point : line.points()) {
             check(point).isA(ImmutablePoint.class);
             check(point).is(IMMUTABLE_POINT);
+        }
+    }
+
+    @Test
+    public void immutableFieldIsConvertedInModifiableFrom() {
+        Line line = ImmutableLine.builder()
+                .color(IMMUTABLE_COLOR)
+                .addPoint(IMMUTABLE_POINT)
+                .build();
+
+        ModifiableLine modifiableLine = ModifiableLine.create().from(line);
+
+        check(modifiableLine.color()).isA(ModifiableColor.class);
+        check(modifiableLine.color()).is(MODIFIABLE_COLOR);
+    }
+
+    @Test
+    public void immutableFieldIsConvertedInModifiableSetter() {
+        ModifiableLine modifiableLine = ModifiableLine.create().setColor(IMMUTABLE_COLOR);
+
+        check(modifiableLine.color()).isA(ModifiableColor.class);
+        check(modifiableLine.color()).is(MODIFIABLE_COLOR);
+    }
+
+    @Test
+    public void immutableCollectionFieldIsConvertedInModifiableSetter() {
+        ModifiableLine modifiableLine = ModifiableLine.create()
+                .setPoints(Collections.singleton(IMMUTABLE_POINT))
+                .addPoint(IMMUTABLE_POINT)
+                .addPoint(IMMUTABLE_POINT, IMMUTABLE_POINT)
+                .addAllPoints(Collections.singleton(IMMUTABLE_POINT));
+
+        check(modifiableLine.points()).isA(ArrayList.class);
+        check(modifiableLine.points()).hasSize(5);
+
+        for (Canvas.Point point : modifiableLine.points()) {
+            check(point).isA(ModifiablePoint.class);
+            check(point).is(MODIFIABLE_POINT);
         }
     }
 }

--- a/value-processor/src/org/immutables/value/processor/Modifiables.generator
+++ b/value-processor/src/org/immutables/value/processor/Modifiables.generator
@@ -480,7 +480,12 @@ public [thisReturnType type] [v.names.add]([v.unwrappedElementType] element) {
   [if v.unwrappedElementPrimitiveType]
   [v.name].add(element);
   [else]
-  [v.name].add([im.requireNonNull type](element, "[v.name] element"));
+  [v.unwrappedElementType] nonNullElement = [im.requireNonNull type](element, "[v.name] element");
+  [if v.attributeValueKindIsCollectionOfModifiable]
+  [v.name].add(element instanceof [v.attributeValueType.constitution.typeModifiable.relativeRaw] ? element : [v.attributeValueType.constitution.factoryCreate]().[v.attributeValueType.names.from](element));
+  [else]
+  [v.name].add(nonNullElement);
+  [/if]
   [/if]
   [nondefaultSetter v]
   [thisReturn type]
@@ -544,11 +549,7 @@ public [thisReturnType type] [v.names.addAll](Iterable<[v.consumedElementType]> 
   }
   [/if]
   for ([v.unwrappedElementType] element : elements) {
-    [if v.unwrappedElementPrimitiveType]
-    [v.name].add(element);
-    [else]
-    [v.name].add([im.requireNonNull type](element, "[v.name] element"));
-    [/if]
+    [v.names.add](element);
   }
   [nondefaultSetter v]
   [thisReturn type]

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -1086,6 +1086,13 @@ public final class ValueAttribute extends TypeIntrospectionBase {
     return attributeValueType != null;
   }
 
+  public boolean attributeValueKindIsCollectionOfModifiable() {
+    return attributeValueType != null
+            && typeKind.isCollectionKind()
+            && attributeValueType.kind().isModifiable()
+            && attributeValueType.isGenerateFilledFrom();
+  }
+
   public boolean isAttributeValueKindCopy() {
     return attributeValueType != null
         && typeKind.isRegular()


### PR DESCRIPTION
Like #333 but for Modifiables instead of Immutables...

In situations like this:

    @Value.Style(deepImmutablesDetection = true)
    @Value.Immutable
    @Value.Modifiable
    public interface Foo {
        List<Bar> getBars();

        // ...
    }

    @Value.Immutable
    @Value.Modifiable
    public interface Bar {
        // ...
    }

When the following methods are called:
 ModifiableFoo#setBars(Iterable<Bar>),
 ModifiableFoo#addBar(Bar),
 ModifiableFoo#addBar(Bar ...),
 ModifiableFoo#addAllBar(Iterable<Bar>)
 ModifiableFoo#from(Foo)

then the Bar parameters will be converted with

ModifiablePoint.create().from()

before being added to the list if they are not already ModifiablePoints.
This is more consistent with non-collection @Value fields when
deepImmutablesDetection is on, and prevents cases where you have an
ModifiableFoo with ImmutableBars inside.