### PR TITLE
Custom nullable annotation.

### DIFF
--- a/value-fixture/src/org/immutables/fixture/nullable/CheckForNull.java
+++ b/value-fixture/src/org/immutables/fixture/nullable/CheckForNull.java
@@ -1,0 +1,5 @@
+package org.immutables.fixture.nullable;
+
+@interface CheckForNull {
+
+}

--- a/value-fixture/src/org/immutables/fixture/nullable/CustomNullableAnnotation.java
+++ b/value-fixture/src/org/immutables/fixture/nullable/CustomNullableAnnotation.java
@@ -1,0 +1,13 @@
+package org.immutables.fixture.nullable;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(nullableAnnotationName = "CheckForNull")
+public interface CustomNullableAnnotation {
+
+    @CheckForNull
+    String string1();
+
+    String string2();
+}

--- a/value-fixture/test/org/immutables/fixture/nullable/CustomNullableAnnotationTest.java
+++ b/value-fixture/test/org/immutables/fixture/nullable/CustomNullableAnnotationTest.java
@@ -1,0 +1,32 @@
+package org.immutables.fixture.nullable;
+
+import static org.immutables.check.Checkers.check;
+
+import org.junit.Test;
+
+public class CustomNullableAnnotationTest {
+
+    @Test
+    public void shouldAllowNulls() {
+        ImmutableCustomNullableAnnotation customNullableAnnotation = ImmutableCustomNullableAnnotation.builder()
+            .string1(null)
+            .string2("non null")
+            .build();
+
+        check(customNullableAnnotation.string1()).isNull();
+        check(customNullableAnnotation.string2()).is("non null");
+    }
+
+    @Test
+    public void banNulls() {
+        ImmutableCustomNullableAnnotation.Builder customNullableAnnotation =
+            ImmutableCustomNullableAnnotation.builder();
+
+        try {
+            customNullableAnnotation.string2(null);
+            check(false);
+        } catch (NullPointerException e) {
+
+        }
+    }
+}

--- a/value-processor/src/org/immutables/value/processor/meta/Proto.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Proto.java
@@ -1787,7 +1787,8 @@ public class Proto {
           input.builtinContainerAttributes(),
           input.beanFriendlyModifiables(),
           input.allMandatoryParameters(),
-          input.redactedMask());
+          input.redactedMask(),
+          input.nullableAnnotationName());
     }
   }
 

