### PR TITLE
Prevent Error-Prone `NumericEquality` warning

### DIFF
--- a/value-fixture/src/org/immutables/fixture/with/ForEquals.java
+++ b/value-fixture/src/org/immutables/fixture/with/ForEquals.java
@@ -1,0 +1,49 @@
+/*
+  Copyright 2017 Immutables Authors and Contributors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+package org.immutables.fixture.with;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class ForEquals {
+    public abstract int myInt();
+
+    public abstract Optional<Integer> myOptinalInt();
+
+    public abstract List<Integer> myIntList();
+
+    public abstract BigDecimal myBigDecimal();
+
+    public abstract Optional<BigDecimal> myOptinalBigDecimal();
+
+    public abstract List<BigDecimal> myBigDecimalList();
+
+    public abstract RoundingMode myRoundingMode();
+
+    public abstract Optional<RoundingMode> myOptinalRoundingMode();
+
+    public abstract List<RoundingMode> myRoundingModeList();
+
+    public abstract Object myObject();
+
+    public abstract Optional<Object> myOptinalObject();
+
+    public abstract List<Object> myObjectList();
+}

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -2862,7 +2862,7 @@ public final [type.typeImmutable.relative] [v.names.with]([v.atNullability][if v
  * Copy the current immutable object by setting a value for the [sourceDocRef type v] attribute.
  [if v.primitive and v.floatType]
  * A value strict bits equality used to prevent copying of the same value by returning {@code this}.
- [else if v.primitive]
+ [else if v.primitive or v.enumType]
  * A value equality check is used to prevent copying of the same value by returning {@code this}.
  [else if v.hasSimpleScalarElementType or v.isSuppressedOptional]
  * An equals check used to prevent copying of the same value by returning {@code this}.
@@ -2878,7 +2878,7 @@ public final [type.typeImmutable.relative] [v.names.with]([v.atNullability][v.ty
   if (Float.floatToIntBits(this.[v.name]) == Float.floatToIntBits(value)) return this;
     [else if v.double]
   if (Double.doubleToLongBits(this.[v.name]) == Double.doubleToLongBits(value)) return this;
-    [else if v.primitive]
+    [else if v.primitive or v.enumType]
   if (this.[v.name] == value) return this;
     [else if v.hasSimpleScalarElementType or v.isSuppressedOptional]
       [if v.nullable]

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -2864,7 +2864,7 @@ public final [type.typeImmutable.relative] [v.names.with]([v.atNullability][if v
  * A value strict bits equality used to prevent copying of the same value by returning {@code this}.
  [else if v.primitive]
  * A value equality check is used to prevent copying of the same value by returning {@code this}.
- [else if v.primitiveWrapperType or v.stringType]
+ [else if v.hasSimpleScalarElementType or v.isSuppressedOptional]
  * An equals check used to prevent copying of the same value by returning {@code this}.
  [else]
  * A shallow reference equality check is used to prevent copying of the same value by returning {@code this}.
@@ -2878,7 +2878,9 @@ public final [type.typeImmutable.relative] [v.names.with]([v.atNullability][v.ty
   if (Float.floatToIntBits(this.[v.name]) == Float.floatToIntBits(value)) return this;
     [else if v.double]
   if (Double.doubleToLongBits(this.[v.name]) == Double.doubleToLongBits(value)) return this;
-    [else if v.stringType or (v.primitiveWrapperType or v.isSuppressedOptional)]
+    [else if v.primitive]
+  if (this.[v.name] == value) return this;
+    [else if v.hasSimpleScalarElementType or v.isSuppressedOptional]
       [if v.nullable]
   if ([objectsEqual type](this.[v.name], value)) return this;
       [else]


### PR DESCRIPTION
In a1d3518d4851291103fd98a449fbbd8fded90579 triggering `NumericEquality`
warnings is prevented for optional numbers. This change tackles non-optional
`java.lang.Number` instances.

This relates to #570.