### PR TITLE
Publish an Automatic-Module-Name

### DIFF
--- a/value/pom.xml
+++ b/value/pom.xml
@@ -48,6 +48,19 @@
           <target>1.6</target>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.immutables.value</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.immutables.tools</groupId>
         <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
This allows org.immutables.value to be referenced from Java 9 module
descriptors.

Affects #713