### PR TITLE
added (eg. readonly) flags to customize repository generator

### DIFF
--- a/mongo/src/org/immutables/mongo/Mongo.java
+++ b/mongo/src/org/immutables/mongo/Mongo.java
@@ -46,8 +46,32 @@ public @interface Mongo {
      * Specify document collection name. If not specified, then collection name will be given
      * automatically by document class name, i.e. {@code "myDocument"} for {@code MyDocument} class.
      * @return name
+     * @deprecated use {@link #collection()} attribute instead
      */
+    @Deprecated
     String value() default "";
+
+    /**
+     * Specify document collection name. If not specified, then collection name will be given
+     * automatically by document class name, i.e. {@code "myDocument"} for {@code MyDocument} class.
+     * @return name
+     */
+    String collection() default "";
+
+    /**
+     * Force repository to be readonly. In this case no collection write methods (eg. {@code insert},
+     * {@code update}, {@code deleteAll} etc.) will be generated.
+     *
+     * @return true for a repository without write actions, false otherwise.
+     */
+    boolean readonly() default false;
+
+    /**
+     * Generate index helper which builds mongo indexes.
+     *
+     * @return true for index operations to be available to the repository, false otherwise.
+     */
+    boolean index() default true;
   }
 
   /**

--- a/mongo/test/org/immutables/mongo/fixture/flags/FlagsTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/flags/FlagsTest.java
@@ -1,0 +1,83 @@
+package org.immutables.mongo.fixture.flags;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import org.immutables.mongo.fixture.MongoContext;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+
+import static org.immutables.check.Checkers.check;
+
+/**
+ * Ensures read / write / index methods are present / absent from generated repositories after some flags have been
+ * set using {@link org.immutables.mongo.Mongo.Repository} annotation.
+ */
+public class FlagsTest {
+
+  @Rule
+  public final MongoContext context = MongoContext.create();
+
+  @Test
+  public void standard() throws Exception {
+    StandardRepository repo = new StandardRepository(context.setup());
+
+    repo.index().withName().ensure().getUnchecked();
+
+    repo.findAll().deleteAll().getUnchecked();
+    repo.findAll().deleteFirst().getUnchecked();
+    repo.findAll().andModifyFirst().setName("foo").update();
+    repo.findAll().andReplaceFirst(ImmutableStandard.builder().id("id1").build()).upsert().getUnchecked();
+
+  }
+
+  @Test
+  public void readonly() throws Exception {
+    ReadonlyRepository repo = new ReadonlyRepository(context.setup());
+
+    // index method should be present. Make it compile time check
+    repo.index().withName().ensure().getUnchecked();
+
+    // ensure write methods are missing
+    check(methodsByName(ReadonlyRepository.class, "andModifyFirst")).isEmpty();
+    check(methodsByName(ReadonlyRepository.class, "andReplaceFirst")).isEmpty();
+    check(methodsByName(ReadonlyRepository.class, "update")).isEmpty();
+    check(methodsByName(ReadonlyRepository.class, "upsert")).isEmpty();
+    check(methodsByName(ReadonlyRepository.class, "insert")).isEmpty();
+
+    check(methodsByName(ReadonlyRepository.Finder.class, "deleteFirst")).isEmpty();
+    check(methodsByName(ReadonlyRepository.Finder.class, "deleteAll")).isEmpty();
+    check(methodsByName(ReadonlyRepository.Finder.class, "delete")).isEmpty();
+    check(methodsByName(ReadonlyRepository.Finder.class, "andModifyFirst")).isEmpty();
+    check(methodsByName(ReadonlyRepository.Finder.class, "andReplaceFirst")).isEmpty();
+  }
+
+  @Test
+  public void noIndex() throws Exception {
+    NoIndexRepository repo = new NoIndexRepository(context.setup());
+
+    repo.find(repo.criteria().id("foo")).fetchAll().getUnchecked();
+    check(methodsByName(NoIndexRepository.class, "index")).isEmpty();
+  }
+
+  /**
+   * Gets all (public) methods by name using reflection
+   */
+  private static Set<Method> methodsByName(Class<?> type, final String name) {
+    return FluentIterable
+            .from(Arrays.asList(type.getDeclaredMethods()))
+            .append(Arrays.asList(type.getMethods()))
+            .filter(new Predicate<Method>() {
+              @Override
+              public boolean apply(Method method) {
+                return Modifier.isPublic(method.getModifiers()) && method.getName().equals(name);
+              }
+            })
+            .toSet();
+  }
+
+}

--- a/mongo/test/org/immutables/mongo/fixture/flags/Repo.java
+++ b/mongo/test/org/immutables/mongo/fixture/flags/Repo.java
@@ -1,0 +1,36 @@
+package org.immutables.mongo.fixture.flags;
+
+import com.google.common.base.Optional;
+import org.immutables.mongo.Mongo;
+import org.immutables.value.Value;
+
+public interface Repo {
+
+  @Mongo.Id
+  String id();
+
+  Optional<String> name();
+
+  @Mongo.Repository
+  @Value.Immutable
+  interface Standard extends Repo {
+
+  }
+
+  /**
+   * Repository without delete / andModifyFirst / andReplaceFirst methods.
+   */
+  @Mongo.Repository(readonly = true)
+  @Value.Immutable
+  interface Readonly extends Repo {
+
+  }
+
+
+  @Mongo.Repository(index = false, readonly = true)
+  @Value.Immutable
+  interface NoIndex extends Repo {
+
+  }
+
+}

--- a/mongo/test/org/immutables/mongo/fixture/flags/package-info.java
+++ b/mongo/test/org/immutables/mongo/fixture/flags/package-info.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2015 Immutables Authors and Contributors
+   Copyright 2013-2015 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,25 +13,8 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  */
-package org.immutables.value.processor.meta;
 
-import org.immutables.mirror.Mirror;
-
-public final class MongoMirrors {
-  private MongoMirrors() {}
-
-  @Mirror.Annotation("org.immutables.mongo.Mongo.Repository")
-  public @interface Repository {
-    String value() default "";
-
-    String collection() default "";
-
-    boolean readonly() default false;
-
-    boolean index() default true;
-
-  }
-
-  @Mirror.Annotation("org.immutables.mongo.Mongo.Id")
-  public @interface Id {}
-}
+/**
+ * Tests repositories with various flags (readonly, index etc.)
+ */
+package org.immutables.mongo.fixture.flags;

--- a/value-processor/src/org/immutables/value/processor/Repositories.generator
+++ b/value-processor/src/org/immutables/value/processor/Repositories.generator
@@ -50,6 +50,10 @@ import [starImport];
 /**
  * A {@code [type.name]Repository} provides type-safe access for storing and retrieving documents
  * from the MongoDB collection {@code "[type.documentName]"}.
+ [if type.repository.readonly]
+ *
+ * This repository was marked as readonly and therefore write operations have been disabled.
+ [/if]
  */
 [if type.generateSuppressAllWarnings]@SuppressWarnings("all")[/if]
 @javax.annotation.Generated({"Repositories.generator", "[type.typeAbstract]"})
@@ -71,6 +75,7 @@ import [starImport];
     this.anyCriteria = new Criteria(this.serialization, Constraints.nilConstraint());
   }
 
