### PR TITLE
Don't generate duplicate @SuppressWarnings

### DIFF
--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1201,7 +1201,7 @@ public interface BuildFinal[type.generics] {
       [/for]
 
 [for bs = type.buildFromTypes]
-[if bs.hasWildcards]
+[if bs.hasWildcards and (not type.suppressesUncheckedWarning)]
   @SuppressWarnings("unchecked")
 [/if]
   private void from(Object object) {
@@ -2557,7 +2557,7 @@ public int ordinal() {
 [/if]
  * @return {@code true} if {@code this} is equal to {@code another} instance
  */
-[if type.generics]@SuppressWarnings("unchecked")[/if]
+[if type.generics and (not type.suppressesUncheckedWarning)]@SuppressWarnings("unchecked")[/if]
 @Override
 public boolean equals([atNullable]Object another) {
   [if type.useReferenceEquality]

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -1363,6 +1363,11 @@ public final class ValueType extends TypeIntrospectionBase {
     return suppressedWarnings;
   }
 
+  public boolean suppressesUncheckedWarning() {
+    Set<String> typeSuppressions = generatedSuppressWarnings();
+    return typeSuppressions.contains("all") || typeSuppressions.contains("unchecked");
+  }
+
   public boolean isGenerateSuppressAllWarnings() {
     return getSuppressedWarnings().generated;
   }


### PR DESCRIPTION
If the type suppresses either all or unchecked, it is unnecessary to
also suppress that warning on a method on the type.

The Buck project compiles with ecj with
org.eclipse.jdt.core.compiler.problem.unusedWarningToken=error where
this is flagged as an error.