### PR TITLE
Support Error Prone's `@Immutable` annotation

### DIFF
--- a/value-fixture/pom.xml
+++ b/value-fixture/pom.xml
@@ -30,6 +30,10 @@
     Module that contains all tests for the code generation capability
   </description>
 
+  <properties>
+    <errorprone.version>2.0.19</errorprone.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.immutables</groupId>
@@ -146,6 +150,11 @@
       <artifactId>hibernate-validator</artifactId>
       <version>5.4.0.Final</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>${errorprone.version}</version>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>
@@ -178,7 +187,7 @@
           <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_core</artifactId>
-            <version>2.0.19</version>
+            <version>${errorprone.version}</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/value-fixture/src/org/immutables/fixture/AllMandatoryParams.java
+++ b/value-fixture/src/org/immutables/fixture/AllMandatoryParams.java
@@ -28,6 +28,7 @@ public interface AllMandatoryParams {
     return "C";
   }
 
+  @SuppressWarnings("CheckReturnValue")
   static void use() {
     ImmutableAllMandatoryParams.of(1, true).withC("ABC");
   }

--- a/value-fixture/src/org/immutables/fixture/CancelParam.java
+++ b/value-fixture/src/org/immutables/fixture/CancelParam.java
@@ -33,6 +33,7 @@ public interface CancelParam extends Param {
   @Value.Parameter(false)
   List<Integer> aux();
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableCancelParam.of(1).withAux(1, 2, 3);
   }

--- a/value-fixture/src/org/immutables/fixture/DeprecateType.java
+++ b/value-fixture/src/org/immutables/fixture/DeprecateType.java
@@ -21,6 +21,7 @@ import org.immutables.value.Value;
 @Deprecated
 interface DeprecateType {
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableDeprecateType.of();
   }

--- a/value-fixture/src/org/immutables/fixture/DerivedNotInConstructor.java
+++ b/value-fixture/src/org/immutables/fixture/DerivedNotInConstructor.java
@@ -37,6 +37,7 @@ public abstract class DerivedNotInConstructor {
     return length;
   }
 
+  @SuppressWarnings("CheckReturnValue")
   void use() {
     ImmutableDerivedNotInConstructor.of(Arrays.asList("a", "b", "c"));
   }
@@ -53,6 +54,7 @@ abstract class DerivedNotInConstructorSimpleCons {
     return 1;
   }
 
+  @SuppressWarnings("CheckReturnValue")
   void use() {
     ImmutableDerivedNotInConstructorSimpleCons.of(1);
   }

--- a/value-fixture/src/org/immutables/fixture/ExtendingInnerBuilderValue.java
+++ b/value-fixture/src/org/immutables/fixture/ExtendingInnerBuilderValue.java
@@ -26,6 +26,7 @@ class SuperInnerBuildeValue {
     void hello() {}
   }
 
+  @SuppressWarnings("CheckReturnValue")
   static void use() {
     ImmutableSuperInnerBuildeValue.builder().hello();
   }
@@ -64,6 +65,7 @@ interface ExtendingInnerCreatorValue {
     }
   }
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableExtendingInnerCreatorValue.Creator c = new ImmutableExtendingInnerCreatorValue.Creator();
     c.create();

