### PR TITLE
Handle Error Prone's `MethodCanBeStatic` check

### DIFF
--- a/value-fixture/pom.xml
+++ b/value-fixture/pom.xml
@@ -166,6 +166,7 @@
           <target>1.8</target>
           <compilerArgs>
             <arg>-Xep:CheckReturnValue:WARN</arg>
+            <arg>-Xep:MethodCanBeStatic:ERROR</arg>
           </compilerArgs>
         </configuration>
         <dependencies>

--- a/value-fixture/test/org/immutables/fixture/builder/AttributeBuilderTest.java
+++ b/value-fixture/test/org/immutables/fixture/builder/AttributeBuilderTest.java
@@ -59,7 +59,7 @@ public class AttributeBuilderTest {
   }
 
   // Allows sharing tests between guava collections, jdk only collections and whatever other combinations are needed.
-  private <ImmutableClassT extends AttributeBuilderValueI, AbstractClassT extends AttributeBuilderValueI>
+  private static <ImmutableClassT extends AttributeBuilderValueI, AbstractClassT extends AttributeBuilderValueI>
   void assertBasicApi(Class<ImmutableClassT> immutableType, Class<AbstractClassT> returnType,
       CopyFunction<ImmutableClassT, AbstractClassT> copyFunction,
       BuilderFunction<AbstractClassT> newBuilder) {

--- a/value-fixture/test/org/immutables/fixture/jackson/FieldConflictTest.java
+++ b/value-fixture/test/org/immutables/fixture/jackson/FieldConflictTest.java
@@ -112,7 +112,7 @@ public final class FieldConflictTest {
     verifyRoundTrip(getMapper(true), ImmutableCustomDummyWithMetaAnnotation.of(true));
   }
 
-  private ObjectMapper getMapper(final boolean useFields) {
+  private static ObjectMapper getMapper(final boolean useFields) {
     final ObjectMapper mapper = new ObjectMapper();
     return useFields
         ? mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
@@ -120,7 +120,7 @@ public final class FieldConflictTest {
         : mapper;
   }
 
-  private void verifyRoundTrip(final ObjectMapper mapper, final Object value) throws IOException {
+  private static void verifyRoundTrip(final ObjectMapper mapper, final Object value) throws IOException {
     final String json = mapper.writeValueAsString(value);
     final Object newValue = mapper.readValue(json, value.getClass());
     check(newValue).is(value);

--- a/value-fixture/test/org/immutables/fixture/jdkonly/JdkOptionalTest.java
+++ b/value-fixture/test/org/immutables/fixture/jdkonly/JdkOptionalTest.java
@@ -93,13 +93,13 @@ public class JdkOptionalTest {
     check(o1.hashCode()).is(o0.hashCode());
   }
 
-  private Serializable deserialize(byte[] bytes) throws Exception {
+  private static Serializable deserialize(byte[] bytes) throws Exception {
     ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
     ObjectInputStream objectStream = new ObjectInputStream(stream);
     return (Serializable) objectStream.readObject();
   }
 
-  private byte[] serialize(Serializable instance) throws Exception {
+  private static byte[] serialize(Serializable instance) throws Exception {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     ObjectOutputStream objectStream = new ObjectOutputStream(stream);
     objectStream.writeObject(instance);

--- a/value-fixture/test/org/immutables/fixture/marshal/MarshallingTest.java
+++ b/value-fixture/test/org/immutables/fixture/marshal/MarshallingTest.java
@@ -129,11 +129,11 @@ public class MarshallingTest {
     check(Marshaling.fromJson(Marshaling.toJson(structure), SillyStructure.class)).is(structure);
   }
 
-  private <T> List<T> fromJsonIterable(String json, TypeToken<List<T>> typeToken) {
+  private static <T> List<T> fromJsonIterable(String json, TypeToken<List<T>> typeToken) {
     return Marshaling.getGson().fromJson(json, typeToken.getType());
   }
 
-  private <T> String toJsonIterable(List<? extends T> list, TypeToken<List<T>> typeToken) {
+  private static <T> String toJsonIterable(List<? extends T> list, TypeToken<List<T>> typeToken) {
     return Marshaling.getGson().toJson(list, typeToken.getType());
   }
 }

--- a/value-fixture/test/org/immutables/fixture/serial/SerialTest.java
+++ b/value-fixture/test/org/immutables/fixture/serial/SerialTest.java
@@ -71,13 +71,13 @@ public class SerialTest {
     check(false);
   }
 
-  private Serializable deserialize(byte[] bytes) throws Exception {
+  private static Serializable deserialize(byte[] bytes) throws Exception {
     ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
     ObjectInputStream objectStream = new ObjectInputStream(stream);
     return (Serializable) objectStream.readObject();
   }
 
-  private byte[] serialize(Serializable instance) throws Exception {
+  private static byte[] serialize(Serializable instance) throws Exception {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     ObjectOutputStream objectStream = new ObjectOutputStream(stream);
     objectStream.writeObject(instance);

--- a/value-fixture/test/org/immutables/metainf/fixture/ServiceTest.java
+++ b/value-fixture/test/org/immutables/metainf/fixture/ServiceTest.java
@@ -34,7 +34,7 @@ public class ServiceTest {
     check(sortedToStringsFrom(ServiceLoader.load(AutoCloseable.class))).isOf("NestedService.Service");
   }
 
-  private TreeSet<String> sortedToStringsFrom(Iterable<?> iterable) {
+  private static TreeSet<String> sortedToStringsFrom(Iterable<?> iterable) {
     return Sets.newTreeSet(FluentIterable.from(iterable).transform(Functions.toStringFunction()));
   }
 }

--- a/value-processor/src/org/immutables/value/processor/Gsons.generator
+++ b/value-processor/src/org/immutables/value/processor/Gsons.generator
@@ -63,7 +63,7 @@ import [starImport];
  * @see [v.typeValue.relativeRaw]
  [/for]
  */
-@SuppressWarnings("all")[-- reliably check for generateSuppressAllWarnings --]
+@SuppressWarnings({"all", "MethodCanBeStatic"})[-- reliably check for generateSuppressAllWarnings --]
 [if classpath.available 'javax.annotation.Generated']
 @javax.annotation.Generated({"Gsons.generator", "[packageName].[simpleName]"})
 [/if]
@@ -478,7 +478,7 @@ private [type.typeAbstract] read[type.name](JsonReader in)
 [else if type.useConstructorOnly]
 
 [for ca = type.constructorArguments]
-private [type.typeAbstract] read[type.name](JsonReader in)
+private [if singular ca][for a in ca][if a.primitive]static[/if][/for][/if] [type.typeAbstract] read[type.name](JsonReader in)
     throws IOException {
 [if singular ca]
   [for a in ca]
@@ -498,7 +498,7 @@ private [type.typeAbstract] read[type.name](JsonReader in)
 [/for]
 [else]
 
-private [type.typeAbstract] read[type.name](JsonReader in)
+private [if type.generics.empty][if not type.unmarshaledAttributes]static[/if][/if] [type.typeAbstract] read[type.name](JsonReader in)
     throws IOException {
   [type.typeBuilder] builder = [castBuildStagedBuilder type][type.factoryBuilder]()[/castBuildStagedBuilder];
     [if type.unmarshaledAttributes]
@@ -557,7 +557,7 @@ private void eachAttribute(JsonReader in, [type.typeBuilder] builder)
 
 [template generateConstructorArgumentUnmarshal Type type Attribute a]
 
-private [a.atNullability][constructorAcceptType a] readParameter[toUpper a.name](JsonReader in)
+private [if a.primitive]static[/if] [a.atNullability][constructorAcceptType a] readParameter[toUpper a.name](JsonReader in)
     throws IOException {
   [if a.primitive]
   return [simpleTypeNext a.type];

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1981,7 +1981,7 @@ checkNotIsSet([v.names.isSet](), "[v.names.raw]");
   [/for]
   [if type.useStrictBuilder and (nondefaultsPositions.longs or positions.longs)]
 
-  private void checkNotIsSet(boolean isSet, String name) {
+  private static void checkNotIsSet(boolean isSet, String name) {
     if (isSet) throw new java.lang.IllegalStateException("Builder of [type.name] is strict, attribute is already set: ".concat(name));
   }
   [/if]
@@ -2727,6 +2727,7 @@ public boolean equals([atNullable]Object another) {
 [/if]
 [if type.useEqualTo]
 
+[if not type.equalToDefined][if not type.usePrehashed][if not getters][if type.generics.empty]@SuppressWarnings("MethodCanBeStatic")[/if][/if][/if][/if]
 private boolean equalTo([equalToType] another) {
   [if type.equalToDefined]
   return super.equals(another);
@@ -3485,7 +3486,7 @@ private static boolean equals(Object left, Object right) {
 
 [atNullable]
 [-- getTopSimple is here to return the concrete class. AttributeBuilders trigger the deepImmutables... --]
-private [v.getAttributeBuilderDescriptor.getQualifiedValueTypeName] [convertToValueType v.getAttributeBuilderDescriptor]([atNullable] [v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName] builder) {
+private static [v.getAttributeBuilderDescriptor.getQualifiedValueTypeName] [convertToValueType v.getAttributeBuilderDescriptor]([atNullable] [v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName] builder) {
   if (builder == null) {
     return null;
   }
@@ -3495,7 +3496,7 @@ private [v.getAttributeBuilderDescriptor.getQualifiedValueTypeName] [convertToVa
 
 [atNullable]
 [-- getTopSimple is here to return the concrete class. AttributeBuilders trigger the deepImmutables... --]
-private [if v.hasAttributeValue][v.attributeValueType.typeAbstract.absolute][else][v.getAttributeBuilderDescriptor.getQualifiedValueTypeName][/if] [convertToValueType v.getAttributeBuilderDescriptor]([atNullable] [if v.hasAttributeValue][v.attributeValueType.typeAbstract.absolute][else][v.getAttributeBuilderDescriptor.getQualifiedValueTypeName][/if] value) {
+private static [if v.hasAttributeValue][v.attributeValueType.typeAbstract.absolute][else][v.getAttributeBuilderDescriptor.getQualifiedValueTypeName][/if] [convertToValueType v.getAttributeBuilderDescriptor]([atNullable] [if v.hasAttributeValue][v.attributeValueType.typeAbstract.absolute][else][v.getAttributeBuilderDescriptor.getQualifiedValueTypeName][/if] value) {
   if (value == null) {
     return null;
   }
@@ -3504,7 +3505,7 @@ private [if v.hasAttributeValue][v.attributeValueType.typeAbstract.absolute][els
 }
 
 [atNullable]
-private [v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName] [convertToBuilderType v.getAttributeBuilderDescriptor]([atNullable] [v.getAttributeBuilderDescriptor.getQualifiedValueTypeName] value) {
+private static [v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName] [convertToBuilderType v.getAttributeBuilderDescriptor]([atNullable] [v.getAttributeBuilderDescriptor.getQualifiedValueTypeName] value) {
   if (value == null) {
     return null;
   }
@@ -3516,19 +3517,19 @@ private [v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName] [convertTo
 
 [for v in type.uniqueAttributeBuilderListAttributes]
 [let listType][if v.hasAttributeValue][v.attributeValueType.typeAbstract.absolute][else][v.getAttributeBuilderDescriptor.getQualifiedValueTypeName][/if][/let]
-private java.util.List<[listType]> [convertToValueType v.getAttributeBuilderDescriptor](Iterable<? extends [v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName]> builderList) {
+private static java.util.List<[listType]> [convertToValueType v.getAttributeBuilderDescriptor](Iterable<? extends [v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName]> builderList) {
 [copyBuilderListBody v true false]builderList[/copyBuilderListBody]
 }
 
-private java.util.List<[listType]> [convertToValueType v.getAttributeBuilderDescriptor]([v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName]... builderArray) {
+private static java.util.List<[listType]> [convertToValueType v.getAttributeBuilderDescriptor]([v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName]... builderArray) {
 [copyBuilderListBody v true true]builderArray[/copyBuilderListBody]
 }
 
-private java.util.List<[v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName]> [convertToBuilderType v.getAttributeBuilderDescriptor](Iterable<? extends [v.getAttributeBuilderDescriptor.getQualifiedValueTypeName]> valueList) {
+private static java.util.List<[v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName]> [convertToBuilderType v.getAttributeBuilderDescriptor](Iterable<? extends [v.getAttributeBuilderDescriptor.getQualifiedValueTypeName]> valueList) {
 [copyBuilderListBody v false false]valueList[/copyBuilderListBody]
 }
 
-private java.util.List<[v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName]> [convertToBuilderType v.getAttributeBuilderDescriptor]([v.getAttributeBuilderDescriptor.getQualifiedValueTypeName]... valueArray) {
+private static java.util.List<[v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName]> [convertToBuilderType v.getAttributeBuilderDescriptor]([v.getAttributeBuilderDescriptor.getQualifiedValueTypeName]... valueArray) {
 [copyBuilderListBody v false true]valueArray[/copyBuilderListBody]
 }
 [/for]

--- a/value-processor/src/org/immutables/value/processor/Modifiables.generator
+++ b/value-processor/src/org/immutables/value/processor/Modifiables.generator
@@ -910,6 +910,7 @@ public boolean equals([atNullable]Object another) {
   return equalTo(other);
 }
 
+[if not type.equalToDefined][if not type.usePrehashed][if not getters][if type.generics.empty]@SuppressWarnings("MethodCanBeStatic")[/if][/if][/if][/if]
 private boolean equalTo([equalToType] another) {
   [if type.equalToDefined]
   return super.equals(another);


### PR DESCRIPTION
Where feasible, mark generated methods `static`. Where infeasible, add a suppression. The Gson code's complexity is such that I had to add an unconditional suppression at the top of the generated class.

@elucash, this change requires quite careful review, unfortunately. The compiler caught most issues, but if a fixture with a certain combination of features is absent, I might have missed an edge case.

Aside from appeasing Error Prone users, I think this change is worthwhile because use of `static` may allow micro-optimizations by the JVM, and we do want our Immutables to have efficient implementations. That said, whether the extra complexity introduced here is worth it is up for debate. WDYT?

Fixes #717. CC @vorburger.