### PR TITLE
Followup of #583

### DIFF
--- a/value-fixture/src/org/immutables/fixture/with/ForEquals.java
+++ b/value-fixture/src/org/immutables/fixture/with/ForEquals.java
@@ -25,25 +25,25 @@ import org.immutables.value.Value;
 public abstract class ForEquals {
     public abstract int myInt();
 
-    public abstract Optional<Integer> myOptinalInt();
+    public abstract Optional<Integer> myOptionalInt();
 
     public abstract List<Integer> myIntList();
 
     public abstract BigDecimal myBigDecimal();
 
-    public abstract Optional<BigDecimal> myOptinalBigDecimal();
+    public abstract Optional<BigDecimal> myOptionalBigDecimal();
 
     public abstract List<BigDecimal> myBigDecimalList();
 
     public abstract RoundingMode myRoundingMode();
 
-    public abstract Optional<RoundingMode> myOptinalRoundingMode();
+    public abstract Optional<RoundingMode> myOptionalRoundingMode();
 
     public abstract List<RoundingMode> myRoundingModeList();
 
     public abstract Object myObject();
 
-    public abstract Optional<Object> myOptinalObject();
+    public abstract Optional<Object> myOptionalObject();
 
     public abstract List<Object> myObjectList();
 }

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -2784,7 +2784,7 @@ public final [type.typeImmutable.relative] [v.names.with]([unwrappedOptionalType
   [else]
   [immutableImplementationType v] newValue = [requireNonNull type](value, "[v.name]");
   [/if]
-  [if v.hasSimpleScalarElementType]
+  [if v.hasSimpleScalarElementType and (not v.enumType)]
   if ([objectsEqual type](this.[v.name], newValue)) return this;
   [else]
   if (this.[v.name] == newValue) return this;
@@ -2792,7 +2792,7 @@ public final [type.typeImmutable.relative] [v.names.with]([unwrappedOptionalType
   [generateReturnCopyContextual type v]
 [else]
   [immutableImplementationType v] newValue = [optionalOf v](value);
-  [if v.hasSimpleScalarElementType]
+  [if v.hasSimpleScalarElementType and (not v.enumType)]
   if (this.[v.name].equals(newValue)) return this;
   [else]
   if (this.[v.name].[optionalPresent v] && this.[v.name].[optionalGet v] == value) return this;


### PR DESCRIPTION
Summary of changes:
- Fix typo in `org.immutables.fixture.with.ForEquals`.
- Compare enums by reference.

(Looking again at the code derived from `ForEquals`, only the equality check mentioned in https://github.com/immutables/immutables/pull/583#issuecomment-287989754 is changed, as desired.)