### PR TITLE
Fix Javadoc generated for @Value.Lazy

### DIFF
--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -869,7 +869,7 @@ public [type.typeAbstract.relative] [v.names.with]([v.atNullability][v.type] val
    * <p>
    * Returns a lazily initialized value of the [sourceDocRef type l] attribute.
    * Initialized once and only once and stored for subsequent access with proper synchronization.
-   * @return A lazily initialized value of the {@code l.name} attribute
+   * @return A lazily initialized value of the {@code [l.name]} attribute
    */
   [eachLine l.accessorInjectedAnnotations]
   @Override


### PR DESCRIPTION
Version 2.6.3 generates this Javadoc:

```
...
@return A lazily initialized value of the {@code l.name} attribute
...
```