--- a/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
+++ b/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
@@ -304,6 +304,10 @@ public abstract class StyleInfo implements ValueMirrors.Style {
   @Override
   public abstract String redactedMask();
 
+  @Value.Parameter
+  @Override
+  public abstract String nullableAnnotationName();
+
   @Value.Lazy
   public Styles getStyles() {
     return new Styles(this);

--- a/value-processor/src/org/immutables/value/processor/meta/Styles.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Styles.java
@@ -101,6 +101,7 @@ public final class Styles {
     Naming create = Naming.from(style.create());
     Naming toImmutable = Naming.from(style.toImmutable());
     Naming typeModifiable = Naming.from(style.typeModifiable());
+    Naming nullableAnnotationName = Naming.from(style.nullableAnnotationName());
   }
 
   public static class UsingName {
@@ -214,6 +215,7 @@ public final class Styles {
       public final String var = apply(Naming.identity(), false);
       public final String init = apply(scheme.init, false);
       public final String with = apply(scheme.with, false);
+      public final String nullableAnnotationName = apply(scheme.nullableAnnotationName, false);
 
       public String add() {
         return forCollection().add;

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -1306,12 +1306,12 @@ public final class ValueAttribute extends TypeIntrospectionBase {
             .warning("@Nullable on a Optional attribute make it lose its special treatment");
       } else if (isPrimitive()) {
         report()
-            .annotationNamed(Annotations.NULLABLE_SIMPLE_NAME)
-            .error("@Nullable could not be used with primitive type attibutes");
+            .annotationNamed(this.names.nullableAnnotationName)
+            .error("@" + this.names.nullableAnnotationName + " could not be used with primitive type attibutes");
       } else if (containingType.isAnnotationType()) {
         report()
-            .annotationNamed(Annotations.NULLABLE_SIMPLE_NAME)
-            .error("@Nullable could not be used with annotation attribute, use default value");
+            .annotationNamed(this.names.nullableAnnotationName)
+            .error("@" + this.names.nullableAnnotationName + " could not be used with annotation attribute, use default value");
       }
     }
 
@@ -1332,9 +1332,9 @@ public final class ValueAttribute extends TypeIntrospectionBase {
       } else if (isNullable()) {
         typeKind = AttributeTypeKind.REGULAR;
         report()
-            .annotationNamed(Annotations.NULLABLE_SIMPLE_NAME)
+            .annotationNamed(this.names.nullableAnnotationName)
             .warning(
-                "@Nullable on a container attribute make it lose its special treatment (when strictBuilder = true)");
+                "@" + this.names.nullableAnnotationName + " on a container attribute make it lose its special treatment (when strictBuilder = true)");
       }
     }
 
@@ -1375,7 +1375,7 @@ public final class ValueAttribute extends TypeIntrospectionBase {
     for (AnnotationMirror annotation : element.getAnnotationMirrors()) {
       TypeElement annotationElement = (TypeElement) annotation.getAnnotationType().asElement();
       Name simpleName = annotationElement.getSimpleName();
-      if (simpleName.contentEquals(Annotations.NULLABLE_SIMPLE_NAME)) {
+      if (simpleName.contentEquals(this.names.nullableAnnotationName)) {
         nullability = ImmutableNullabilityAnnotationInfo.of(annotationElement);
       } else if (simpleName.contentEquals(TypeStringProvider.EPHEMERAL_ANNOTATION_ALLOW_NULLS)) {
         nullElements = NullElements.ALLOW;

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -215,6 +215,8 @@ public final class ValueMirrors {
 
     String redactedMask() default "";
 
+    String nullableAnnotationName() default "Nullable";
+
     public enum ImplementationVisibility {
       PUBLIC,
       SAME,

--- a/value/src/org/immutables/value/Value.java
+++ b/value/src/org/immutables/value/Value.java
@@ -203,16 +203,16 @@ public @interface Value {
    * <pre>
    * {@literal @}Value.Immutable
    * public abstract class Order {
-   * 
+   *
    *   public abstract List&lt;Item&gt; items();
-   * 
+   *
    *   {@literal @}Value.Lazy
    *   public int totalCost() {
    *     int cost = 0;
-   * 
+   *
    *     for (Item i : items())
    *       cost += i.count() * i.price();
-   * 
+   *
    *     return cost;
    *   }
    * }
@@ -281,19 +281,19 @@ public @interface Value {
    * (non-private) method and have a {@code void} return type, which also should not throw a checked
    * exceptions.
    * </p>
-   * 
+   *
    * <pre>
    * {@literal @}Value.Immutable
    * public abstract class NumberContainer {
    *   public abstract List<Number> nonEmptyNumbers();
-   * 
+   *
    *   {@literal @}Value.Check
    *   protected void check() {
    *     Preconditions.checkState(!nonEmptyNumbers().isEmpty(),
    *         "'nonEmptyNumbers' should have at least one number");
    *   }
    * }
-   * 
+   *
    * // will throw IllegalStateException("'nonEmptyNumbers' should have at least one number")
    * ImmutableNumberContainer.builder().build();
    * </pre>
@@ -314,12 +314,12 @@ public @interface Value {
    * <em>Be warned that it's easy introduce unresolvable recursion if normalization is implemented without
    * proper or with conflicting checks. Always return {@code this} if value do not require normalization.</em>
    * </p>
-   * 
+   *
    * <pre>
    * {@literal @}Value.Immutable
    * public interface Normalize {
    *   int value();
-   * 
+   *
    *   {@literal @}Value.Check
    *   default Normalize normalize() {
    *     if (value() == Integer.MIN_VALUE) {
@@ -335,7 +335,7 @@ public @interface Value {
    *     return this;
    *   }
    * }
-   * 
+   *
    * int shouldBePositive2 = ImmutableNormalize.builder()
    *     .value(-2)
    *     .build()
@@ -734,7 +734,7 @@ public @interface Value {
      *     allParameters = true,
      *     defaults = {@literal @}Value.Immutable(builder = false))
      * public @interface Tuple {}
-     * 
+     *
      * {@literal @}Tuple
      * {@literal @}Value.Immutable
      * interface Color {
@@ -744,7 +744,7 @@ public @interface Value {
      *   {@literal @}Value.Parameter(false)
      *   List<Info> auxiliaryInfo();
      * }
-     * 
+     *
      * ColorTuple.of(0xFF, 0x00, 0xFE);
      * </pre>
      * @return if all attributes will be considered parameters
@@ -899,7 +899,7 @@ public @interface Value {
      * confusing overload).</li>
      * </ul>
      * See the example below which illustrates these behaviors.
-     * 
+     *
      * <pre>
      * {@literal @}Value.Style(deepImmutablesDetection = true)
      * public interface Canvas {
@@ -909,20 +909,20 @@ public @interface Value {
      *     {@literal @}Value.Parameter double green();
      *     {@literal @}Value.Parameter double blue();
      *   }
-     * 
+     *
      *   {@literal @}Value.Immutable
      *   public interface Point {
      *     {@literal @}Value.Parameter int x();
      *     {@literal @}Value.Parameter int y();
      *   }
-     * 
+     *
      *   {@literal @}Value.Immutable
      *   public interface Line {
      *     Color color();
      *     Point start();
      *     Point end();
      *   }
-     * 
+     *
      *   public static void main(String... args) {
      *     ImmutableLine line = ImmutableLine.builder()
      *         .start(1, 2) // overload, equivalent of .start(ImmutablePoint.of(1, 2))
@@ -931,11 +931,11 @@ public @interface Value {
      *         .color(0.9, 0.7, 0.4)
      *         // overload, equivalent of .color(ImmutableColor.of(0.9, 0.7. 0.4))
      *         .build();
-     * 
+     *
      *     ImmutablePoint start = line.start(); // return type is ImmutablePoint rather than declared Point
      *     ImmutablePoint end = line.end(); // return type is ImmutablePoint rather than declared Point
      *     ImmutableColor color = line.color(); // return type is ImmutableColor rather than declared Color
-     * 
+     *
      *     ImmutableLine.builder()
      *         .start(start)
      *         .end(end)
@@ -1028,13 +1028,13 @@ public @interface Value {
      * ("*ies" to "*y" is also supported).
      * Exceptions are provided using {@link #depluralizeDictionary()} array of "singular:plural"
      * pairs as alternative to mechanical "*s" depluralization.
-     * 
+     *
      * <pre>
      * {@literal @}Value.Style(
      *    depluralize = true, // enable feature
      *    depluralizeDictionary = {"person:people", "foot:feet"}) // specifying dictionary of exceptions
      * </pre>
-     * 
+     *
      * When given the dictionary defined as {@code "person:people", "foot:feet"} then
      * depluralization examples for collection {@code add*} method in builder would be:
      * <ul>
@@ -1147,6 +1147,9 @@ public @interface Value {
      * @return redacted value substitution string
      */
     String redactedMask() default "";
+
+
+    String nullableAnnotationName() default "Nullable";
 
     /**
      * If implementation visibility is more restrictive than visibility of abstract value type, then


### PR DESCRIPTION
Custom nullable annotation feature.

Added ability to configure custom annotation which will be considered as special nulllable annotation.
Added property `nullableAnnotationName` to `Value.Style`. Default value is `Nullable`
This PR is just for review and approval.

TODO write java doc for new property.