+  [if not type.repository.readonly]
   /**
    * Inserts a single document into the collection.
    * @param document The [toLower type.name] to insert
@@ -88,10 +93,11 @@ import [starImport];
   public FluentFuture<Integer> insert(Iterable<? extends [type.typeDocument]> documents) {
     return super.doInsert(com.google.common.collect.ImmutableList.copyOf(documents));
   }
+  [/if]
 
   /**
    * Finds all documents. Use the returned {@link Finder} object to complete
-   * {@link Finder#fetchAll() fetch all}, {@link Finder#deleteAll() delete all}, or other operations.
+   * {@link Finder#fetchAll() fetch all} or other operations.
    * @return A finder object used to complete operations
    */
   @javax.annotation.CheckReturnValue
@@ -101,7 +107,7 @@ import [starImport];
 
  /**
   * Find documents by the criteria expressed as a JSON string. Use the returned {@link Finder} object to complete
-  * {@link Finder#fetchAll() fetch}, {@link Finder#andModifyFirst() modify}, or {@link Finder#deleteFirst() delete} operations.
+  * {@link Finder#fetchAll() fetch} or {@link Finder#fetchFirst() fetch} operations.
   * @param jsonCriteria A JSON string for native criteria
   * @return A finder object used to complete operations
   */
@@ -114,7 +120,11 @@ import [starImport];
 
   /**
    * Find documents by the {@link [type.name]#[a.names.get]() [a.name]} identity attribute. Use the returned {@link Finder} object to complete
-   * {@link Finder#fetchFirst() fetch}, {@link Finder#andModifyFirst() modify}, or {@link Finder#deleteFirst() delete} operations.
+   * {@link Finder#fetchFirst() fetch} or {@link Finder#fetchAll() fetchAll} read operations.
+   [if not type.repository.readonly]
+   * You can also use {@link Finder#andModifyFirst() modify}, {@link Finder#andReplaceFirst() replace}
+   * or {@link Finder#deleteFirst() delete} operations to update / delete the document.
+   [/if]
    * @param [a.name] The exact {@code [a.name]} value
    * @return A finder object used to complete operations
    */
