### PR TITLE
#578 Modifiable#addAll* misses null check on @Nullable

### DIFF
--- a/value-fixture/src/org/immutables/fixture/modifiable/Companion.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/Companion.java
@@ -126,6 +126,9 @@ public interface Companion {
     default int derived() {
       return v1().or(0);
     }
+
+    @Nullable
+    List<Unit> nullableUnit();
   }
 
   @Value.Style(strictBuilder = true)

--- a/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
+++ b/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
@@ -178,4 +178,10 @@ public class ModifiablesTest {
     m.lst().add("b");
     check(m.lst()).isOf("a", "b");
   }
+
+  @Test
+  public void listsAreNullableSafe(){
+    // Test for #578
+    ModifiableStandalone.create().addAllNullableUnit(null);
+  }
 }

--- a/value-processor/src/org/immutables/value/processor/Modifiables.generator
+++ b/value-processor/src/org/immutables/value/processor/Modifiables.generator
@@ -551,6 +551,8 @@ public [thisSetterReturnType type] [v.names.addAll](Iterable<[v.consumedElementT
   if ([v.name] == null) {
     [defineOrResetField v false]
   }
+  if (elements == null) return this;
+
   [/if]
   for ([v.unwrappedElementType] element : elements) {
     [v.names.add](element);


### PR DESCRIPTION
Should fix a NPE when creating a modifiable model from an immutable one if a nullable List is actually null. 