### PR TITLE
Assorted fixes

### DIFF
--- a/value-fixture/src/org/immutables/fixture/ordered/SortedCollectionWrapper.java
+++ b/value-fixture/src/org/immutables/fixture/ordered/SortedCollectionWrapper.java
@@ -6,7 +6,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface SortedMultisetWrapper {
+public interface SortedCollectionWrapper {
     @Value.NaturalOrder
     ImmutableSortedSet<Elem> getElemSet();
 

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -431,34 +431,26 @@ public final class ValueAttribute extends TypeIntrospectionBase {
       report()
           .error("@Value.Natural and @Value.Reverse annotations cannot be used on the same attribute");
     } else if (naturalOrderAnnotation.isPresent()) {
-      if (typeKind.isSortedKind()) {
-        if (isMaybeComparableKey()) {
-          orderKind = OrderKind.NATURAL;
-        } else {
-          report()
-              .annotationNamed(NaturalOrderMirror.simpleName())
-              .error("@Value.Natural requires that a (multi)set's elements or a map's key are Comparable");
-        }
-      } else {
-        report()
-            .annotationNamed(NaturalOrderMirror.simpleName())
-            .error("@Value.Natural can be applied only to SortedSet, SortedMap and SortedMultiset attributes");
-      }
+      configureOrdering(OrderKind.NATURAL, NaturalOrderMirror.simpleName());
     } else if (reverseOrderAnnotation.isPresent()) {
-      if (typeKind.isSortedKind()) {
-        if (isMaybeComparableKey()) {
-          orderKind = OrderKind.REVERSE;
-        } else {
-          report()
-              .annotationNamed(ReverseOrderMirror.simpleName())
-              .error("@Value.Reverse requires that a (multi)set's elements or a map's key are Comparable");
-        }
-      } else {
-        report()
-            .annotationNamed(ReverseOrderMirror.simpleName())
-            .error("@Value.Reverse can be applied only to SortedSet, SortedMap and SortedMultiset attributes");
-      }
+      configureOrdering(OrderKind.REVERSE, ReverseOrderMirror.simpleName());
     }
+  }
+
+  private void configureOrdering(OrderKind orderKind, String annotationName) {
+    if (typeKind.isSortedKind()) {
+      if (isMaybeComparableKey()) {
+        this.orderKind = orderKind;
+      } else {
+        reportOrderingError(annotationName, "requires that a (multi)set's elements or a map's keys are Comparable");
+      }
+    } else {
+      reportOrderingError(annotationName, "can be applied only to SortedSet, SortedMap and SortedMultiset attributes");
+    }
+  }
+
+  private void reportOrderingError(String annotationName, String msg) {
+    report().annotationNamed(annotationName).error(String.format("@Value.%s %s", annotationName, msg));
   }
 
   public boolean isJdkOptional() {


### PR DESCRIPTION
While reviewing PR #526 once more I noticed that I forgot to rename the test class. So this PR rectifies that and throws in two more tweaks:

1. Rename `SortedMultisetWrapper` -> `SortedCollectionWrapper` to match its content.
2. Deduplicate logic in `ValueAttribute#checkOrderAnnotations`.
3. Fix typo: "a map's key are Comparable" -> "a map's keys are Comparable".