@@ -123,6 +133,7 @@ import [starImport];
     return find(criteria().[a.name]([a.name]));
   }
 
+  [if not type.repository.readonly]
   /**
    * Update or insert a document, matched by the identifier value of the '[a.name]' attribute.
    * @param document The [toLower type.name] to upsert
@@ -132,13 +143,18 @@ import [starImport];
     Criteria byId = criteria().[a.name](document.[a.names.get]());
     return super.doUpsert(byId.constraint, document);
   }
+  [/if]
 [/if]
 [/for]
   [generateFinder type]
-  [generateUpdater type]
-  [generateModifier type]
-  [generateReplacer type]
-  [generateIndexer type]
+  [if not type.repository.readonly]
+    [generateUpdater type]
+    [generateModifier type]
+    [generateReplacer type]
+  [/if]
+  [if type.repository.index]
+    [generateIndexer type]
+  [/if]
   [generateCriteria type]
   [generateSerializationHelpers type]
 }
@@ -186,7 +202,11 @@ public [tT] exclude[toUpper a.name]() {
 
 /**
  * Find a document by the given {@link [type.name]Repository#criteria() criteria}. Use the returned {@link Finder} object to complete
- * {@link Finder#fetchAll() fetch}, {@link Finder#andModifyFirst() modify}, or {@link Finder#deleteFirst() delete} operations.
+ * {@link Finder#fetchAll() fetch}  operations.
+ [if not type.repository.readonly]
+ * You can also use {@link Finder#andModifyFirst() modify}, {@link Finder#andReplaceFirst() replace}
+ * or {@link Finder#deleteFirst() delete} operations to update / delete the document(s).
+ [/if]
  * @param criteria The search criteria
  * @return A finder object used to complete operations
  */
@@ -197,12 +217,12 @@ public Finder find(Criteria criteria) {
 
 /**
  * The finder object used to proceed with find operations via the
- * {@link Finder#fetchAll()}, {@link Finder#fetchFirst()}, {@link Finder#andModifyFirst()}, or {@link Finder#deleteFirst()} methods.
+ * {@link Finder#fetchAll()}, {@link Finder#fetchFirst()}[if not type.repository.readonly], {@link Finder#andModifyFirst()}, or {@link Finder#deleteFirst()}[/if] methods.
  * Configure exclusion and sort ordering for results using the family of {@code exclude*()} and {@code orderBy*()} attribute-specific methods.
  * @see [type.name]Repository#find(Criteria)
  */
 @javax.annotation.concurrent.NotThreadSafe
-public static final class Finder extends Repositories.Finder<[type.typeDocument], Finder> {
+public static final class Finder extends Repositories.[if type.repository.readonly]Finder[else]FinderWithDelete[/if]<[type.typeDocument], Finder> {
   private final Serialization serialization;
 
   private Finder([type.name]Repository repository, Constraints.ConstraintHost criteria) {
@@ -211,8 +231,10 @@ public static final class Finder extends Repositories.Finder<[type.typeDocument]
     this.serialization = repository.serialization;
   }
   [generateOrderingAndExcludes type 'Finder']
-  [generateAndModifyFirst type]
-  [generateAndReplaceFirst type]
+  [if not type.repository.readonly]
+    [generateAndModifyFirst type]
+    [generateAndReplaceFirst type]
+  [/if]
 }
 [/template]
 

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -381,6 +381,10 @@ public final class ValueType extends TypeIntrospectionBase {
     return constitution.protoclass().repository().isPresent();
   }
 
+  public MongoMirrors.Repository getRepository() {
+    return constitution.protoclass().repository().get();
+  }
+
   public boolean isAnnotationType() {
     return element.getKind() == ElementKind.ANNOTATION_TYPE;
   }
@@ -547,9 +551,11 @@ public final class ValueType extends TypeIntrospectionBase {
   public String getDocumentName() {
     Optional<RepositoryMirror> repositoryAnnotation = RepositoryMirror.find(element);
     if (repositoryAnnotation.isPresent()) {
-      String value = repositoryAnnotation.get().value();
-      if (!value.isEmpty()) {
-        return value;
+      RepositoryMirror mirror = repositoryAnnotation.get();
+      if (!mirror.collection().isEmpty()) {
+        return mirror.collection();
+      } else if (!mirror.value().isEmpty()) {
+        return mirror.value();
       }
     }
     return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, name());


### PR DESCRIPTION
Added two `@Mongo.Repository` annotation attributes:
1. `readonly`. Setting this flag to `true` will remove `delete` / `insert` / `upsert` / `andModifyFirst` ...  write operations from repository. The default value is `false`
2. `index`. Setting this flag to `false` will disable indexer functionality of the repository.

