### PR TITLE
Support @{Natural,Reverse}Order on SortedMultiset

### DIFF
--- a/value-fixture/src/org/immutables/fixture/OrderAttributeValue.java
+++ b/value-fixture/src/org/immutables/fixture/OrderAttributeValue.java
@@ -15,6 +15,7 @@
  */
 package org.immutables.fixture;
 
+import com.google.common.collect.SortedMultiset;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
 import java.util.SortedMap;
@@ -34,4 +35,11 @@ public abstract class OrderAttributeValue {
 
   @Value.NaturalOrder
   public abstract NavigableMap<Integer, String> navigableMap();
+
+  @Value.NaturalOrder
+  public abstract SortedMultiset<Integer> naturalMultiset();
+
+  @Value.ReverseOrder
+  public abstract SortedMultiset<String> reverseMultiset();
+
 }

--- a/value-fixture/test/org/immutables/fixture/ValuesTest.java
+++ b/value-fixture/test/org/immutables/fixture/ValuesTest.java
@@ -99,6 +99,10 @@ public class ValuesTest {
         .putNavigableMap(1, "2")
         .navigableMap(ImmutableMap.of(2, "2"))
         .reverseMap(ImmutableMap.of("a", "a"))
+        .addNaturalMultiset(10, 10, 11)
+        .addReverseMultiset("x", "y", "y")
+        .naturalMultiset(ImmutableList.of(20, 13, 20))
+        .reverseMultiset(ImmutableList.of("w", "z", "z"))
         .build();
 
     OrderAttributeValue b = ImmutableOrderAttributeValue.builder()
@@ -106,6 +110,8 @@ public class ValuesTest {
         .addReverse("a", "z", "b", "y")
         .putNavigableMap(2, "2")
         .putReverseMap("a", "a")
+        .addNaturalMultiset(20, 13, 20)
+        .addReverseMultiset("w", "z", "z")
         .build();
 
     check(a).is(b);
@@ -154,12 +160,16 @@ public class ValuesTest {
         .putNavigableMap(1, "1")
         .putReverseMap("a", "a")
         .putReverseMap("b", "b")
+        .addNaturalMultiset(20, 13, 20)
+        .addReverseMultiset("w", "z", "z")
         .build();
 
     check(value.natural()).isOf(1, 2, 3, 4);
     check(value.reverse()).isOf("z", "y", "b", "a");
     check(value.navigableMap().keySet()).isOf(1, 2);
     check(value.reverseMap().keySet()).isOf("b", "a");
+    check(value.naturalMultiset()).isOf(13, 20, 20);
+    check(value.reverseMultiset()).isOf("z", "z", "w");
   }
 
   @Test

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -3052,6 +3052,14 @@ public static[type.generics.def] [type.typeValue.relative] [type.factoryOf.simpl
     [guava].collect.Sets.immutableEnumSet([expression])
   [else if a.generateOrdinalValueSet]
     org.immutables.ordinal.ImmutableOrdinalSet.copyOf([expression])
+  [else if a.generateSortedMultiset]
+    [guava].collect.ImmutableSortedMultiset.copyOf(
+      [if a.hasNaturalOrder]
+        [guava].collect.Ordering.<[a.elementType]>natural(),
+      [else]
+        [guava].collect.Ordering.<[a.elementType]>natural().reverse(),
+      [/if]
+        [expression])
   [else if a.customCollectionType]
     [a.rawType].from([expression])
   [else if a.collectionType]
@@ -3413,6 +3421,8 @@ this.[v.name].clear();
     [else]
       [if v.generateSortedSet]
 [if declare]private [guava].collect.ImmutableSortedSet.Builder[v.genericArgs] [else]this.[/if][v.name] = [if toNull]null[else][guava].collect.ImmutableSortedSet.[if v.hasNaturalOrder]naturalOrder[else]reverseOrder[/if]()[/if];
+      [else if v.generateSortedMultiset]
+[if declare]private [guava].collect.ImmutableSortedMultiset.Builder[v.genericArgs] [else]this.[/if][v.name] = [if toNull]null[else][guava].collect.ImmutableSortedMultiset.[if v.hasNaturalOrder]naturalOrder[else]reverseOrder[/if]()[/if];
       [else if v.customCollectionType]
 [if declare]private [v.rawType].Builder[v.genericArgs] [else]this.[/if][v.name] = [if toNull]null[else][v.rawType].builder()[/if];
       [else if v.collectionType]

--- a/value-processor/src/org/immutables/value/processor/meta/AttributeTypeKind.java
+++ b/value-processor/src/org/immutables/value/processor/meta/AttributeTypeKind.java
@@ -49,6 +49,10 @@ public enum AttributeTypeKind {
       "Multiset",
       UnshadeGuava.typeString("collect.Multiset"),
       UnshadeGuava.typeString("collect.ImmutableMultiset")),
+  SORTED_MULTISET(
+      "SortedMultiset",
+      UnshadeGuava.typeString("collect.SortedMultiset"),
+      UnshadeGuava.typeString("collect.ImmutableSortedMultiset")),
   MULTIMAP(
       "Multimap",
       UnshadeGuava.typeString("collect.Multimap"),
@@ -144,6 +148,7 @@ public enum AttributeTypeKind {
     switch (this) {
     case SORTED_MAP:
     case SORTED_SET:
+    case SORTED_MULTISET:
       return true;
     default:
       return false;
@@ -156,6 +161,7 @@ public enum AttributeTypeKind {
     case ENUM_SET:
     case SORTED_SET:
     case MULTISET:
+    case SORTED_MULTISET:
       return true;
     default:
       return false;
@@ -180,6 +186,7 @@ public enum AttributeTypeKind {
     case ENUM_SET:
     case SORTED_SET:
     case MULTISET:
+    case SORTED_MULTISET:
     case CUSTOM_COLLECTION:
       return true;
     default:
@@ -233,6 +240,7 @@ public enum AttributeTypeKind {
   public boolean isGuavaContainerKind() {
     switch (this) {
     case MULTISET:
+    case SORTED_MULTISET:
     case MULTIMAP:
     case LIST_MULTIMAP:
     case SET_MULTIMAP:
@@ -299,6 +307,16 @@ public enum AttributeTypeKind {
     return isCollectionKind() || isMappingKind();
   }
 
+  public boolean isMultisetKind() {
+    switch (this) {
+    case MULTISET:
+    case SORTED_MULTISET:
+      return true;
+    default:
+      return false;
+    }
+  }
+
   public boolean isMultimapKind() {
     switch (this) {
     case MULTIMAP:
@@ -363,6 +381,10 @@ public enum AttributeTypeKind {
     return this == MULTISET;
   }
 
+  public boolean isSortedMultiset() {
+    return this == SORTED_MULTISET;
+  }
+
   public boolean isMultimap() {
     return this == MULTIMAP;
   }
@@ -372,7 +394,7 @@ public enum AttributeTypeKind {
   }
 
   public boolean isListMultimap() {
-    return this == SET_MULTIMAP;
+    return this == LIST_MULTIMAP;
   }
 
   public boolean isEnumMap() {

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -414,13 +414,17 @@ public final class ValueAttribute extends TypeIntrospectionBase {
     return typeKind.isSortedMap();
   }
 
+  public boolean isGenerateSortedMultiset() {
+    return typeKind.isSortedMultiset();
+  }
+
   private void checkOrderAnnotations() {
     Optional<NaturalOrderMirror> naturalOrderAnnotation = NaturalOrderMirror.find(element);
     Optional<ReverseOrderMirror> reverseOrderAnnotation = ReverseOrderMirror.find(element);
 
     if (naturalOrderAnnotation.isPresent() && reverseOrderAnnotation.isPresent()) {
       report()
-          .error("@Value.Natural and @Value.Reverse annotations could not be used on the same attribute");
+          .error("@Value.Natural and @Value.Reverse annotations cannot be used on the same attribute");
     } else if (naturalOrderAnnotation.isPresent()) {
       if (typeKind.isSortedKind()) {
         if (isComparableKey()) {
@@ -428,12 +432,12 @@ public final class ValueAttribute extends TypeIntrospectionBase {
         } else {
           report()
               .annotationNamed(NaturalOrderMirror.simpleName())
-              .error("@Value.Natural should used on a set of Comparable elements (map keys)");
+              .error("@Value.Natural requires that a (multi)set's elements or a map's key are Comparable");
         }
       } else {
         report()
             .annotationNamed(NaturalOrderMirror.simpleName())
-            .error("@Value.Natural should specify order for SortedSet, SortedMap, NavigableSet or NavigableMap attributes");
+            .error("@Value.Natural can be applied only to SortedSet, SortedMap and SortedMultiset attributes");
       }
     } else if (reverseOrderAnnotation.isPresent()) {
       if (typeKind.isSortedKind()) {
@@ -442,12 +446,12 @@ public final class ValueAttribute extends TypeIntrospectionBase {
         } else {
           report()
               .annotationNamed(ReverseOrderMirror.simpleName())
-              .error("@Value.Reverse should used with a set of Comparable elements");
+              .error("@Value.Reverse requires that a (multi)set's elements or a map's key are Comparable");
         }
       } else {
         report()
             .annotationNamed(ReverseOrderMirror.simpleName())
-            .error("@Value.Reverse should specify order for SortedSet, SortedMap, NavigableSet or NavigableMap attributes");
+            .error("@Value.Reverse can be applied only to SortedSet, SortedMap and SortedMultiset attributes");
       }
     }
   }
@@ -769,7 +773,7 @@ public final class ValueAttribute extends TypeIntrospectionBase {
   }
 
   public boolean isMultisetType() {
-    return typeKind.isMultiset();
+    return typeKind.isMultisetKind();
   }
 
   public boolean isCustomCollectionType() {


### PR DESCRIPTION
From the commit message:
```
While there, also:
- Tweak the error messages in `ValueAttribute#checkOrderAnnotations`. (Note
  that `NavigableSet` extends `SortedSet` and `NavigableMap` extends
  `SortedMap`, so those don't need to be listed explicitly.)
- Fix the (unused) `AttributeTypeKind#isListMultimap`.
```

This PR relates to #516. Note that:
1. I added some tests and also tried the changes with `ImmutableSortedMultiset` in a local project and things seem to work, but I'm not sure I covered all cases.
2. I can trigger the error for when one specifies both `@NaturalOrder` and `@ReverseOrder`, but when I annotate an `ImmutableList` with (just) `@NaturalOrder`, the associated error is not triggered (as I also mentioned in #516). No idea why this is.