### PR TITLE
Fix nondeterminism in code generation of nested values

### DIFF
--- a/value-processor/src/org/immutables/value/processor/meta/Round.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Round.java
@@ -113,7 +113,7 @@ public abstract class Round {
   }
 
   private Set<Element> allAnnotatedElements() {
-    Set<Element> elements = Sets.newHashSetWithExpectedSize(100);
+    Set<Element> elements = Sets.newLinkedHashSetWithExpectedSize(100);
     for (TypeElement annotation : annotations()) {
       Set<? extends Element> annotatedElements = round().getElementsAnnotatedWith(annotation);
       checkAnnotation(annotation, annotatedElements);


### PR DESCRIPTION
Because `HashSet` iteration order can vary from run to run, the order in which the processor
was generating nested value classes could change from run to run. This caused problems with
build systems like Buck that assume deterministic output so that artifacts can be cached.

Switching to a `LinkedHashSet` takes care of the issue.