--- a/value-fixture/src/org/immutables/fixture/ExtraCollection.java
+++ b/value-fixture/src/org/immutables/fixture/ExtraCollection.java
@@ -44,6 +44,7 @@ public interface ExtraCollection {
   @Value.Parameter
   BiMap<Integer, String> biMap();
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableExtraCollection.of(
         ImmutableList.<String>of(),

--- a/value-fixture/src/org/immutables/fixture/InheritConstructorParameter.java
+++ b/value-fixture/src/org/immutables/fixture/InheritConstructorParameter.java
@@ -27,6 +27,7 @@ interface InheritConstructorParameter {
   @Value.Immutable
   abstract class ExtendsIt extends HasParam {}
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableExtendsIt.of(1);
   }

--- a/value-fixture/src/org/immutables/fixture/OptionalCast.java
+++ b/value-fixture/src/org/immutables/fixture/OptionalCast.java
@@ -27,6 +27,7 @@ public interface OptionalCast {
 
   Optional<String[]> getStringArray();
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableOptionalCast.of(
         Optional.absent(),

--- a/value-fixture/src/org/immutables/fixture/OptionalOfOptionalRegular.java
+++ b/value-fixture/src/org/immutables/fixture/OptionalOfOptionalRegular.java
@@ -23,6 +23,7 @@ import org.immutables.value.Value;
 public interface OptionalOfOptionalRegular<T> {
   Option<Optional<T>> optionalOfOptional();
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableOptionalOfOptionalRegular.<Void>builder()
         .optionalOfOptional(Option.some(Optional.<Void>absent()))

--- a/value-fixture/src/org/immutables/fixture/PrivateNoargConstructor.java
+++ b/value-fixture/src/org/immutables/fixture/PrivateNoargConstructor.java
@@ -74,6 +74,7 @@ interface PrivateNoargConstructorIsOverriddenBySingleton {
     return 1;
   }
   
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutablePrivateNoargConstructorIsOverriddenBySingleton.of();
   }

--- a/value-fixture/src/org/immutables/fixture/Singletons.java
+++ b/value-fixture/src/org/immutables/fixture/Singletons.java
@@ -26,6 +26,7 @@ public interface Singletons {}
 interface Sing1 {
   List<Integer> list();
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableSing1.builder();
     ImmutableSing1.of()
@@ -40,6 +41,7 @@ interface Sing2 {
     return 1;
   }
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableSing2.of().withA(1);
   }
@@ -47,6 +49,7 @@ interface Sing2 {
 
 @Value.Immutable(builder = false)
 interface Sing3 {
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableSing3.of();
   }
@@ -55,6 +58,7 @@ interface Sing3 {
 @Value.Immutable(singleton = true)
 interface Sing4 {
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableSing4.builder();
     ImmutableSing4.of();
@@ -69,6 +73,7 @@ interface Sing5 {
     return 1;
   }
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableSing5.of();
     ImmutableSing5.of(1);
@@ -77,6 +82,7 @@ interface Sing5 {
 
 @Value.Immutable
 interface Sing6 {
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableSing6.builder();
   }
@@ -85,6 +91,7 @@ interface Sing6 {
 @Value.Immutable(builder = false)
 @Value.Style(attributelessSingleton = true)
 interface Sing7 {
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableSing7.of();
   }

--- a/value-fixture/src/org/immutables/fixture/UseImmutableCollections.java
+++ b/value-fixture/src/org/immutables/fixture/UseImmutableCollections.java
@@ -53,6 +53,7 @@ public interface UseImmutableCollections {
 
   ImmutableListMultimap<String, Integer> listMultimap();
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
 
     ImmutableUseImmutableCollections.builder()

--- a/value-fixture/src/org/immutables/fixture/annotation/AbstractDeeplyImmutable.java
+++ b/value-fixture/src/org/immutables/fixture/annotation/AbstractDeeplyImmutable.java
@@ -1,0 +1,37 @@
+package org.immutables.fixture.annotation;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.errorprone.annotations.Immutable;
+import org.immutables.value.Value;
+
+/**
+ * An abstract type which triggers the generation of an immutable type with hidden mutable state.
+ *
+ * <ul>
+ * <li>{@code @JsonDeserialize} causes a private secondary mutable subclass to be generated.
+ * <li>{@code @Value.Default} causes the temporary storage of an {@code InitShim} in a field.
+ * <li>{@code @Value.Lazy} causes the annotated property to be computed lazily, requiring it to be
+ *     stored in a non-final field. Its initialization state is tracked using a mutable bitmap.
+ * </ul>
+ *
+ * <p>This type is annotated with Error Prone's {@code @Immutable} annotation. The Error Prone
+ * checker would normally complain about the mutable constructs enumerated above. The generated
+ * code must thus take care to suppress such complaints.
+ */
+@Immutable
+@JsonDeserialize
+@Value.Immutable
+@Value.Style(passAnnotations = Immutable.class)
+abstract class AbstractDeeplyImmutable {
+    public abstract String getA();
+
+    @Value.Default
+    public String getB() {
+        return "";
+    }
+
+    @Value.Lazy
+    public String getC() {
+        return "";
+    }
+}

--- a/value-fixture/src/org/immutables/fixture/ast/InstantiationGenerics.java
+++ b/value-fixture/src/org/immutables/fixture/ast/InstantiationGenerics.java
@@ -38,6 +38,7 @@ public interface InstantiationGenerics {
   @Value.Immutable
   interface StringLeaf extends Leaf<String> {}
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     TreeElement<String> tree =
         ImmutableStringNode.builder()

--- a/value-fixture/src/org/immutables/fixture/couse/AbstractB.java
+++ b/value-fixture/src/org/immutables/fixture/couse/AbstractB.java
@@ -24,6 +24,7 @@ interface AbstractB {
 
   Optional<A> aO();
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     B b = B.builder()
         .a(A.builder().build())

--- a/value-fixture/src/org/immutables/fixture/couse/sub/AbstractC.java
+++ b/value-fixture/src/org/immutables/fixture/couse/sub/AbstractC.java
@@ -45,6 +45,7 @@ interface AbstractC {
 
   Map<RetentionPolicy, C> raM();
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     C c = C.builder()
         .a(A.builder().build())

--- a/value-fixture/src/org/immutables/fixture/custann/CustomEncl.java
+++ b/value-fixture/src/org/immutables/fixture/custann/CustomEncl.java
@@ -24,6 +24,7 @@ public interface CustomEncl {
   @CustomWithEncStyle
   interface Cuzt {}
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     JeNcCustomEncl.Cuzt.builder();
   }

--- a/value-fixture/src/org/immutables/fixture/custann/CustomImmutables.java
+++ b/value-fixture/src/org/immutables/fixture/custann/CustomImmutables.java
@@ -23,6 +23,7 @@ public class CustomImmutables {
   @CustomWithStyle2
   interface Dv {}
 
+  @SuppressWarnings("CheckReturnValue")
   void use() {
     CustoOd.builder().build();
     JcIvDv.builder().build();

--- a/value-fixture/src/org/immutables/fixture/deep/Canvas.java
+++ b/value-fixture/src/org/immutables/fixture/deep/Canvas.java
@@ -55,6 +55,7 @@ public interface Canvas {
     int y();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableLine line = ImmutableLine.builder()
         .color(0.9, 0.7, 0.4)

--- a/value-fixture/src/org/immutables/fixture/deep/DeepAndJdkOnly.java
+++ b/value-fixture/src/org/immutables/fixture/deep/DeepAndJdkOnly.java
@@ -48,6 +48,7 @@ public interface DeepAndJdkOnly {
 
   // Compile validation of generation of immutable return type and builder initializer by
   // constructor-args .
+  @SuppressWarnings("CheckReturnValue")
   static void use() {
     ImmutableContainer c = ImmutableContainer.builder().deep(1, 2).build();
     ImmutableDeep deep = c.getDeep();

--- a/value-fixture/src/org/immutables/fixture/generics/RawType.java
+++ b/value-fixture/src/org/immutables/fixture/generics/RawType.java
@@ -29,6 +29,7 @@ public interface RawType {
 
   Map map();
 
+  @SuppressWarnings("CheckReturnValue")
   static void use() {
     ImmutableRawType.builder()
         .set(Collections.emptySet())

--- a/value-fixture/src/org/immutables/fixture/jackson/KeywordNames.java
+++ b/value-fixture/src/org/immutables/fixture/jackson/KeywordNames.java
@@ -26,6 +26,7 @@ public interface KeywordNames {
 
   boolean isDefault();
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableKeywordNames names = ImmutableKeywordNames.builder()
         .setDefault(true)

--- a/value-fixture/src/org/immutables/fixture/jackson/MetaJacksonAnnotation.java
+++ b/value-fixture/src/org/immutables/fixture/jackson/MetaJacksonAnnotation.java
@@ -30,7 +30,7 @@ interface Val {
   // compile check for presense of
   // the Jackson specific creator method
   // triggered by meta annotation
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "CheckReturnValue"})
   default void use() {
     ImmutableVal.fromJson(null);
   }

--- a/value-fixture/src/org/immutables/fixture/jdkonly/JdkOptionalBuilderFactory.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/JdkOptionalBuilderFactory.java
@@ -31,6 +31,7 @@ public interface JdkOptionalBuilderFactory {
     return b.hashCode() + c.hashCode();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   static void use() {
     new ApplBuilder()
         .a(1)

--- a/value-fixture/src/org/immutables/fixture/jdkonly/UsingAllOptionals.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/UsingAllOptionals.java
@@ -52,6 +52,7 @@ public interface UsingAllOptionals {
   javaslang.control.Option<String> jso();
 
   class Use {
+    @SuppressWarnings("CheckReturnValue")
     void use() {
       UsingAllOptionals value =
           ImmutableUsingAllOptionals.builder()

--- a/value-fixture/src/org/immutables/fixture/modifiable/CreateFromDetect.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/CreateFromDetect.java
@@ -31,6 +31,7 @@ public interface CreateFromDetect {
     int zzz();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ModifiableAaa.create()
         .setBbb(ModifiableBbb.create());

--- a/value-fixture/src/org/immutables/fixture/modifiable/ToImmutableCopyFalse.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/ToImmutableCopyFalse.java
@@ -23,6 +23,7 @@ public interface ToImmutableCopyFalse {
   @Value.Immutable(copy = false)
   public interface A {
 
+    @SuppressWarnings("CheckReturnValue")
     default void use() {
       ModifiableA.create().toImmutable();
     }
@@ -33,6 +34,7 @@ public interface ToImmutableCopyFalse {
   @Value.Style(strictBuilder = true)
   public interface B {
 
+    @SuppressWarnings("CheckReturnValue")
     default void use() {
       ModifiableB.create().toImmutable();
     }
@@ -44,6 +46,7 @@ public interface ToImmutableCopyFalse {
     @Value.Parameter
     int c();
 
+    @SuppressWarnings("CheckReturnValue")
     default void use() {
       ModifiableC.create().toImmutable();
     }

--- a/value-fixture/src/org/immutables/fixture/packoutput/Packs.java
+++ b/value-fixture/src/org/immutables/fixture/packoutput/Packs.java
@@ -32,6 +32,7 @@ public abstract class Packs {
   @Value.Immutable
   public interface Perk {}
 
+  @SuppressWarnings("CheckReturnValue")
   void use() {
     borg.immutables.fixture.packoutput.impl.ImmutablePacks.builder().build();
     borg.immutables.fixture.packoutput.impl.ImmutablePacks.Perk.builder().build();

--- a/value-fixture/src/org/immutables/fixture/style/AbstractValueNamingDetected.java
+++ b/value-fixture/src/org/immutables/fixture/style/AbstractValueNamingDetected.java
@@ -42,6 +42,7 @@ abstract class AbstractValueNamingDetected {
 
   abstract Set<String> collectStr();
 
+  @SuppressWarnings("CheckReturnValue")
   void use() {
     ValueNamingDetected.newBuilder()
         .usingVal(1)

--- a/value-fixture/src/org/immutables/fixture/style/BeanStyleDetected.java
+++ b/value-fixture/src/org/immutables/fixture/style/BeanStyleDetected.java
@@ -25,6 +25,7 @@ abstract class BeanStyleDetected {
 
   abstract List<String> getEm();
 
+  @SuppressWarnings("CheckReturnValue")
   void use() {
     ImmutableBeanStyleDetected.builder()
         .setIt(1)

--- a/value-fixture/src/org/immutables/fixture/style/ConservativeStyleDetected.java
+++ b/value-fixture/src/org/immutables/fixture/style/ConservativeStyleDetected.java
@@ -27,6 +27,7 @@ abstract class ConservativeStyleDetected {
 
   abstract String getString();
 
+  @SuppressWarnings("CheckReturnValue")
   void use() {
     new ConservativeStyleDetectedBuilder()
         .setValue(1)

--- a/value-fixture/src/org/immutables/fixture/style/Depluralize.java
+++ b/value-fixture/src/org/immutables/fixture/style/Depluralize.java
@@ -43,6 +43,7 @@ public interface Depluralize {
 
   Multiset<Boolean> goods();
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableDepluralize.builder()
         .addBoat("") // automatically trims s

--- a/value-fixture/src/org/immutables/fixture/style/EnclosingBuilderNew.java
+++ b/value-fixture/src/org/immutables/fixture/style/EnclosingBuilderNew.java
@@ -32,6 +32,7 @@ public abstract class EnclosingBuilderNew {
   @Value.Immutable
   public static class Hidden {}
 
+  @SuppressWarnings("CheckReturnValue")
   void use() {
     new ImmutableEnclosingBuilderNew.HiddenBuilder().build();
   }

--- a/value-fixture/src/org/immutables/fixture/style/EnclosingHiddenImplementation.java
+++ b/value-fixture/src/org/immutables/fixture/style/EnclosingHiddenImplementation.java
@@ -55,6 +55,7 @@ public abstract class EnclosingHiddenImplementation {
     public abstract Optional<Integer> cons();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   void use() {
     EnclosingFactory.HiddenImplementationBuilder.create().build();
 

--- a/value-fixture/src/org/immutables/fixture/style/HaveBuilderNew.java
+++ b/value-fixture/src/org/immutables/fixture/style/HaveBuilderNew.java
@@ -22,6 +22,7 @@ import org.immutables.value.Value;
 public interface HaveBuilderNew {
   int a();
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     new ImmutableHaveBuilderNew.Builder().build();
   }

--- a/value-fixture/src/org/immutables/fixture/style/HiddenImplementation.java
+++ b/value-fixture/src/org/immutables/fixture/style/HiddenImplementation.java
@@ -30,6 +30,7 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
 @Value.Style(visibility = ImplementationVisibility.PRIVATE)
 public class HiddenImplementation {
 
+  @SuppressWarnings("CheckReturnValue")
   void use() {
     HiddenImplementation instance = new HiddenImplementationBuilder().build();
     instance.toString();

--- a/value-fixture/src/org/immutables/fixture/style/IncludeTypes.java
+++ b/value-fixture/src/org/immutables/fixture/style/IncludeTypes.java
@@ -32,6 +32,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 public class IncludeTypes {
 
+  @SuppressWarnings("CheckReturnValue")
   void use() {
     // this immutable type (package style used)
     ImIncludeTypes.builder().build();

--- a/value-fixture/src/org/immutables/fixture/style/LessVisibleImplementation.java
+++ b/value-fixture/src/org/immutables/fixture/style/LessVisibleImplementation.java
@@ -29,6 +29,7 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
 @Value.Style(visibility = ImplementationVisibility.PACKAGE)
 public class LessVisibleImplementation {
 
+  @SuppressWarnings("CheckReturnValue")
   void use() {
     ImmutableLessVisibleImplementation.Builder lessVisibleBuilder = ImmutableLessVisibleImplementation.builder();
     ImmutableLessVisibleImplementation lessVisibleImplementation = lessVisibleBuilder.build();

--- a/value-fixture/src/org/immutables/fixture/style/NestingClassOrBuilder.java
+++ b/value-fixture/src/org/immutables/fixture/style/NestingClassOrBuilder.java
@@ -34,6 +34,7 @@ interface NestingClassOrBuilder {
       builderVisibility = BuilderVisibility.PACKAGE)
   interface NonPublicBuild {}
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImplNestedInBuildBuilder builder = new ImplNestedInBuildBuilder();
     ImplNestedInBuild abstractValue = builder.build();

--- a/value-fixture/src/org/immutables/fixture/style/OutsideBuildable.java
+++ b/value-fixture/src/org/immutables/fixture/style/OutsideBuildable.java
@@ -45,6 +45,7 @@ public class OutsideBuildable {
 @Value.Style(newBuilder = "newBuilder", visibility = ImplementationVisibility.PRIVATE)
 class OutsideBuildableNew {
 
+  @SuppressWarnings("CheckReturnValue")
   void use() {
     OutsideBuildableNewBuilder.newBuilder().build();
   }

--- a/value-fixture/src/org/immutables/fixture/style/Tuple.java
+++ b/value-fixture/src/org/immutables/fixture/style/Tuple.java
@@ -30,6 +30,7 @@ interface Color {
   int green();
   int blue();
   
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ColorTuple.of(0xFF, 0x00, 0xFE);
   }
@@ -48,6 +49,7 @@ interface OverrideColor {
     return black() - gray();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     OverrideColorTuple.of(0xFF, 0x00);
   }

--- a/value-fixture/src/org/immutables/fixture/style/depl/DepluralizeMergeDictionary.java
+++ b/value-fixture/src/org/immutables/fixture/style/depl/DepluralizeMergeDictionary.java
@@ -45,6 +45,7 @@ public interface DepluralizeMergeDictionary {
     Multiset<Boolean> goods();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   default void use() {
     ImmutableInner.builder()
         .addBoat("") // automatically trims s

--- a/value-fixture/src/org/immutables/fixture/style/nested/PackageStyleFromParent.java
+++ b/value-fixture/src/org/immutables/fixture/style/nested/PackageStyleFromParent.java
@@ -28,6 +28,7 @@ interface PackageStyleFromParent {
   }
 
   /** Generated API dictated by parent package's style. */
+  @SuppressWarnings("CheckReturnValue")
   static void use() {
     ImVal.builder().a(1).build().copyWithA(2);
   }

--- a/value-fixture/src/org/immutables/fixture/style/nested/nest/PackageStyleFromAncestor.java
+++ b/value-fixture/src/org/immutables/fixture/style/nested/nest/PackageStyleFromAncestor.java
@@ -28,6 +28,7 @@ interface PackageStyleFromAncestor {
   }
 
   /** Generated API dictated by parent package's style. */
+  @SuppressWarnings("CheckReturnValue")
   static void use() {
     ImBaj.builder().a(1).build().copyWithA(2);
   }

--- a/value-fixture/src/org/immutables/fixture/with/Copied.java
+++ b/value-fixture/src/org/immutables/fixture/with/Copied.java
@@ -37,6 +37,7 @@ public abstract class Copied implements WithCopied {
 
   public static class Builder extends ImmutableCopied.Builder {}
 
+  @SuppressWarnings("CheckReturnValue")
   static void use() {
     new Copied.Builder()
         .attr(1)

--- a/value-fixture/src/org/immutables/fixture/with/Enc.java
+++ b/value-fixture/src/org/immutables/fixture/with/Enc.java
@@ -43,6 +43,7 @@ public interface Enc {
     class Builder<T extends Number> extends ImmutableEnc.Suppied.Builder<T> {}
   }
 
+  @SuppressWarnings("CheckReturnValue")
   static void use() {
     new Suppied.Builder<Long>()
         .a("a")

--- a/value-fixture/test/org/immutables/fixture/PrivateDefaultConstructorTest.java
+++ b/value-fixture/test/org/immutables/fixture/PrivateDefaultConstructorTest.java
@@ -26,6 +26,7 @@ public class PrivateDefaultConstructorTest {
     ImmutablePrivateNoargConstructorNominal.class.getDeclaredConstructor();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = NoSuchMethodException.class)
   public void testOverridePrehash() throws Exception {
     ImmutablePrivateNoargConstructorOverridePrehash.class.getDeclaredMethod("computeHashCode");

--- a/value-fixture/test/org/immutables/fixture/SafeInitTest.java
+++ b/value-fixture/test/org/immutables/fixture/SafeInitTest.java
@@ -20,6 +20,7 @@ import static org.immutables.check.Checkers.*;
 
 public class SafeInitTest {
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void cycles() {
     try {
       ImmutableSafeInitIface.builder().build();

--- a/value-fixture/test/org/immutables/fixture/ValuesTest.java
+++ b/value-fixture/test/org/immutables/fixture/ValuesTest.java
@@ -59,6 +59,7 @@ public class ValuesTest {
         .build());
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = NullPointerException.class)
   public void orderAndNullCheckForConstructor() {
     ImmutableHostWithPort.of(1, null);
@@ -192,6 +193,7 @@ public class ValuesTest {
   }
 
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void requiredAttributesSetChecked() {
     try {
       ImmutableIfaceValue.builder().build();
@@ -265,6 +267,7 @@ public class ValuesTest {
   }
 
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void withMethods() {
     ImmutableSillyValidatedBuiltValue value = ImmutableSillyValidatedBuiltValue.builder()
         .value(-10)
@@ -327,6 +330,7 @@ public class ValuesTest {
     check(ImmutableSillyInterned.of(1, 2).hashCode()).not(ImmutableSillyInterned.of(2, 2).hashCode());
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = IllegalStateException.class)
   public void cannotBuildWrongInvariants() {
     ImmutableSillyValidatedBuiltValue.builder()
@@ -404,6 +408,7 @@ public class ValuesTest {
   }
 
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void canBuildCorrectInvariants() {
 
     ImmutableSillyValidatedBuiltValue.builder()
@@ -422,12 +427,14 @@ public class ValuesTest {
         .build();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = IllegalStateException.class)
   public void cannotConstructWithWrongInvariants() {
     ImmutableSillyValidatedConstructedValue.of(10, true);
   }
 
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void canConstructWithCorrectInvariants() {
     ImmutableSillyValidatedConstructedValue.of(-10, true);
     ImmutableSillyValidatedConstructedValue.of(10, false);
@@ -435,6 +442,7 @@ public class ValuesTest {
   }
 
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void optionalWhichAcceptsNullable() {
     ImmutableOptionalWithNullable.builder()
         .guavaOptional((String) null)
@@ -443,6 +451,7 @@ public class ValuesTest {
         .build();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = NullPointerException.class)
   public void optionalWhichDoesntAcceptsNullable() {
     ImmutableOptionalWithoutNullable.builder()
@@ -451,6 +460,7 @@ public class ValuesTest {
   }
 
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void properInitInternNoBuilder() {
     ImmutableProperInitInternNoBuilder.of();
   }
@@ -464,6 +474,7 @@ public class ValuesTest {
   }
 
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void primitiveOptional() {
     ImmutablePrimitiveOptionals.builder()
         .v1(1)
@@ -480,15 +491,18 @@ public class ValuesTest {
         .withV2(0.3);
   }
 
+  @SuppressWarnings("CheckReturnValue")
   public void multipleCheck0() {
     ImmutableMultipleChecks.C.builder().a(1).b(1).build();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = IllegalStateException.class)
   public void multipleCheck1() {
     ImmutableMultipleChecks.C.builder().a(0).b(1).build();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = IllegalStateException.class)
   public void multipleCheck2() {
     ImmutableMultipleChecks.C.builder().a(1).b(0).build();

--- a/value-fixture/test/org/immutables/fixture/VeryManyAttributesTest.java
+++ b/value-fixture/test/org/immutables/fixture/VeryManyAttributesTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 public class VeryManyAttributesTest {
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void builableWhenAllSet() {
     ImmutableHugeInterface.builder()
         .number0_0(1)
@@ -94,6 +95,7 @@ public class VeryManyAttributesTest {
         .build();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = IllegalStateException.class)
   public void noInitBuildOverflow() {
     ImmutableHugeInterface.builder()
@@ -171,6 +173,7 @@ public class VeryManyAttributesTest {
   }
   
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void noOccupationOverflow() {
     ImmutableHugeOccupationOverflow.builder()
         .number0(0)

--- a/value-fixture/test/org/immutables/fixture/annotation/AnnotationTest.java
+++ b/value-fixture/test/org/immutables/fixture/annotation/AnnotationTest.java
@@ -35,6 +35,7 @@ public class AnnotationTest {
   }
 
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void bee() {
     ImmutableHasDefault.of(1).withOtherValue("w");
 

--- a/value-fixture/test/org/immutables/fixture/builder/AccessBuilderFieldsTest.java
+++ b/value-fixture/test/org/immutables/fixture/builder/AccessBuilderFieldsTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 public class AccessBuilderFieldsTest {
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void accessFields() {
     new AccessBuilderFields.Builder()
         .a(1)

--- a/value-fixture/test/org/immutables/fixture/generatorext/RewriteTest.java
+++ b/value-fixture/test/org/immutables/fixture/generatorext/RewriteTest.java
@@ -18,6 +18,7 @@ package org.immutables.fixture.generatorext;
 import org.junit.Test;
 
 public class RewriteTest {
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = IllegalArgumentException.class)
   public void rewrite() {
     // Our changed preconditions will be able to throw IllegalArgumentException

--- a/value-fixture/test/org/immutables/fixture/jdkonly/JdkOnlyTest.java
+++ b/value-fixture/test/org/immutables/fixture/jdkonly/JdkOnlyTest.java
@@ -29,6 +29,7 @@ public class JdkOnlyTest {
     check(ImmutableJdkColl.of()).same(ImmutableJdkColl.builder().build());
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = IllegalStateException.class)
   public void checkingOfAttributesBeingSet() {
     ImmutableJdkUtil.builder().build();
@@ -53,6 +54,7 @@ public class JdkOnlyTest {
   }
 
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void modify() {
     ImmutableJdkColl coll = ImmutableJdkColl.builder()
         .addInts(1)
@@ -79,6 +81,7 @@ public class JdkOnlyTest {
   }
 
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void collectionNulls() {
     try {
       ImmutableJdkColl.builder().addPols((RetentionPolicy) null).build();
@@ -113,6 +116,7 @@ public class JdkOnlyTest {
   }
 
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void mapNulls() {
     try {
       new JdkMapsBuilder().putPols((RetentionPolicy) null, 1).build();

--- a/value-fixture/test/org/immutables/fixture/modifiable/ClearBuilderTest.java
+++ b/value-fixture/test/org/immutables/fixture/modifiable/ClearBuilderTest.java
@@ -20,6 +20,7 @@ import static org.immutables.check.Checkers.*;
 
 public class ClearBuilderTest {
   @Test
+  @SuppressWarnings("CheckReturnValue")
   public void clear() {
     ImmutableClearBuilder.Builder builder = ImmutableClearBuilder.builder()
         .a(true)

--- a/value-fixture/test/org/immutables/fixture/nullable/NullableAttributesTest.java
+++ b/value-fixture/test/org/immutables/fixture/nullable/NullableAttributesTest.java
@@ -101,6 +101,7 @@ public class NullableAttributesTest {
     check(ImmutableNullableCompact.of(null, null)).is(c1);
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = NullPointerException.class)
   public void nonnullDefaultBlowupOnNull() {
     ImmutableNonnullConstruction.builder()

--- a/value-fixture/test/org/immutables/fixture/strict/StrictBuilderTest.java
+++ b/value-fixture/test/org/immutables/fixture/strict/StrictBuilderTest.java
@@ -19,6 +19,7 @@ import com.google.common.base.Optional;
 import org.junit.Test;
 
 public class StrictBuilderTest {
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = IllegalStateException.class)
   public void noReassignment() {
     ImmutableAar.builder()
@@ -28,6 +29,7 @@ public class StrictBuilderTest {
         .build();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = IllegalStateException.class)
   public void noReassignmentOptional() {
     ImmutableBar.builder()

--- a/value-fixture/test/org/immutables/fixture/style/SpecifiedExceptionTest.java
+++ b/value-fixture/test/org/immutables/fixture/style/SpecifiedExceptionTest.java
@@ -20,11 +20,13 @@ import org.junit.Test;
 import nonimmutables.SampleRuntimeException;
 
 public class SpecifiedExceptionTest {
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = SampleRuntimeException.class)
   public void itThrowsExpectedConfiguredException() {
     ImmutableSpecifiedException.builder().build();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test(expected = IllegalArgumentException.class)
   public void itThrowsSpecifiedExceptionOnBuild() {
     ImmutableSpecifiedException.builder().buildOrThrow(IllegalArgumentException::new);

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -827,6 +827,7 @@ public [type.typeAbstract.relative] [v.names.with]([v.atNullability][v.type] val
   [for LongPositions positions = longsFor lz]
   [for l in positions.longs]
   [jsonIgnore type]
+  [hiddenMutableState type]
   private [if type.serial.simple]transient [/if]volatile long lazyInitBitmap[emptyIfZero l.index];
   [/for]
   [for l in lz, BitPosition pos = positions l]
@@ -836,6 +837,10 @@ public [type.typeAbstract.relative] [v.names.with]([v.atNullability][v.type] val
   private static final long [maskConstantName] = [literal.hex pos.mask];
 
   [jsonIgnore type]
+  [-- By suppressing warnings about non-final fields we also prevent warnings
+  about lazily computed attributes that are genuinely mutable. That is an
+  unfortunate trade-off. --]
+  [hiddenMutableState type]
   private [if type.serial.simple]transient [/if][l.type] [l.name];
 
   /**
@@ -2386,6 +2391,7 @@ private static final int STAGE_INITIALIZING = -1;
 private static final int STAGE_UNINITIALIZED = 0;
 private static final int STAGE_INITIALIZED = 1;
 [-- would it remain thread safe if remove volatile? --]
+[hiddenMutableState type]
 private transient volatile InitShim [disambiguateField type 'initShim'] = new InitShim();
 
 private final class InitShim {
@@ -2505,6 +2511,9 @@ static[type.generics.def] [type.typeImmutable.relative] fromJson([jval.type] jso
  * @deprecated Do not use this type directly, it exists only for the <em>Jackson</em>-binding infrastructure
  */
 @Deprecated
+[-- The `Json` class implements or extends the immutable type, but is not
+itself immutable. Since it's private, that's benign. --]
+[hiddenMutableState type]
 [overrideJsonDeserialize type]
 [overrideJsonTypeInfo type]
 @com.fasterxml.jackson.annotation.JsonAutoDetect(fieldVisibility = com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE)
@@ -3927,3 +3936,5 @@ private static final long serialVersionUID = [literal serialVersion];
 [template castObject String typename][if typename ne 'java.lang.Object']([typename]) [/if][/template]
 
 [template maybeMasked Attribute a String value][if a.redactedMask][literal.string a.redactedMask][else][value][/if][/template]
+
+[template hiddenMutableState Type type][if classpath.available 'com.google.errorprone.annotations.Immutable']@SuppressWarnings("Immutable")[/if][/template]

--- a/value-processor/src/org/immutables/value/processor/Modifiables.generator
+++ b/value-processor/src/org/immutables/value/processor/Modifiables.generator
@@ -99,7 +99,7 @@ Use @Value.Modifiable cannot be used with @Value.Immutable which implements Ordi
    * Clears the object by setting all attributes to their initial values.
    * @return {@code this} for use in a chained invocation
    */
-  [atCanIgnoreReturnValue]
+  [atCanIgnoreReturnValue type]
   public [thisSetterReturnType type] [type.names.clear]() {
     [for l in positions.longs]
     [disambiguateField type 'initBits'][emptyIfZero l.index] = [literal.hex l.occupation];
@@ -167,7 +167,7 @@ Use @Value.Modifiable cannot be used with @Value.Immutable which implements Ordi
    * Reset an attribute to its initial value.
    * @return {@code this} for use in a chained invocation
    */
-  [atCanIgnoreReturnValue]
+  [atCanIgnoreReturnValue type]
   public final [thisSetterReturnType type] [unset m]() {
     [disambiguateField type 'initBits'][emptyIfZero pos.index] |= INIT_BIT_[toConstant m.name];
     [clearField m true]
@@ -179,7 +179,7 @@ Use @Value.Modifiable cannot be used with @Value.Immutable which implements Ordi
    * Reset an attribute to its initial value.
    * @return {@code this} for use in a chained invocation
    */
-  [atCanIgnoreReturnValue]
+  [atCanIgnoreReturnValue type]
   public final [thisSetterReturnType type] [unset p]() {
     [disambiguateField type 'optBits'][emptyIfZero pos.index] |= 0;
     [clearField p true]
@@ -344,7 +344,7 @@ public static[type.generics.def] [thisReturnType type] [type.names.create]() {
  * @param instance The instance from which to copy values
  * @return {@code this} for use in a chained invocation
  */
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public [thisSetterReturnType type] [type.names.from]([s.type] instance) {
   [im.requireNonNull type](instance, "instance");
   from((Object) instance);
@@ -482,7 +482,7 @@ public [thisReturnType type] [type.names.from]([type.typeAbstract] instance) {
  * @return {@code this} for use in a chained invocation
  */
 [deprecation v]
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public [thisSetterReturnType type] [v.names.add]([v.unwrappedElementType] element) {
   [if v.nullableCollector]
   if ([v.name] == null) {
@@ -510,7 +510,7 @@ public [thisSetterReturnType type] [v.names.add]([v.unwrappedElementType] elemen
  */
 [deprecation v]
 [varargsSafety v]
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public final [thisSetterReturnType type] [v.names.add]([v.unwrappedElementType]... elements) {
   for ([v.unwrappedElementType] element : elements) {
     [if v.unwrappedElementPrimitiveType]
@@ -529,7 +529,7 @@ public final [thisSetterReturnType type] [v.names.add]([v.unwrappedElementType].
  * @return {@code this} for use in a chained invocation
  */
 [deprecation v]
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public [thisSetterReturnType type] [v.names.set]([v.atNullability][if type.beanFriendlyModifiable][v.type][else]Iterable<[v.consumedElementType]>[/if] elements) {
   [if v.nullable]
   if (elements == null) {
@@ -557,7 +557,7 @@ public [thisSetterReturnType type] [v.names.set]([v.atNullability][if type.beanF
  * @return {@code this} for use in a chained invocation
  */
 [deprecation v]
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public [thisSetterReturnType type] [v.names.addAll](Iterable<[v.consumedElementType]> elements) {
   [if v.nullableCollector]
   if (elements == null) [thisSetterReturn type]
@@ -579,7 +579,7 @@ public [thisSetterReturnType type] [v.names.addAll](Iterable<[v.consumedElementT
  * @return {@code this} for use in a chained invocation
  */
 [deprecation v]
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public [thisSetterReturnType type] [v.names.set]([unwrappedOptionalType v] [v.name]) {
   this.[v.name] = [optionalOf v]([v.name]);
   [nondefaultSetter v]
@@ -592,7 +592,7 @@ public [thisSetterReturnType type] [v.names.set]([unwrappedOptionalType v] [v.na
  * @return {@code this} for use in a chained invocation
  */
 [deprecation v]
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public [thisSetterReturnType type] [v.names.set]([v.rawType][if not v.jdkSpecializedOptional]<[v.wrappedElementType]>[/if] [v.name]) {
   this.[v.name] = [im.requireNonNull type]([v.name], "[v.name]");
   [nondefaultSetter v]
@@ -610,7 +610,7 @@ public [thisSetterReturnType type] [v.names.set]([v.rawType][if not v.jdkSpecial
  */
 [varargsSafety v]
 [deprecation v]
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public final [thisSetterReturnType type] [v.names.put]([uK] key, [uV]... values) {
   [v.names.putAll](key, [im.arrayAsListSecondary v 'values']);
   [thisSetterReturn type]
@@ -623,7 +623,7 @@ public final [thisSetterReturnType type] [v.names.put]([uK] key, [uV]... values)
  * @return {@code this} for use in a chained invocation
  */
 [deprecation v]
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public [thisSetterReturnType type] [v.names.putAll]([uK] key, Iterable<[wV]> values) {
   [if v.nullableCollector]
   if ([v.name] == null) {
@@ -643,7 +643,7 @@ public [thisSetterReturnType type] [v.names.putAll]([uK] key, Iterable<[wV]> val
  * @return {@code this} for use in a chained invocation
  */
 [deprecation v]
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public [thisSetterReturnType type] [v.names.put]([uK] key, [uV] value) {
   [if v.nullableCollector]
   if ([v.name] == null) {
@@ -664,7 +664,7 @@ public [thisSetterReturnType type] [v.names.put]([uK] key, [uV] value) {
  * @return {@code this} for use in a chained invocation
  */
 [deprecation v]
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public [thisSetterReturnType type] [v.names.set]([v.atNullability][if type.beanFriendlyModifiable][v.type][else][if v.multimapType][guava].collect.Multimap[else]java.util.Map[/if]<[gE], ? extends [wV]>[/if] entries) {
   [if v.nullable]
   if (entries == null) {
@@ -693,7 +693,7 @@ public [thisSetterReturnType type] [v.names.set]([v.atNullability][if type.beanF
  * @return {@code this} for use in a chained invocation
  */
 [deprecation v]
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public [thisSetterReturnType type] [v.names.putAll]([if v.multimapType][guava].collect.Multimap[else]java.util.Map[/if]<[gE], ? extends [wV]> entries) {
   [if v.nullableCollector]
   if ([v.name] == null) {
@@ -721,7 +721,7 @@ public [thisSetterReturnType type] [v.names.putAll]([if v.multimapType][guava].c
  */
 [varargsSafety v]
 [deprecation v]
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public final [thisSetterReturnType type] [v.names.set]([v.elementType]... elements) {
   this.[v.name] = [if v.nullable]elements == null ? null : [/if]elements.clone();
   [mandatorySetter v]
@@ -739,7 +739,7 @@ public final [thisSetterReturnType type] [v.names.set]([v.elementType]... elemen
  * @return {@code this} for use in a chained invocation
  */
 [deprecation v]
-[atCanIgnoreReturnValue]
+[atCanIgnoreReturnValue type]
 public [thisSetterReturnType type] [v.names.set]([v.atNullability][v.type] [v.name]) {
   [if v.attributeValueKindModifyFrom]
   this.[v.name] = [if v.nullable][v.name] == null ? null : [/if]([v.name] instanceof [v.attributeValueType.constitution.typeModifiable.absoluteRaw] ? ([v.attributeValueType.constitution.typeModifiable.absolute]) [v.name] : [v.attributeValueType.constitution.factoryCreate]().[v.attributeValueType.names.from]([v.name]));
@@ -1163,4 +1163,4 @@ import [starImport];
 
 [template maybeMasked Attribute a String value][if a.redactedMask][literal.string a.redactedMask][else][value][/if][/template]
 
-[template atCanIgnoreReturnValue][if classpath.available 'com.google.errorprone.annotations.CanIgnoreReturnValue']@com.google.errorprone.annotations.CanIgnoreReturnValue[/if][/template]
+[template atCanIgnoreReturnValue Type type][if classpath.available 'com.google.errorprone.annotations.CanIgnoreReturnValue'][if not type.beanFriendlyModifiable]@com.google.errorprone.annotations.CanIgnoreReturnValue[/if][/if][/template]

--- a/value-processor/src/org/immutables/value/processor/encode/Renderers.generator
+++ b/value-processor/src/org/immutables/value/processor/encode/Renderers.generator
@@ -100,6 +100,7 @@ private [inst.typer el.type] with_[inst.namer el]([for p in el.params][if not fo
 [ann]
   [/for]
 [/if]
+[atCanIgnoreReturnValue]
 [if el.private]private [else]public [/if][if el.final]final [/if][builderReturnType a] [inst.namer el]([for p in el.params][if not for.first], [/if][inst.typer p.type] [p.name][/for])[throwsClause inst el] [inst.codeOf el]return [builderReturnThis a][/inst.codeOf]
 [/for]
 [/template]
@@ -208,3 +209,5 @@ private [inst.typer el.type] with_[inst.namer el]([for p in el.params][if not fo
 [template builderReturnType Attribute a][if a.containingType.innerBuilder.isExtending][a.containingType.typeBuilder][else][a.containingType.typeBuilder.simple][a.containingType.generics.args][/if][/template]
 
 [template jsonIgnore Attribute a][if a.containingType.generateJacksonIngoreFields]@com.fasterxml.jackson.annotation.JsonIgnore[/if][/template]
+
+[template atCanIgnoreReturnValue][if classpath.available 'com.google.errorprone.annotations.CanIgnoreReturnValue']@com.google.errorprone.annotations.CanIgnoreReturnValue[/if][/template]


### PR DESCRIPTION
Introduces support for [`@com.google.errorprone.annotations.Immutable`](http://errorprone.info/bugpattern/Immutable) by selectively suppressing known-safe mutable implementation details in the generated code.