### PR TITLE
Handle `CheckReturnValue` violations as errors

### DIFF
--- a/value-fixture/pom.xml
+++ b/value-fixture/pom.xml
@@ -165,7 +165,7 @@
           <source>1.8</source>
           <target>1.8</target>
           <compilerArgs>
-            <arg>-Xep:CheckReturnValue:WARN</arg>
+            <arg>-Xep:CheckReturnValue:ERROR</arg>
           </compilerArgs>
         </configuration>
         <dependencies>


### PR DESCRIPTION
Rationale:
- Prevents regressions w.r.t. this feature.
- Proves that the issue reported in https://github.com/google/error-prone/issues/647#issuecomment-341664913 is either already fixed or not covered by current tests.

CC @bmhm.