### PR TITLE
Add style which allows developer to configure how validation is performed, including new option to disable null checks, and another option to use Java Validation API

### DIFF
--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1766,8 +1766,24 @@ checkNotIsSet([v.names.isSet](), "[v.names.raw]");
     checkRequiredAttributes();
     [/if]
   [/if]
+[if type.useJavaValidationApi]
+    [returnType] bean = _[type.names.build]();
+    javax.validation.Validator validator = javax.validation.Validation.buildDefaultValidatorFactory().getValidator();
+    java.util.Set<javax.validation.ConstraintViolation<[returnType]>> constraintViolations = validator.validate(bean);
+    if (!constraintViolations.isEmpty()) {
+      throw new javax.validation.ConstraintViolationException(constraintViolations);
+    }    
+    return bean;
+[else]  
+    [builderReturnValue type]
+[/if]
+  }
+[if type.useJavaValidationApi]
+  private [returnType] _[type.names.build]() {
     [builderReturnValue type]
   }
+[/if]
+  
   [if type.isGenerateBuildOrThrow]
   [if classpath.isJava8 or (not type.generateJdkOnly)]
 

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -705,7 +705,17 @@ public [type.typeAbstract.relative] [v.names.with]([v.atNullability][v.type] val
 [/if]
 [if type.useValidation]
 
+[if type.useJavaValidationApi]
+  private static final javax.validation.Validator [disambiguateField type 'validator'] = javax.validation.Validation.buildDefaultValidatorFactory().getValidator();
+[/if]
+
   private static [type.generics.spaceAfter][type.typeImmutable.relative] validate([type.typeImmutable.relative] instance) {
+[if type.useJavaValidationApi]
+    java.util.Set<javax.validation.ConstraintViolation<[type.typeImmutable.relative]>> constraintViolations = [disambiguateField type 'validator'].validate(instance);
+    if (!constraintViolations.isEmpty()) {
+      throw new javax.validation.ConstraintViolationException(constraintViolations);
+    }
+[/if]
 [for vm in type.validationMethods]
   [if vm.normalize]
     instance = ([type.typeImmutable.relative]) instance.[vm.name]();
@@ -1020,9 +1030,6 @@ public interface BuildFinal[type.generics] {
 [if type.constitution.outsideBuilder]
   [rr.staticFields setters]
   [rr.staticMethods setters]
-[/if]
-[if type.useJavaValidationApi]
-  private static final javax.validation.Validator [disambiguateField type 'validator'] = javax.validation.Validation.buildDefaultValidatorFactory().getValidator();
 [/if]
   [for m in mandatories, BitPosition pos = positions m]
   private static final long INIT_BIT_[toConstant m.name] = [literal.hex pos.mask];
@@ -1769,23 +1776,8 @@ checkNotIsSet([v.names.isSet](), "[v.names.raw]");
     checkRequiredAttributes();
     [/if]
   [/if]
-[if type.useJavaValidationApi]
-    [returnType] bean = [type.names.build]Unvalidated();
-    java.util.Set<javax.validation.ConstraintViolation<[returnType]>> constraintViolations = [disambiguateField type 'validator'].validate(bean);
-    if (!constraintViolations.isEmpty()) {
-      throw new javax.validation.ConstraintViolationException(constraintViolations);
-    }    
-    return bean;
-[else]  
-    [builderReturnValue type]
-[/if]
-  }
-[if type.useJavaValidationApi]
-
-  private [returnType] [type.names.build]Unvalidated() {
     [builderReturnValue type]
   }
-[/if]
   [if type.isGenerateBuildOrThrow]
   [if classpath.isJava8 or (not type.generateJdkOnly)]
 

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1021,6 +1021,9 @@ public interface BuildFinal[type.generics] {
   [rr.staticFields setters]
   [rr.staticMethods setters]
 [/if]
+[if type.useJavaValidationApi]
+  private static final javax.validation.Validator [disambiguateField type 'validator'] = javax.validation.Validation.buildDefaultValidatorFactory().getValidator();
+[/if]
   [for m in mandatories, BitPosition pos = positions m]
   private static final long INIT_BIT_[toConstant m.name] = [literal.hex pos.mask];
   [/for]
@@ -1767,9 +1770,8 @@ checkNotIsSet([v.names.isSet](), "[v.names.raw]");
     [/if]
   [/if]
 [if type.useJavaValidationApi]
-    [returnType] bean = _[type.names.build]();
-    javax.validation.Validator validator = javax.validation.Validation.buildDefaultValidatorFactory().getValidator();
-    java.util.Set<javax.validation.ConstraintViolation<[returnType]>> constraintViolations = validator.validate(bean);
+    [returnType] bean = [type.names.build]Unvalidated();
+    java.util.Set<javax.validation.ConstraintViolation<[returnType]>> constraintViolations = [disambiguateField type 'validator'].validate(bean);
     if (!constraintViolations.isEmpty()) {
       throw new javax.validation.ConstraintViolationException(constraintViolations);
     }    
@@ -1779,11 +1781,11 @@ checkNotIsSet([v.names.isSet](), "[v.names.raw]");
 [/if]
   }
 [if type.useJavaValidationApi]
-  private [returnType] _[type.names.build]() {
+
+  private [returnType] [type.names.build]Unvalidated() {
     [builderReturnValue type]
   }
 [/if]
-  
   [if type.isGenerateBuildOrThrow]
   [if classpath.isJava8 or (not type.generateJdkOnly)]
 

--- a/value-processor/src/org/immutables/value/processor/meta/Proto.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Proto.java
@@ -1721,7 +1721,7 @@ public class Proto {
           input.packageGenerated(),
           ToImmutableInfo.FUNCTION.apply(input.defaults()),
           input.strictBuilder(),
-          input.builderValidationMethod(),
+          input.validationMethod(),
           input.allParameters(),
           input.defaultAsDefault(),
           input.headerComments(),

--- a/value-processor/src/org/immutables/value/processor/meta/Proto.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Proto.java
@@ -1721,7 +1721,7 @@ public class Proto {
           input.packageGenerated(),
           ToImmutableInfo.FUNCTION.apply(input.defaults()),
           input.strictBuilder(),
-          input.disableRequiredAttributes(),
+          input.builderValidationMethod(),
           input.allParameters(),
           input.defaultAsDefault(),
           input.headerComments(),

--- a/value-processor/src/org/immutables/value/processor/meta/Proto.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Proto.java
@@ -1721,6 +1721,7 @@ public class Proto {
           input.packageGenerated(),
           ToImmutableInfo.FUNCTION.apply(input.defaults()),
           input.strictBuilder(),
+          input.disableRequiredAttributes(),
           input.allParameters(),
           input.defaultAsDefault(),
           input.headerComments(),

--- a/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
+++ b/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
@@ -166,7 +166,7 @@ public abstract class StyleInfo implements ValueMirrors.Style {
 
   @Value.Parameter
   @Override
-  public abstract boolean disableRequiredAttributes();
+  public abstract BuilderValidationMethod builderValidationMethod();
 
   @Value.Parameter
   @Override

--- a/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
+++ b/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
@@ -166,7 +166,7 @@ public abstract class StyleInfo implements ValueMirrors.Style {
 
   @Value.Parameter
   @Override
-  public abstract BuilderValidationMethod builderValidationMethod();
+  public abstract ValidationMethod validationMethod();
 
   @Value.Parameter
   @Override

--- a/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
+++ b/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
@@ -166,6 +166,10 @@ public abstract class StyleInfo implements ValueMirrors.Style {
 
   @Value.Parameter
   @Override
+  public abstract boolean disableRequiredAttributes();
+
+  @Value.Parameter
+  @Override
   public abstract boolean allParameters();
 
   @Value.Parameter

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -160,7 +160,8 @@ public final class ValueAttribute extends TypeIntrospectionBase {
         && !isContainerType()
         && !isNullable()
         && !isEncoding()
-        && !hasBuilderSwitcherDefault();
+        && !hasBuilderSwitcherDefault()
+        && !protoclass().styles().style().disableRequiredAttributes();
   }
 
   public boolean isNullable() {

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -49,7 +49,7 @@ import org.immutables.value.processor.meta.Proto.Environment;
 import org.immutables.value.processor.meta.Proto.MetaAnnotated;
 import org.immutables.value.processor.meta.Proto.Protoclass;
 import org.immutables.value.processor.meta.Styles.UsingName.AttributeNames;
-import org.immutables.value.processor.meta.ValueMirrors.Style.BuilderValidationMethod;
+import org.immutables.value.processor.meta.ValueMirrors.Style.ValidationMethod;
 import org.immutables.value.processor.meta.ValueMirrors.Style.ImplementationVisibility;
 
 /**
@@ -162,7 +162,7 @@ public final class ValueAttribute extends TypeIntrospectionBase {
         && !isNullable()
         && !isEncoding()
         && !hasBuilderSwitcherDefault()
-        && protoclass().styles().style().builderValidationMethod() == BuilderValidationMethod.SIMPLE;
+        && protoclass().styles().style().validationMethod() == ValidationMethod.SIMPLE;
   }
 
   public boolean isNullable() {

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -49,6 +49,7 @@ import org.immutables.value.processor.meta.Proto.Environment;
 import org.immutables.value.processor.meta.Proto.MetaAnnotated;
 import org.immutables.value.processor.meta.Proto.Protoclass;
 import org.immutables.value.processor.meta.Styles.UsingName.AttributeNames;
+import org.immutables.value.processor.meta.ValueMirrors.Style.BuilderValidationMethod;
 import org.immutables.value.processor.meta.ValueMirrors.Style.ImplementationVisibility;
 
 /**
@@ -161,7 +162,7 @@ public final class ValueAttribute extends TypeIntrospectionBase {
         && !isNullable()
         && !isEncoding()
         && !hasBuilderSwitcherDefault()
-        && !protoclass().styles().style().disableRequiredAttributes();
+        && protoclass().styles().style().builderValidationMethod() == BuilderValidationMethod.SIMPLE;
   }
 
   public boolean isNullable() {

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -150,7 +150,7 @@ public final class ValueMirrors {
 
     boolean strictBuilder() default false;
 
-    boolean disableRequiredAttributes() default false;
+    BuilderValidationMethod builderValidationMethod() default BuilderValidationMethod.SIMPLE;
 
     boolean allParameters() default false;
 
@@ -216,6 +216,12 @@ public final class ValueMirrors {
       PUBLIC,
       SAME,
       PACKAGE
+    }
+    
+    public enum BuilderValidationMethod {
+      NONE,
+      SIMPLE,
+      VALIDATION_API
     }
   }
 

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -150,7 +150,7 @@ public final class ValueMirrors {
 
     boolean strictBuilder() default false;
 
-    BuilderValidationMethod builderValidationMethod() default BuilderValidationMethod.SIMPLE;
+    ValidationMethod validationMethod() default ValidationMethod.SIMPLE;
 
     boolean allParameters() default false;
 
@@ -218,7 +218,7 @@ public final class ValueMirrors {
       PACKAGE
     }
     
-    public enum BuilderValidationMethod {
+    public enum ValidationMethod {
       NONE,
       SIMPLE,
       VALIDATION_API

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -150,6 +150,8 @@ public final class ValueMirrors {
 
     boolean strictBuilder() default false;
 
+    boolean disableRequiredAttributes() default false;
+
     boolean allParameters() default false;
 
     boolean defaultAsDefault() default false;

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -60,6 +60,7 @@ import org.immutables.value.processor.meta.Proto.DeclaringType;
 import org.immutables.value.processor.meta.Proto.Environment;
 import org.immutables.value.processor.meta.Proto.Protoclass;
 import org.immutables.value.processor.meta.Styles.UsingName.TypeNames;
+import org.immutables.value.processor.meta.ValueMirrors.Style.BuilderValidationMethod;
 
 /**
  * It's pointless to refactor this mess until
@@ -819,6 +820,10 @@ public final class ValueType extends TypeIntrospectionBase {
   public boolean isUseStrictBuilder() {
     return constitution.style().strictBuilder()
         || constitution.style().stagedBuilder();
+  }
+  
+  public boolean isUseJavaValidationApi() {
+	  return constitution.style().builderValidationMethod() == BuilderValidationMethod.VALIDATION_API; 
   }
 
   private @Nullable TelescopicBuild telescopicBuild;

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -15,20 +15,6 @@
  */
 package org.immutables.value.processor.meta;
 
-import com.google.common.base.Splitter;
-import com.google.common.base.CaseFormat;
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Ordering;
-import com.google.common.collect.Sets;
 import java.lang.annotation.ElementType;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
 import javax.annotation.Nullable;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -50,6 +37,7 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
+
 import org.immutables.generator.Output;
 import org.immutables.generator.SourceExtraction;
 import org.immutables.generator.TypeHierarchyCollector;
@@ -60,7 +48,21 @@ import org.immutables.value.processor.meta.Proto.DeclaringType;
 import org.immutables.value.processor.meta.Proto.Environment;
 import org.immutables.value.processor.meta.Proto.Protoclass;
 import org.immutables.value.processor.meta.Styles.UsingName.TypeNames;
-import org.immutables.value.processor.meta.ValueMirrors.Style.BuilderValidationMethod;
+
+import com.google.common.base.CaseFormat;
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.base.Splitter;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
 
 /**
  * It's pointless to refactor this mess until
@@ -295,7 +297,7 @@ public final class ValueType extends TypeIntrospectionBase {
   }
 
   public boolean isUseValidation() {
-    if (isGenerateOrdinalValue() || !validationMethods.isEmpty()) {
+    if (isGenerateOrdinalValue() || !validationMethods.isEmpty() || isUseJavaValidationApi()) {
       return true;
     }
     if (isUseSingletonOnly()) {
@@ -823,7 +825,7 @@ public final class ValueType extends TypeIntrospectionBase {
   }
   
   public boolean isUseJavaValidationApi() {
-	  return constitution.style().builderValidationMethod() == BuilderValidationMethod.VALIDATION_API; 
+	  return constitution.style().validationMethod() == ValueMirrors.Style.ValidationMethod.VALIDATION_API; 
   }
 
   private @Nullable TelescopicBuild telescopicBuild;

--- a/value/src/org/immutables/value/Value.java
+++ b/value/src/org/immutables/value/Value.java
@@ -200,16 +200,16 @@ public @interface Value {
    * <pre>
    * {@literal @}Value.Immutable
    * public abstract class Order {
-   * 
+   *
    *   public abstract List&lt;Item&gt; items();
-   * 
+   *
    *   {@literal @}Value.Lazy
    *   public int totalCost() {
    *     int cost = 0;
-   * 
+   *
    *     for (Item i : items())
    *       cost += i.count() * i.price();
-   * 
+   *
    *     return cost;
    *   }
    * }
@@ -274,19 +274,19 @@ public @interface Value {
    * (non-private) method and have a {@code void} return type, which also should not throw a checked
    * exceptions.
    * </p>
-   * 
+   *
    * <pre>
    * {@literal @}Value.Immutable
    * public abstract class NumberContainer {
    *   public abstract List<Number> nonEmptyNumbers();
-   * 
+   *
    *   {@literal @}Value.Check
    *   protected void check() {
    *     Preconditions.checkState(!nonEmptyNumbers().isEmpty(),
    *         "'nonEmptyNumbers' should have at least one number");
    *   }
    * }
-   * 
+   *
    * // will throw IllegalStateException("'nonEmptyNumbers' should have at least one number")
    * ImmutableNumberContainer.builder().build();
    * </pre>
@@ -307,12 +307,12 @@ public @interface Value {
    * <em>Be warned that it's easy introduce unresolvable recursion if normalization is implemented without
    * proper or with conflicting checks. Always return {@code this} if value do not require normalization.</em>
    * </p>
-   * 
+   *
    * <pre>
    * {@literal @}Value.Immutable
    * public interface Normalize {
    *   int value();
-   * 
+   *
    *   {@literal @}Value.Check
    *   default Normalize normalize() {
    *     if (value() == Integer.MIN_VALUE) {
@@ -328,7 +328,7 @@ public @interface Value {
    *     return this;
    *   }
    * }
-   * 
+   *
    * int shouldBePositive2 = ImmutableNormalize.builder()
    *     .value(-2)
    *     .build()
@@ -695,6 +695,11 @@ public @interface Value {
     boolean strictBuilder() default false;
 
     /**
+     * When {@code true} @mdash; disables check that all required attributes have been provided to a builder.
+     */
+    boolean disableRequiredAttributes() default false;
+
+    /**
      * <p>
      * When {@code true} &mdash; all settable attributes are considered as they are annotated with
      * {@link Value.Parameter}. Use {@code Value.Parameter(false)} annotation on an attribute to
@@ -710,7 +715,7 @@ public @interface Value {
      *     allParameters = true,
      *     defaults = {@literal @}Value.Immutable(builder = false))
      * public @interface Tuple {}
-     * 
+     *
      * {@literal @}Tuple
      * {@literal @}Value.Immutable
      * interface Color {
@@ -720,7 +725,7 @@ public @interface Value {
      *   {@literal @}Value.Parameter(false)
      *   List<Info> auxiliaryInfo();
      * }
-     * 
+     *
      * ColorTuple.of(0xFF, 0x00, 0xFE);
      * </pre>
      * @return if all attributes will be considered parameters
@@ -874,7 +879,7 @@ public @interface Value {
      * confusing overload).</li>
      * </ul>
      * See the example below which illustrates these behaviors.
-     * 
+     *
      * <pre>
      * {@literal @}Value.Style(deepImmutablesDetection = true)
      * public interface Canvas {
@@ -884,20 +889,20 @@ public @interface Value {
      *     {@literal @}Value.Parameter double green();
      *     {@literal @}Value.Parameter double blue();
      *   }
-     * 
+     *
      *   {@literal @}Value.Immutable
      *   public interface Point {
      *     {@literal @}Value.Parameter int x();
      *     {@literal @}Value.Parameter int y();
      *   }
-     * 
+     *
      *   {@literal @}Value.Immutable
      *   public interface Line {
      *     Color color();
      *     Point start();
      *     Point end();
      *   }
-     * 
+     *
      *   public static void main(String... args) {
      *     ImmutableLine line = ImmutableLine.builder()
      *         .start(1, 2) // overload, equivalent of .start(ImmutablePoint.of(1, 2))
@@ -906,11 +911,11 @@ public @interface Value {
      *         .color(0.9, 0.7, 0.4)
      *         // overload, equivalent of .color(ImmutableColor.of(0.9, 0.7. 0.4))
      *         .build();
-     * 
+     *
      *     ImmutablePoint start = line.start(); // return type is ImmutablePoint rather than declared Point
      *     ImmutablePoint end = line.end(); // return type is ImmutablePoint rather than declared Point
      *     ImmutableColor color = line.color(); // return type is ImmutableColor rather than declared Color
-     * 
+     *
      *     ImmutableLine.builder()
      *         .start(start)
      *         .end(end)
@@ -1004,13 +1009,13 @@ public @interface Value {
      * ("*ies" to "*y" is also supported).
      * Exceptions are provided using {@link #depluralizeDictionary()} array of "singular:plural"
      * pairs as alternative to mechanical "*s" depluralization.
-     * 
+     *
      * <pre>
      * {@literal @}Value.Style(
      *    depluralize = true, // enable feature
      *    depluralizeDictionary = {"person:people", "foot:feet"}) // specifying dictionary of exceptions
      * </pre>
-     * 
+     *
      * When given the dictionary defined as {@code "person:people", "foot:feet"} then
      * depluralization examples for collection {@code add*} method in builder would be:
      * <ul>

--- a/value/src/org/immutables/value/Value.java
+++ b/value/src/org/immutables/value/Value.java
@@ -200,16 +200,16 @@ public @interface Value {
    * <pre>
    * {@literal @}Value.Immutable
    * public abstract class Order {
-   *
+   * 
    *   public abstract List&lt;Item&gt; items();
-   *
+   * 
    *   {@literal @}Value.Lazy
    *   public int totalCost() {
    *     int cost = 0;
-   *
+   * 
    *     for (Item i : items())
    *       cost += i.count() * i.price();
-   *
+   * 
    *     return cost;
    *   }
    * }
@@ -274,19 +274,19 @@ public @interface Value {
    * (non-private) method and have a {@code void} return type, which also should not throw a checked
    * exceptions.
    * </p>
-   *
+   * 
    * <pre>
    * {@literal @}Value.Immutable
    * public abstract class NumberContainer {
    *   public abstract List<Number> nonEmptyNumbers();
-   *
+   * 
    *   {@literal @}Value.Check
    *   protected void check() {
    *     Preconditions.checkState(!nonEmptyNumbers().isEmpty(),
    *         "'nonEmptyNumbers' should have at least one number");
    *   }
    * }
-   *
+   * 
    * // will throw IllegalStateException("'nonEmptyNumbers' should have at least one number")
    * ImmutableNumberContainer.builder().build();
    * </pre>
@@ -307,12 +307,12 @@ public @interface Value {
    * <em>Be warned that it's easy introduce unresolvable recursion if normalization is implemented without
    * proper or with conflicting checks. Always return {@code this} if value do not require normalization.</em>
    * </p>
-   *
+   * 
    * <pre>
    * {@literal @}Value.Immutable
    * public interface Normalize {
    *   int value();
-   *
+   * 
    *   {@literal @}Value.Check
    *   default Normalize normalize() {
    *     if (value() == Integer.MIN_VALUE) {
@@ -328,7 +328,7 @@ public @interface Value {
    *     return this;
    *   }
    * }
-   *
+   * 
    * int shouldBePositive2 = ImmutableNormalize.builder()
    *     .value(-2)
    *     .build()
@@ -695,8 +695,8 @@ public @interface Value {
     boolean strictBuilder() default false;
 
     /**
-     * When {@code true} @mdash; disables check that all required attributes have been provided to a builder.
-     */
+      * When {@code true} @mdash; disables check that all required attributes have been provided to a builder.
+      */
     boolean disableRequiredAttributes() default false;
 
     /**
@@ -715,7 +715,7 @@ public @interface Value {
      *     allParameters = true,
      *     defaults = {@literal @}Value.Immutable(builder = false))
      * public @interface Tuple {}
-     *
+     * 
      * {@literal @}Tuple
      * {@literal @}Value.Immutable
      * interface Color {
@@ -725,7 +725,7 @@ public @interface Value {
      *   {@literal @}Value.Parameter(false)
      *   List<Info> auxiliaryInfo();
      * }
-     *
+     * 
      * ColorTuple.of(0xFF, 0x00, 0xFE);
      * </pre>
      * @return if all attributes will be considered parameters
@@ -879,7 +879,7 @@ public @interface Value {
      * confusing overload).</li>
      * </ul>
      * See the example below which illustrates these behaviors.
-     *
+     * 
      * <pre>
      * {@literal @}Value.Style(deepImmutablesDetection = true)
      * public interface Canvas {
@@ -889,20 +889,20 @@ public @interface Value {
      *     {@literal @}Value.Parameter double green();
      *     {@literal @}Value.Parameter double blue();
      *   }
-     *
+     * 
      *   {@literal @}Value.Immutable
      *   public interface Point {
      *     {@literal @}Value.Parameter int x();
      *     {@literal @}Value.Parameter int y();
      *   }
-     *
+     * 
      *   {@literal @}Value.Immutable
      *   public interface Line {
      *     Color color();
      *     Point start();
      *     Point end();
      *   }
-     *
+     * 
      *   public static void main(String... args) {
      *     ImmutableLine line = ImmutableLine.builder()
      *         .start(1, 2) // overload, equivalent of .start(ImmutablePoint.of(1, 2))
@@ -911,11 +911,11 @@ public @interface Value {
      *         .color(0.9, 0.7, 0.4)
      *         // overload, equivalent of .color(ImmutableColor.of(0.9, 0.7. 0.4))
      *         .build();
-     *
+     * 
      *     ImmutablePoint start = line.start(); // return type is ImmutablePoint rather than declared Point
      *     ImmutablePoint end = line.end(); // return type is ImmutablePoint rather than declared Point
      *     ImmutableColor color = line.color(); // return type is ImmutableColor rather than declared Color
-     *
+     * 
      *     ImmutableLine.builder()
      *         .start(start)
      *         .end(end)
@@ -1009,13 +1009,13 @@ public @interface Value {
      * ("*ies" to "*y" is also supported).
      * Exceptions are provided using {@link #depluralizeDictionary()} array of "singular:plural"
      * pairs as alternative to mechanical "*s" depluralization.
-     *
+     * 
      * <pre>
      * {@literal @}Value.Style(
      *    depluralize = true, // enable feature
      *    depluralizeDictionary = {"person:people", "foot:feet"}) // specifying dictionary of exceptions
      * </pre>
-     *
+     * 
      * When given the dictionary defined as {@code "person:people", "foot:feet"} then
      * depluralization examples for collection {@code add*} method in builder would be:
      * <ul>

--- a/value/src/org/immutables/value/Value.java
+++ b/value/src/org/immutables/value/Value.java
@@ -697,7 +697,7 @@ public @interface Value {
     /**
       * When {@code true} @mdash; disables check that all required attributes have been provided to a builder.
       */
-    BuilderValidationMethod builderValidationMethod() default BuilderValidationMethod.SIMPLE;
+    ValidationMethod validationMethod() default ValidationMethod.SIMPLE;
 
     /**
      * <p>
@@ -1133,7 +1133,7 @@ public @interface Value {
       PACKAGE
     }
 
-    public enum BuilderValidationMethod {
+    public enum ValidationMethod {
       /**
        * No validation of attributes
        */

--- a/value/src/org/immutables/value/Value.java
+++ b/value/src/org/immutables/value/Value.java
@@ -697,7 +697,7 @@ public @interface Value {
     /**
       * When {@code true} @mdash; disables check that all required attributes have been provided to a builder.
       */
-    boolean disableRequiredAttributes() default false;
+    BuilderValidationMethod builderValidationMethod() default BuilderValidationMethod.SIMPLE;
 
     /**
      * <p>
@@ -1131,6 +1131,21 @@ public @interface Value {
        * Generated builder visibility is forced to be package-private.
        */
       PACKAGE
+    }
+
+    public enum BuilderValidationMethod {
+      /**
+       * No validation of attributes
+       */
+      NONE,
+      /**
+       * Simple validation, verifying that non-null attributes have been provided
+       */
+      SIMPLE,
+      /**
+       * Validation using Java Validation API
+       */
+      VALIDATION_API
     }
 
     /**


### PR DESCRIPTION
@elucash, this is a very rough, untested, first cut at disabling required fields, per our discussion in #496. Just wanted you to take a look at it, and let me know if I'm on the right path.

The intent of this PR is disable checks for "required" attributes, such that:
1. You don't have to add "@Nullable" to every field
2. You don't have to provide default values for primitives if you are content with 0 and false.