### PR TITLE
Make checkNotIsSet() static for error-prone's MethodCanBeStatic

### DIFF
--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1981,7 +1981,7 @@ checkNotIsSet([v.names.isSet](), "[v.names.raw]");
   [/for]
   [if type.useStrictBuilder and (nondefaultsPositions.longs or positions.longs)]
 
-  private void checkNotIsSet(boolean isSet, String name) {
+  private static void checkNotIsSet(boolean isSet, String name) {
     if (isSet) throw new java.lang.IllegalStateException("Builder of [type.name] is strict, attribute is already set: ".concat(name));
   }
   [/if]


### PR DESCRIPTION
see http://errorprone.info/bugpattern/MethodCanBeStatic

Fixes #717 https://github.com/immutables/immutables/issues/717

Signed-off-by: Michael Vorburger <vorburger@redhat.com>