### PR TITLE
Allow unresolved ordered collection elements

### DIFF
--- a/value-fixture/src/org/immutables/fixture/ordered/SortedMultisetWrapper.java
+++ b/value-fixture/src/org/immutables/fixture/ordered/SortedMultisetWrapper.java
@@ -1,0 +1,37 @@
+package org.immutables.fixture.ordered;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedMultiset;
+import com.google.common.collect.ImmutableSortedSet;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface SortedMultisetWrapper {
+    @Value.NaturalOrder
+    ImmutableSortedSet<Elem> getElemSet();
+
+    @Value.NaturalOrder
+    ImmutableSortedSet<ImmutableElem> getImmutableElemSet();
+
+    @Value.ReverseOrder
+    ImmutableSortedMultiset<Elem> getElemMultiset();
+
+    @Value.ReverseOrder
+    ImmutableSortedMultiset<ImmutableElem> getImmutableElemMultiset();
+
+    @Value.NaturalOrder
+    ImmutableSortedMap<Elem, Void> getElemMap();
+
+    @Value.NaturalOrder
+    ImmutableSortedMap<ImmutableElem, Void> getImmutableElemMap();
+
+    @Value.Immutable
+    public interface Elem extends Comparable<Elem> {
+        int getValue();
+
+        @Override
+        public default int compareTo(Elem other) {
+            return getValue() - other.getValue();
+        }
+    }
+}

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -172,9 +172,9 @@ public final class ValueAttribute extends TypeIntrospectionBase {
 
   public boolean deprecated;
 
-  public boolean isComparableKey() {
+  public boolean isMaybeComparableKey() {
     return isContainerType()
-        && super.isComparable();
+        && (super.isComparable() || this.containedTypeElement == null);
   }
 
   @Override
@@ -432,7 +432,7 @@ public final class ValueAttribute extends TypeIntrospectionBase {
           .error("@Value.Natural and @Value.Reverse annotations cannot be used on the same attribute");
     } else if (naturalOrderAnnotation.isPresent()) {
       if (typeKind.isSortedKind()) {
-        if (isComparableKey()) {
+        if (isMaybeComparableKey()) {
           orderKind = OrderKind.NATURAL;
         } else {
           report()
@@ -446,7 +446,7 @@ public final class ValueAttribute extends TypeIntrospectionBase {
       }
     } else if (reverseOrderAnnotation.isPresent()) {
       if (typeKind.isSortedKind()) {
-        if (isComparableKey()) {
+        if (isMaybeComparableKey()) {
           orderKind = OrderKind.REVERSE;
         } else {
           report()


### PR DESCRIPTION
From the commit message:

```
Relax the check for `@NaturalOrder` and `@ReverseOrder` to allow unresolved
element/key types, as it is not possible to determine with certainty whether
such types are in fact `Comparable`.
```

This is a possible fix for #525. I replaced `#isComparableKey()` with `#isMaybeComparableKey()` because it was used nowhere else. If you prefer I can also retain the original method alongside the new method, or split the logic into a method `#isUnresolvedKey()`. Let me know :)