### PR TITLE
added more tests for numbers

### DIFF
--- a/mongo/src/org/immutables/mongo/repository/internal/BsonWriter.java
+++ b/mongo/src/org/immutables/mongo/repository/internal/BsonWriter.java
@@ -162,6 +162,9 @@ public class BsonWriter extends com.google.gson.stream.JsonWriter {
     if (value instanceof Short) {
       return value(value.shortValue());
     }
+    if (value instanceof Byte) {
+     return value(value.byteValue());
+    }
     if (value instanceof LazilyParsedNumber) {
       return value(value.longValue());
     }

--- a/mongo/test/org/immutables/mongo/fixture/NumbersTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/NumbersTest.java
@@ -73,8 +73,8 @@ public class NumbersTest {
 
     Advanced doc = ImmutableAdvanced.builder()
             .id(id)
-            .bigDecimal(new BigDecimal((String.valueOf(Long.MAX_VALUE) + "000").toCharArray())) // make number big
-            .bigInteger(new BigInteger(String.valueOf(Long.MAX_VALUE) + "333")) // make it also big
+            .bigDecimal(new BigDecimal(Long.MAX_VALUE).multiply(new BigDecimal(128))) // make number big
+            .bigInteger(new BigInteger(String.valueOf(Long.MAX_VALUE)).multiply(new BigInteger("128"))) // make it also big
             .atomicBoolean(new AtomicBoolean())
             .atomicInteger(new AtomicInteger(55))
             .atomicLong(new AtomicLong(77))

--- a/mongo/test/org/immutables/mongo/fixture/NumbersTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/NumbersTest.java
@@ -1,0 +1,157 @@
+package org.immutables.mongo.fixture;
+
+import org.bson.types.ObjectId;
+import org.immutables.gson.Gson;
+import org.immutables.mongo.Mongo;
+import org.immutables.value.Value;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.immutables.check.Checkers.check;
+
+/**
+ * A set of tests for entities with primitive numbers (byte, short, int, long ...) and more advanced number wrappers
+ * (BigInteger, BigDecimal, AtomicLong, AtomicInteger etc.).
+ *
+ * Some conversions are provided by Gson directly (like {@link com.google.gson.internal.bind.TypeAdapters#ATOMIC_INTEGER}
+ */
+@Gson.TypeAdapters
+public class NumbersTest {
+
+  @Rule
+  public final MongoContext context = MongoContext.create();
+
+  @Test
+  public void primitives() {
+    final PrimitivesRepository repo = new PrimitivesRepository(context.setup());
+    ObjectId id = ObjectId.get();
+    ImmutablePrimitives doc = ImmutablePrimitives.builder()
+            .id(id)
+            .booleanValue(true)
+            .byteValue((byte) 0)
+            .shortValue((short) 12)
+            .intValue(42)
+            .longValue(123L)
+            .floatValue(11.11F)
+            .doubleValue(22.22D)
+            .build();
+
+    repo.insert(doc).getUnchecked();
+    check(repo.findById(id).fetchAll().getUnchecked()).hasContentInAnyOrder(doc);
+  }
+
+  @Test
+  public void boxed() {
+    final BoxedRepository repo = new BoxedRepository(context.setup());
+    ObjectId id = ObjectId.get();
+
+    Boxed doc = ImmutableBoxed.builder()
+            .id(id)
+            .booleanValue(Boolean.FALSE)
+            .byteValue(Byte.MAX_VALUE)
+            .shortValue(Short.MAX_VALUE)
+            .intValue(Integer.MAX_VALUE)
+            .longValue(Long.MAX_VALUE)
+            .floatValue(Float.MAX_VALUE)
+            .doubleValue(Double.MAX_VALUE)
+            .build();
+
+    repo.insert(doc).getUnchecked();
+    check(repo.findById(id).fetchAll().getUnchecked()).hasContentInAnyOrder(doc);
+  }
+
+  @Test
+  public void advanced() {
+    final AdvancedRepository repo = new AdvancedRepository(context.setup());
+    ObjectId id = ObjectId.get();
+
+    Advanced doc = ImmutableAdvanced.builder()
+            .id(id)
+            .bigDecimal(new BigDecimal((String.valueOf(Long.MAX_VALUE) + "000").toCharArray())) // make number big
+            .bigInteger(new BigInteger(String.valueOf(Long.MAX_VALUE) + "333")) // make it also big
+            .atomicBoolean(new AtomicBoolean())
+            .atomicInteger(new AtomicInteger(55))
+            .atomicLong(new AtomicLong(77))
+            .build();
+
+    repo.insert(doc).getUnchecked();
+
+    final Advanced doc2 = repo.findById(id).fetchFirst().getUnchecked().get();
+    check(doc2.id()).is(id);
+
+    check(doc2.bigDecimal()).is(doc.bigDecimal());
+    check(doc2.bigInteger()).is(doc.bigInteger());
+    check(!doc2.atomicBoolean().get());
+    check(doc2.atomicInteger().get()).is(doc.atomicInteger().get());
+    check(doc2.atomicLong().get()).is(doc.atomicLong().get());
+  }
+
+  @Mongo.Repository
+  @Value.Immutable
+  interface Primitives {
+
+    @Mongo.Id
+    ObjectId id();
+
+    boolean booleanValue();
+
+    byte byteValue();
+
+    short shortValue();
+
+    int intValue();
+
+    long longValue();
+
+    float floatValue();
+
+    double doubleValue();
+  }
+
+  @Mongo.Repository
+  @Value.Immutable
+  interface Boxed {
+
+    @Mongo.Id
+    ObjectId id();
+
+    Boolean booleanValue();
+
+    Byte byteValue();
+
+    Short shortValue();
+
+    Integer intValue();
+
+    Long longValue();
+
+    Float floatValue();
+
+    Double doubleValue();
+  }
+
+  @Mongo.Repository
+  @Value.Immutable
+  interface Advanced {
+
+    @Mongo.Id
+    ObjectId id();
+
+    BigDecimal bigDecimal();
+
+    BigInteger bigInteger();
+
+    AtomicBoolean atomicBoolean();
+
+    AtomicInteger atomicInteger();
+
+    AtomicLong atomicLong();
+  }
+
+}

--- a/mongo/test/org/immutables/mongo/repository/internal/BsonDecimal128Test.java
+++ b/mongo/test/org/immutables/mongo/repository/internal/BsonDecimal128Test.java
@@ -1,23 +1,16 @@
 package org.immutables.mongo.repository.internal;
 
 import com.google.gson.JsonObject;
-import com.google.gson.internal.bind.TypeAdapters;
+import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
-import org.bson.BsonBinaryReader;
-import org.bson.BsonBinaryWriter;
 import org.bson.BsonDecimal128;
 import org.bson.BsonDocument;
 import org.bson.BsonType;
-import org.bson.codecs.BsonDocumentCodec;
-import org.bson.codecs.DecoderContext;
-import org.bson.codecs.EncoderContext;
-import org.bson.io.BasicOutputBuffer;
 import org.bson.types.Decimal128;
 import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 
 import static org.immutables.check.Checkers.check;
 
@@ -33,9 +26,7 @@ public class BsonDecimal128Test {
     doc.put("long", new BsonDecimal128(new Decimal128(Long.MAX_VALUE)));
     doc.put("double", new BsonDecimal128(Decimal128.parse("12.111")));
 
-    BasicOutputBuffer output = new BasicOutputBuffer();
-    new BsonDocumentCodec().encode(new BsonBinaryWriter(output), doc, EncoderContext.builder().build());
-    BsonReader reader =  new BsonReader(new BsonBinaryReader(ByteBuffer.wrap(output.toByteArray())));
+    JsonReader reader =  Jsons.asGsonReader(doc);
 
     reader.beginObject();
     check(reader.nextName()).is("int");
@@ -64,12 +55,7 @@ public class BsonDecimal128Test {
     BigDecimal bigDecimal = new BigDecimal(Long.MAX_VALUE).multiply(new BigDecimal(1024));
     obj.addProperty("bigDecimal", bigDecimal);
 
-    BasicOutputBuffer buffer = new BasicOutputBuffer();
-    BsonWriter writer = new BsonWriter(new BsonBinaryWriter(buffer));
-
-    TypeAdapters.JSON_ELEMENT.write(writer, obj);
-
-    BsonDocument doc = new BsonDocumentCodec().decode(new BsonBinaryReader(ByteBuffer.wrap(buffer.toByteArray())), DecoderContext.builder().build());
+    BsonDocument doc = Jsons.toBson(obj);
 
     check(doc.get("bigInteger").getBsonType()).is(BsonType.DECIMAL128);
     check(doc.get("bigInteger").asDecimal128().decimal128Value().bigDecimalValue().toBigInteger()).is(bigInteger);

--- a/mongo/test/org/immutables/mongo/repository/internal/BsonDecimal128Test.java
+++ b/mongo/test/org/immutables/mongo/repository/internal/BsonDecimal128Test.java
@@ -1,0 +1,81 @@
+package org.immutables.mongo.repository.internal;
+
+import com.google.gson.JsonObject;
+import com.google.gson.internal.bind.TypeAdapters;
+import com.google.gson.stream.JsonToken;
+import org.bson.BsonBinaryReader;
+import org.bson.BsonBinaryWriter;
+import org.bson.BsonDecimal128;
+import org.bson.BsonDocument;
+import org.bson.BsonType;
+import org.bson.codecs.BsonDocumentCodec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
+import org.bson.types.Decimal128;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+
+import static org.immutables.check.Checkers.check;
+
+/**
+ * Tests for read/write of {@link org.bson.types.Decimal128}
+ */
+public class BsonDecimal128Test {
+
+  @Test
+  public void read() throws Exception {
+    BsonDocument doc = new BsonDocument();
+    doc.put("int", new BsonDecimal128(Decimal128.parse(Integer.toString(Integer.MAX_VALUE))));
+    doc.put("long", new BsonDecimal128(new Decimal128(Long.MAX_VALUE)));
+    doc.put("double", new BsonDecimal128(Decimal128.parse("12.111")));
+
+    BasicOutputBuffer output = new BasicOutputBuffer();
+    new BsonDocumentCodec().encode(new BsonBinaryWriter(output), doc, EncoderContext.builder().build());
+    BsonReader reader =  new BsonReader(new BsonBinaryReader(ByteBuffer.wrap(output.toByteArray())));
+
+    reader.beginObject();
+    check(reader.nextName()).is("int");
+    check(reader.peek()).is(JsonToken.NUMBER);
+    check(reader.nextInt()).is(Integer.MAX_VALUE);
+
+    check(reader.nextName()).is("long");
+    check(reader.peek()).is(JsonToken.NUMBER);
+    check(reader.nextLong()).is(Long.MAX_VALUE);
+
+    check(reader.nextName()).is("double");
+    check(reader.peek()).is(JsonToken.NUMBER);
+    check(reader.nextDouble()).is(12.111D);
+
+    reader.endObject();
+
+    reader.close();
+  }
+
+  @Test
+  public void write() throws Exception {
+    JsonObject obj = new JsonObject();
+    BigInteger bigInteger = new BigInteger(Long.toString(Long.MAX_VALUE)).multiply(new BigInteger("128"));
+    obj.addProperty("bigInteger", bigInteger);
+
+    BigDecimal bigDecimal = new BigDecimal(Long.MAX_VALUE).multiply(new BigDecimal(1024));
+    obj.addProperty("bigDecimal", bigDecimal);
+
+    BasicOutputBuffer buffer = new BasicOutputBuffer();
+    BsonWriter writer = new BsonWriter(new BsonBinaryWriter(buffer));
+
+    TypeAdapters.JSON_ELEMENT.write(writer, obj);
+
+    BsonDocument doc = new BsonDocumentCodec().decode(new BsonBinaryReader(ByteBuffer.wrap(buffer.toByteArray())), DecoderContext.builder().build());
+
+    check(doc.get("bigInteger").getBsonType()).is(BsonType.DECIMAL128);
+    check(doc.get("bigInteger").asDecimal128().decimal128Value().bigDecimalValue().toBigInteger()).is(bigInteger);
+
+    check(doc.get("bigDecimal").getBsonType()).is(BsonType.DECIMAL128);
+    check(doc.get("bigDecimal").asDecimal128().decimal128Value().bigDecimalValue()).is(bigDecimal);
+  }
+
+}

--- a/mongo/test/org/immutables/mongo/repository/internal/BsonNumbersTest.java
+++ b/mongo/test/org/immutables/mongo/repository/internal/BsonNumbersTest.java
@@ -1,0 +1,60 @@
+package org.immutables.mongo.repository.internal;
+
+import com.google.gson.JsonObject;
+import org.bson.BsonDocument;
+import org.bson.BsonType;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.immutables.check.Checkers.check;
+
+public class BsonNumbersTest {
+
+  @Test
+  public void basicNumbers() throws Exception {
+    JsonObject obj = new JsonObject();
+    obj.addProperty("boolean", true);
+    obj.addProperty("byte", (byte) 1);
+    obj.addProperty("short", (short) 4);
+    obj.addProperty("int", Integer.MAX_VALUE);
+    obj.addProperty("long", Long.MAX_VALUE);
+    obj.addProperty("float", 55F);
+    obj.addProperty("double", 128D);
+
+    BsonDocument doc = Jsons.toBson(obj);
+
+    check(doc.get("boolean").getBsonType()).is(BsonType.BOOLEAN);
+    check(doc.get("boolean").asBoolean());
+    check(doc.get("byte").getBsonType()).is(BsonType.INT32);
+    check(doc.get("byte").asInt32().getValue()).is(1);
+    check(doc.get("short").getBsonType()).is(BsonType.INT32);
+    check(doc.get("short").asInt32().getValue()).is(4);
+    check(doc.get("int").getBsonType()).is(BsonType.INT32);
+    check(doc.get("int").asInt32().getValue()).is(Integer.MAX_VALUE);
+    check(doc.get("long").getBsonType()).is(BsonType.INT64);
+    check(doc.get("long").asInt64().getValue()).is(Long.MAX_VALUE);
+    check(doc.get("float").getBsonType()).is(BsonType.DOUBLE);
+    check(doc.get("float").asDouble().getValue()).is(55D);
+    check(doc.get("double").getBsonType()).is(BsonType.DOUBLE);
+    check(doc.get("double").asDouble().getValue()).is(128D);
+  }
+
+  @Test
+  public void bigNumbers() throws Exception {
+    JsonObject obj = new JsonObject();
+    BigInteger bigInteger = new BigInteger(Long.toString(Long.MAX_VALUE)).multiply(new BigInteger("128"));
+    obj.addProperty("bigInteger", bigInteger);
+    BigDecimal bigDecimal = new BigDecimal(Long.MAX_VALUE).multiply(new BigDecimal(1024));
+    obj.addProperty("bigDecimal", bigDecimal);
+
+    BsonDocument bson = Jsons.toBson(obj);
+    check(bson.get("bigInteger").getBsonType()).is(BsonType.DECIMAL128);
+    check(bson.get("bigInteger").asDecimal128().decimal128Value().bigDecimalValue().toBigInteger()).is(bigInteger);
+    check(bson.get("bigDecimal").getBsonType()).is(BsonType.DECIMAL128);
+    check(bson.get("bigDecimal").asDecimal128().decimal128Value().bigDecimalValue()).is(bigDecimal);
+
+    check(Jsons.toGson(bson)).is(obj);
+  }
+}

--- a/mongo/test/org/immutables/mongo/repository/internal/BsonReaderTest.java
+++ b/mongo/test/org/immutables/mongo/repository/internal/BsonReaderTest.java
@@ -69,6 +69,10 @@ public class BsonReaderTest {
         compare(Long.toString(Long.MAX_VALUE));
         compare(Integer.toString(Integer.MIN_VALUE));
         compare(Integer.toString(Integer.MAX_VALUE));
+        compare(Byte.toString(Byte.MIN_VALUE));
+        compare(Byte.toString(Byte.MAX_VALUE));
+        compare(Short.toString(Short.MIN_VALUE));
+        compare(Short.toString(Short.MAX_VALUE));
         compare("0.1");
         compare("-0.1111");
         compare("-2.222");

--- a/mongo/test/org/immutables/mongo/repository/internal/BsonReaderTest.java
+++ b/mongo/test/org/immutables/mongo/repository/internal/BsonReaderTest.java
@@ -25,166 +25,169 @@ import static org.immutables.check.Checkers.check;
 
 public class BsonReaderTest {
 
-    @Test
-    public void array() throws Exception {
-        compare("[]");
-        compare("[[]]");
-        compare("[[[]]]");
-        compare("[[], []]");
-        compare("[[], [[]]]");
-        compare("[[], [[]], []]");
-        compare("[1]");
-        compare("[1, 2]");
-        compare("[1, 2, 3]");
-        compare("[true]");
-        compare("[true, true]");
-        compare("[true, true, false]");
-        compare("[0.11, 11.22, 3]");
-        compare("[\"foo\"]");
-        compare("[\"\"]");
-        compare("[\"\", \"\"]");
-        compare("[\"\", \"foo\"]");
-        compare("[\"foo\", \"bar\"]");
-        compare("[1, true, 0, 1.111]");
-        compare("[null]");
-        compare("[null, 1, false]");
-        compare("[0.0, -1.2, 3]");
-        compare("[[0], [1]]");
-        compare("[[0], [], 1]");
-        compare("[true, [], []]");
-        compare("[{}]");
-        compare("[{}, {}]");
-        compare("[{}, {}, {}]");
-        compare("[{\"a\": 1}, {\"b\": null}, {\"c\": false}]");
-        compare("[{\"0\": 1}, [], {\"1\": null}, {}]");
-    }
+  @Test
+  public void array() throws Exception {
+    compare("[]");
+    compare("[[]]");
+    compare("[[[]]]");
+    compare("[[], []]");
+    compare("[[], [[]]]");
+    compare("[[], [[]], []]");
+    compare("[1]");
+    compare("[1, 2]");
+    compare("[1, 2, 3]");
+    compare("[true]");
+    compare("[true, true]");
+    compare("[true, true, false]");
+    compare("[0.11, 11.22, 3]");
+    compare("[\"foo\"]");
+    compare("[\"\"]");
+    compare("[\"\", \"\"]");
+    compare("[\"\", \"foo\"]");
+    compare("[\"foo\", \"bar\"]");
+    compare("[1, true, 0, 1.111]");
+    compare("[null]");
+    compare("[null, 1, false]");
+    compare("[0.0, -1.2, 3]");
+    compare("[[0], [1]]");
+    compare("[[0], [], 1]");
+    compare("[true, [], []]");
+    compare("[{}]");
+    compare("[{}, {}]");
+    compare("[{}, {}, {}]");
+    compare("[{\"a\": 1}, {\"b\": null}, {\"c\": false}]");
+    compare("[{\"0\": 1}, [], {\"1\": null}, {}]");
+  }
 
-    @Test
-    public void scalar() throws Exception {
-        compare("0");
-        compare("0.0");
-        compare("-1");
-        compare("-200");
-        compare(Long.toString(Long.MIN_VALUE));
-        compare(Long.toString(Long.MAX_VALUE));
-        compare(Integer.toString(Integer.MIN_VALUE));
-        compare(Integer.toString(Integer.MAX_VALUE));
-        compare(Byte.toString(Byte.MIN_VALUE));
-        compare(Byte.toString(Byte.MAX_VALUE));
-        compare(Short.toString(Short.MIN_VALUE));
-        compare(Short.toString(Short.MAX_VALUE));
-        compare("0.1");
-        compare("-0.1111");
-        compare("-2.222");
-        compare("0.11111111111");
-        compare("true");
-        compare("false");
-        compare("null");
-        compare("\"foo\"");
-        compare("\"\"");
-        compare("\"null\"");
-    }
+  @Test
+  public void scalar() throws Exception {
+    compare("0");
+    compare("0.0");
+    compare("-1");
+    compare("-200");
+    compare(Long.toString(Long.MIN_VALUE));
+    compare(Long.toString(Long.MAX_VALUE));
+    compare(Integer.toString(Integer.MIN_VALUE));
+    compare(Integer.toString(Integer.MAX_VALUE));
+    compare(Byte.toString(Byte.MIN_VALUE));
+    compare(Byte.toString(Byte.MAX_VALUE));
+    compare(Short.toString(Short.MIN_VALUE));
+    compare(Short.toString(Short.MAX_VALUE));
+    compare("0.1");
+    compare("-0.1111");
+    compare("-2.222");
+    compare("0.11111111111");
+    compare("true");
+    compare("false");
+    compare("null");
+    compare("\"foo\"");
+    compare("\"\"");
+    compare("\"null\"");
+  }
 
-    @Test
-    public void object() throws Exception {
-        compare("{}");
-        compare("{\"foo\": \"bar\"}");
-        compare("{\"foo\": 1}");
-        compare("{\"foo\": true}");
-        compare("{\"foo\": 0.1}");
-        compare("{\"foo\": null}");
-        compare("{\"foo\": {}}");
-        compare("{\"foo\": []}");
-        compare("{\"foo\": [{}]}");
-        compare("{\"foo\": [{}, {}]}");
-        compare("{\"foo\": [1, 2, 3]}");
-        compare("{\"foo\": [null]}");
-        compare("{\"foo\": \"\"}");
-        compare("{\"foo\": \"2017-09-09\"}");
-        compare("{\"foo\": {\"bar\": \"qux\"}}");
-        compare("{\"foo\": 1, \"bar\": 2}");
-        compare("{\"foo\": [], \"bar\": {}}");
-        compare("{\"foo\": {\"bar\": {\"baz\": true}}}");
-    }
+  @Test
+  public void object() throws Exception {
+    compare("{}");
+    compare("{\"foo\": \"bar\"}");
+    compare("{\"foo\": 1}");
+    compare("{\"foo\": true}");
+    compare("{\"foo\": 0.1}");
+    compare("{\"foo\": null}");
+    compare("{\"foo\": {}}");
+    compare("{\"foo\": []}");
+    compare("{\"foo\": [{}]}");
+    compare("{\"foo\": [{}, {}]}");
+    compare("{\"foo\": [1, 2, 3]}");
+    compare("{\"foo\": [null]}");
+    compare("{\"foo\": \"\"}");
+    compare("{\"foo\": \"2017-09-09\"}");
+    compare("{\"foo\": {\"bar\": \"qux\"}}");
+    compare("{\"foo\": 1, \"bar\": 2}");
+    compare("{\"foo\": [], \"bar\": {}}");
+    compare("{\"foo\": {\"bar\": {\"baz\": true}}}");
+  }
 
-    /**
-     * Reading from BSON to GSON
-     */
-    @Test
-    public void bsonToGson() throws Exception {
-        BsonDocument document = new BsonDocument();
-        document.append("boolean", new BsonBoolean(true));
-        document.append("int32", new BsonInt32(32));
-        document.append("int64", new BsonInt64(64));
-        document.append("double", new BsonDouble(42.42D));
-        document.append("string", new BsonString("foo"));
-        document.append("null", new BsonNull());
-        document.append("array", new BsonArray());
-        document.append("object", new BsonDocument());
+  /**
+   * Reading from BSON to GSON
+   */
+  @Test
+  public void bsonToGson() throws Exception {
+    BsonDocument document = new BsonDocument();
+    document.append("boolean", new BsonBoolean(true));
+    document.append("int32", new BsonInt32(32));
+    document.append("int64", new BsonInt64(64));
+    document.append("double", new BsonDouble(42.42D));
+    document.append("string", new BsonString("foo"));
+    document.append("null", new BsonNull());
+    document.append("array", new BsonArray());
+    document.append("object", new BsonDocument());
 
-        JsonElement element = TypeAdapters.JSON_ELEMENT.read(new BsonReader(new BsonDocumentReader(document)));
-        check(element.isJsonObject());
+    JsonElement element = TypeAdapters.JSON_ELEMENT.read(new BsonReader(new BsonDocumentReader(document)));
+    check(element.isJsonObject());
 
-        check(element.getAsJsonObject().get("boolean").getAsJsonPrimitive().isBoolean());
-        check(element.getAsJsonObject().get("boolean").getAsJsonPrimitive().getAsBoolean());
+    check(element.getAsJsonObject().get("boolean").getAsJsonPrimitive().isBoolean());
+    check(element.getAsJsonObject().get("boolean").getAsJsonPrimitive().getAsBoolean());
 
-        check(element.getAsJsonObject().get("int32").getAsJsonPrimitive().isNumber());
-        check(element.getAsJsonObject().get("int32").getAsJsonPrimitive().getAsNumber().intValue()).is(32);
+    check(element.getAsJsonObject().get("int32").getAsJsonPrimitive().isNumber());
+    check(element.getAsJsonObject().get("int32").getAsJsonPrimitive().getAsNumber().intValue()).is(32);
 
-        check(element.getAsJsonObject().get("int64").getAsJsonPrimitive().isNumber());
-        check(element.getAsJsonObject().get("int64").getAsJsonPrimitive().getAsNumber().longValue()).is(64L);
+    check(element.getAsJsonObject().get("int64").getAsJsonPrimitive().isNumber());
+    check(element.getAsJsonObject().get("int64").getAsJsonPrimitive().getAsNumber().longValue()).is(64L);
 
-        check(element.getAsJsonObject().get("double").getAsJsonPrimitive().isNumber());
-        check(element.getAsJsonObject().get("double").getAsJsonPrimitive().getAsNumber().doubleValue()).is(42.42D);
+    check(element.getAsJsonObject().get("double").getAsJsonPrimitive().isNumber());
+    check(element.getAsJsonObject().get("double").getAsJsonPrimitive().getAsNumber().doubleValue()).is(42.42D);
 
-        check(element.getAsJsonObject().get("string").getAsJsonPrimitive().isString());
-        check(element.getAsJsonObject().get("string").getAsJsonPrimitive().getAsString()).is("foo");
+    check(element.getAsJsonObject().get("string").getAsJsonPrimitive().isString());
+    check(element.getAsJsonObject().get("string").getAsJsonPrimitive().getAsString()).is("foo");
 
-        check(element.getAsJsonObject().get("null").isJsonNull());
-        check(element.getAsJsonObject().get("array").isJsonArray());
-        check(element.getAsJsonObject().get("object").isJsonObject());
-    }
+    check(element.getAsJsonObject().get("null").isJsonNull());
+    check(element.getAsJsonObject().get("array").isJsonArray());
+    check(element.getAsJsonObject().get("object").isJsonObject());
+  }
 
-    @Test
-    public void gsonToBson() throws Exception {
-        JsonObject obj = new JsonObject();
-        obj.addProperty("boolean", true);
-        obj.addProperty("int32", 32);
-        obj.addProperty("int64", 64L);
-        obj.addProperty("double", 42.42D);
-        obj.addProperty("string", "foo");
-        obj.add("null", JsonNull.INSTANCE);
-        obj.add("array", new JsonArray());
-        obj.add("object", new JsonObject());
+  /**
+   * Tests direct bson and gson mappings
+   */
+  @Test
+  public void gsonToBson() throws Exception {
+    JsonObject obj = new JsonObject();
+    obj.addProperty("boolean", true);
+    obj.addProperty("int32", 32);
+    obj.addProperty("int64", 64L);
+    obj.addProperty("double", 42.42D);
+    obj.addProperty("string", "foo");
+    obj.add("null", JsonNull.INSTANCE);
+    obj.add("array", new JsonArray());
+    obj.add("object", new JsonObject());
 
 
-        BsonDocument doc = new BsonDocument();
-        TypeAdapters.JSON_ELEMENT.write(new BsonWriter(new BsonDocumentWriter(doc)), obj);
+    BsonDocument doc = Jsons.toBson(obj);
+    TypeAdapters.JSON_ELEMENT.write(new BsonWriter(new BsonDocumentWriter(doc)), obj);
 
-        check(doc.keySet()).notEmpty();
+    check(doc.keySet()).notEmpty();
 
-        check(doc.get("boolean").getBsonType()).is(BsonType.BOOLEAN);
-        check(doc.get("boolean").asBoolean());
-        check(doc.get("int32").getBsonType()).is(BsonType.INT32);
-        check(doc.get("int32").asInt32().getValue()).is(32);
-        check(doc.get("int64").getBsonType()).is(BsonType.INT64);
-        check(doc.get("int64").asInt64().getValue()).is(64L);
-        check(doc.get("double").getBsonType()).is(BsonType.DOUBLE);
-        check(doc.get("double").asDouble().getValue()).is(42.42D);
-        check(doc.get("string").getBsonType()).is(BsonType.STRING);
-        check(doc.get("string").asString().getValue()).is("foo");
-        check(doc.get("null").getBsonType()).is(BsonType.NULL);
-        check(doc.get("null").isNull());
-        check(doc.get("array").getBsonType()).is(BsonType.ARRAY);
-        check(doc.get("array").asArray()).isEmpty();
-        check(doc.get("object").getBsonType()).is(BsonType.DOCUMENT);
-        check(doc.get("object").asDocument().keySet()).isEmpty();
-    }
+    check(doc.get("boolean").getBsonType()).is(BsonType.BOOLEAN);
+    check(doc.get("boolean").asBoolean());
+    check(doc.get("int32").getBsonType()).is(BsonType.INT32);
+    check(doc.get("int32").asInt32().getValue()).is(32);
+    check(doc.get("int64").getBsonType()).is(BsonType.INT64);
+    check(doc.get("int64").asInt64().getValue()).is(64L);
+    check(doc.get("double").getBsonType()).is(BsonType.DOUBLE);
+    check(doc.get("double").asDouble().getValue()).is(42.42D);
+    check(doc.get("string").getBsonType()).is(BsonType.STRING);
+    check(doc.get("string").asString().getValue()).is("foo");
+    check(doc.get("null").getBsonType()).is(BsonType.NULL);
+    check(doc.get("null").isNull());
+    check(doc.get("array").getBsonType()).is(BsonType.ARRAY);
+    check(doc.get("array").asArray()).isEmpty();
+    check(doc.get("object").getBsonType()).is(BsonType.DOCUMENT);
+    check(doc.get("object").asDocument().keySet()).isEmpty();
+  }
 
-    private static void compare(String string) throws IOException {
-        JsonElement bson = TypeAdapters.JSON_ELEMENT.read(new BsonReader(new JsonReader(string))); // compare as BSON
-        JsonElement gson = TypeAdapters.JSON_ELEMENT.fromJson(string); // compare as JSON
-        check(bson).is(gson); // compare the two
-    }
+  private static void compare(String string) throws IOException {
+    JsonElement bson = TypeAdapters.JSON_ELEMENT.read(new BsonReader(new JsonReader(string))); // compare as BSON
+    JsonElement gson = TypeAdapters.JSON_ELEMENT.fromJson(string); // compare as JSON
+    check(bson).is(gson); // compare the two
+  }
 
 }

--- a/mongo/test/org/immutables/mongo/repository/internal/BsonWriterTest.java
+++ b/mongo/test/org/immutables/mongo/repository/internal/BsonWriterTest.java
@@ -3,13 +3,10 @@ package org.immutables.mongo.repository.internal;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.internal.bind.TypeAdapters;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-
 import org.junit.Test;
+
+import java.io.IOException;
+
 import static org.immutables.check.Checkers.check;
 
 public class BsonWriterTest {
@@ -18,7 +15,9 @@ public class BsonWriterTest {
   public void scalars() throws Exception {
     write("1");
     write("0");
-    write("{}");
+    write("true");
+    write("false");
+    write("null");
   }
 
   @Test
@@ -30,31 +29,18 @@ public class BsonWriterTest {
 
   @Test
   public void objects() throws Exception {
+    write("{}");
     write("{ \"foo\": 123, \"bar\": 444}");
   }
 
   @Test
   public void customTypes() throws Exception {
     JsonObject obj = new JsonObject();
-    obj.addProperty("byte", (byte) 1);
-    obj.addProperty("short", (short) 4);
-    obj.addProperty("int", 2222);
-    obj.addProperty("long", 1111L);
-    obj.addProperty("float", 55F);
-    obj.addProperty("double", 128D);
-    obj.addProperty("boolean", true);
     obj.addProperty("null", (String) null);
     obj.addProperty("string", "Hello");
     write(obj);
   }
 
-  @Test
-  public void bigNumbers() throws Exception {
-    JsonObject obj = new JsonObject();
-    obj.addProperty("bigInteger", new BigInteger(Long.toString(Long.MAX_VALUE)).multiply(new BigInteger("128")));
-    obj.addProperty("bigDecimal", new BigDecimal(Long.MAX_VALUE).multiply(new BigDecimal(1024)));
-    write(obj);
-  }
 
   private static void write(String string) throws IOException {
     write(TypeAdapters.JSON_ELEMENT.fromJson(string));
@@ -68,12 +54,8 @@ public class BsonWriterTest {
       temp.add("ignore", gson);
       gson = temp;
     }
-    Writer output = new StringWriter();
-    com.google.gson.stream.JsonWriter bsonWriter = new BsonWriter(new org.bson.json.JsonWriter(output));
-    TypeAdapters.JSON_ELEMENT.write(bsonWriter, gson);
 
-    JsonElement bson = TypeAdapters.JSON_ELEMENT.read(new BsonReader(new org.bson.json.JsonReader(output.toString())));
-
+    JsonElement bson = Jsons.toGson(Jsons.toBson(gson.getAsJsonObject()));
     check(gson).is(bson);
   }
 }

--- a/mongo/test/org/immutables/mongo/repository/internal/BsonWriterTest.java
+++ b/mongo/test/org/immutables/mongo/repository/internal/BsonWriterTest.java
@@ -6,6 +6,9 @@ import com.google.gson.internal.bind.TypeAdapters;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 import org.junit.Test;
 import static org.immutables.check.Checkers.check;
 
@@ -45,6 +48,13 @@ public class BsonWriterTest {
     write(obj);
   }
 
+  @Test
+  public void bigNumbers() throws Exception {
+    JsonObject obj = new JsonObject();
+    obj.addProperty("bigInteger", new BigInteger(Long.toString(Long.MAX_VALUE)).multiply(new BigInteger("128")));
+    obj.addProperty("bigDecimal", new BigDecimal(Long.MAX_VALUE).multiply(new BigDecimal(1024)));
+    write(obj);
+  }
 
   private static void write(String string) throws IOException {
     write(TypeAdapters.JSON_ELEMENT.fromJson(string));

--- a/mongo/test/org/immutables/mongo/repository/internal/BsonWriterTest.java
+++ b/mongo/test/org/immutables/mongo/repository/internal/BsonWriterTest.java
@@ -33,6 +33,7 @@ public class BsonWriterTest {
   @Test
   public void customTypes() throws Exception {
     JsonObject obj = new JsonObject();
+    obj.addProperty("byte", (byte) 1);
     obj.addProperty("short", (short) 4);
     obj.addProperty("int", 2222);
     obj.addProperty("long", 1111L);

--- a/mongo/test/org/immutables/mongo/repository/internal/Jsons.java
+++ b/mongo/test/org/immutables/mongo/repository/internal/Jsons.java
@@ -1,0 +1,42 @@
+package org.immutables.mongo.repository.internal;
+
+import com.google.gson.JsonObject;
+import com.google.gson.internal.bind.TypeAdapters;
+import com.google.gson.stream.JsonReader;
+import org.bson.BsonBinaryReader;
+import org.bson.BsonBinaryWriter;
+import org.bson.BsonDocument;
+import org.bson.codecs.BsonDocumentCodec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Util methods to convert to/from bson/gson types.
+ */
+final class Jsons {
+
+  static org.bson.BsonReader asBsonReader(JsonObject gson) throws IOException {
+    BasicOutputBuffer buffer = new BasicOutputBuffer();
+    BsonWriter writer = new BsonWriter(new BsonBinaryWriter(buffer));
+    TypeAdapters.JSON_ELEMENT.write(writer, gson);
+    return new BsonBinaryReader(ByteBuffer.wrap(buffer.toByteArray()));
+  }
+
+  static JsonReader asGsonReader(BsonDocument bson) {
+    BasicOutputBuffer output = new BasicOutputBuffer();
+    new BsonDocumentCodec().encode(new BsonBinaryWriter(output), bson, EncoderContext.builder().build());
+    return new BsonReader(new BsonBinaryReader(ByteBuffer.wrap(output.toByteArray())));
+  }
+
+  static BsonDocument toBson(JsonObject gson) throws IOException {
+    return new BsonDocumentCodec().decode(asBsonReader(gson), DecoderContext.builder().build());
+  }
+
+  static JsonObject toGson(BsonDocument bson) throws IOException {
+    return TypeAdapters.JSON_ELEMENT.read(asGsonReader(bson)).getAsJsonObject();
+  }
+}


### PR DESCRIPTION
Explicit `NumbersTest` to validate number wrappers like `BigDecimal`, `BigInteger`, `AtomicLong` etc.
Also added a separate statement for `Byte` (inside `BsonWriter`) which will persist Byte as int32 (in mongo) instead of [default double](https://github.com/asereda-gs/immutables/blob/449d63b4f9c71e430a699ec75cbd093c383c6cb5/mongo/src/org/immutables/mongo/repository/internal/BsonWriter.java#L190).