### PR TITLE
Resolve Eclipse APT Unsupported location: CLASS_PATH

### DIFF
--- a/generator/src/org/immutables/generator/ExtensionLoader.java
+++ b/generator/src/org/immutables/generator/ExtensionLoader.java
@@ -75,7 +75,7 @@ public final class ExtensionLoader {
   }
 
   private static String getClasspathResourceText(Filer filer, String resourceName) throws IOException {
-    return filer.getResource(StandardLocation.CLASS_PATH, "", resourceName)
+    return filer.getResource(StandardLocation.CLASS_OUTPUT, "", resourceName)
         .getCharContent(true)
         .toString();
   }


### PR DESCRIPTION
When using org.immutables:builder:2.6.0
Eclipse Oxygen APT raises 

`org.immutables.value.internal.$processor$.$Processor threw java.lang.IllegalArgumentException: Unsupported location: CLASS_PATH
	at org.eclipse.jdt.internal.apt.pluggable.core.filer.IdeFilerImpl.getFileFromOutputLocation(IdeFilerImpl.java:186)
	at org.eclipse.jdt.internal.apt.pluggable.core.filer.IdeFilerImpl.getResource(IdeFilerImpl.java:154)
	at org.immutables.value.internal.$generator$.$ExtensionLoader.getClasspathResourceText($ExtensionLoader.java:78)
	at org.immutables.value.internal.$generator$.$ExtensionLoader.access$000($ExtensionLoader.java:33)
	at org.immutables.value.internal.$generator$.$ExtensionLoader$1.get($ExtensionLoader.java:50)
	at org.immutables.value.internal.$generator$.$ExtensionLoader$1.get($ExtensionLoader.java:42)
	at org.immutables.value.internal.$guava$.base.$Suppliers$MemoizingSupplier.get($Suppliers.java:131)
	at org.immutables.value.internal.$generator$.$ClasspathFence.isInhibited($ClasspathFence.java:31)
	at org.immutables.value.internal.$processor$.meta.$Proto$Environment.findElement($Proto.java:403)
	at org.immutables.value.internal.$processor$.meta.$Proto$Environment.defaultStyles($Proto.java:265)
	at org.immutables.value.internal.$processor$.meta.$ImmutableProto$Environment.<init>($ImmutableProto.java:519)
	at org.immutables.value.internal.$processor$.meta.$ImmutableProto$Environment.of($ImmutableProto.java:968)
	at org.immutables.value.internal.$processor$.meta.$Round.environment($Round.java:61)
	at org.immutables.value.internal.$processor$.meta.$ImmutableRound.environment($ImmutableRound.java:222)
	at org.immutables.value.internal.$processor$.$Processor.process($Processor.java:66)
	at org.immutables.value.internal.$generator$.$AbstractGenerator.process($AbstractGenerator.java:87)
	at org.immutables.processor.ProxyProcessor.process(ProxyProcessor.java:72)
	at org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher.handleProcessor(RoundDispatcher.java:139)
	at org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher.round(RoundDispatcher.java:110)
	at org.eclipse.jdt.internal.compiler.apt.dispatch.BaseAnnotationProcessorManager.processAnnotations(BaseAnnotationProcessorManage
r.java:159)
	at org.eclipse.jdt.internal.apt.pluggable.core.dispatch.IdeAnnotationProcessorManager.processAnnotations(IdeAnnotationProcessorMa
nager.java:135)
	at org.eclipse.jdt.internal.compiler.Compiler.processAnnotations(Compiler.java:933)
	at org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:443)
	at org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:419)
	at org.eclipse.jdt.internal.core.builder.AbstractImageBuilder.compile(AbstractImageBuilder.java:372)
	at org.eclipse.jdt.internal.core.builder.BatchImageBuilder.compile(BatchImageBuilder.java:187)
	at org.eclipse.jdt.internal.core.builder.AbstractImageBuilder.compile(AbstractImageBuilder.java:305)
	at org.eclipse.jdt.internal.core.builder.BatchImageBuilder.build(BatchImageBuilder.java:61)
	at org.eclipse.jdt.internal.core.builder.JavaBuilder.buildAll(JavaBuilder.java:256)
	at org.eclipse.jdt.internal.core.builder.JavaBuilder.build(JavaBuilder.java:180)
	at org.eclipse.core.internal.events.BuildManager$2.run(BuildManager.java:735)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:206)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:246)
	at org.eclipse.core.internal.events.BuildManager$1.run(BuildManager.java:301)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:304)
	at org.eclipse.core.internal.events.BuildManager.basicBuildLoop(BuildManager.java:360)
	at org.eclipse.core.internal.events.BuildManager.build(BuildManager.java:383)
	at org.eclipse.core.internal.events.AutoBuildJob.doBuild(AutoBuildJob.java:142)
	at org.eclipse.core.internal.events.AutoBuildJob.run(AutoBuildJob.java:232)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:56)
`

References:
- https://github.com/immutables/immutables/issues/259
- https://github.com/hal/elemento/issues/40