### PR TITLE
Feature/optionals factory

### DIFF
--- a/value-annotations/src/org/immutables/value/Value.java
+++ b/value-annotations/src/org/immutables/value/Value.java
@@ -809,7 +809,7 @@ public @interface Value {
     ImplementationVisibility visibility() default ImplementationVisibility.SAME;
 
     /**
-     * Specify whether init and copy methods for an unwrapped {@code X} of {@code Optional<X>}
+     * Specify whether init, copy and factory methods and constructors for an unwrapped {@code X} of {@code Optional<X>}
      * should accept {@code null} values as empty value. By default nulls are rejected in favor of
      * explicit conversion using {@code Optional.ofNullable}. Please note that initializers that
      * take explicit {@code Optional} value always reject nulls regardless of this setting.

--- a/value-fixture/src/org/immutables/fixture/jdkonly/JdkOptionals.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/JdkOptionals.java
@@ -56,3 +56,19 @@ interface JdkOptionalsSer extends Serializable {
   @Value.Parameter
   OptionalDouble d1();
 }
+
+@Value.Immutable(builder = false)
+@Value.Style(optionalAcceptNullable = true)
+interface JdkOptionalsWithNullable {
+  @Value.Parameter
+  Optional<String> v2();
+
+  @Value.Parameter
+  OptionalInt i1();
+
+  @Value.Parameter
+  OptionalLong l1();
+
+  @Value.Parameter
+  OptionalDouble d1();
+}

--- a/value-fixture/src/org/immutables/fixture/style/OptionalWithNullable.java
+++ b/value-fixture/src/org/immutables/fixture/style/OptionalWithNullable.java
@@ -28,4 +28,7 @@ public interface OptionalWithNullable {
   Optional<Integer> getJavaOptionalInteger();
 
   com.google.common.base.Optional<String> getGuavaOptional();
+
+  @Value.Parameter
+  Optional<String> getJavaOptionalStringParameter();
 }

--- a/value-fixture/src/org/immutables/fixture/style/OptionalWithoutNullable.java
+++ b/value-fixture/src/org/immutables/fixture/style/OptionalWithoutNullable.java
@@ -28,4 +28,7 @@ public interface OptionalWithoutNullable {
   OptionalInt getJavaOptionalInt();
 
   com.google.common.base.Optional<String> getGuavaOptional();
+
+  @Value.Parameter
+  Optional<String> getJavaOptionalStringParameter();
 }

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -2231,11 +2231,13 @@ return [type.factoryOf]([output.linesShortable][for v in type.settableAttributes
 [/if]
 [/output.trim][/template]
 
-[template valueFromValueNoOptional Attribute v String expression][output.trim]
+[template valueFromValueNoOptional Type type Attribute v String expression][output.trim]
 [if v.encoding]
   [valueFromValue v expression]
+[else if v.jdkOptional and (v.jdkSpecializedOptional or v.optionalAcceptNullable)]
+  [maybeCopyOf v][expression][/maybeCopyOf]
 [else if v.jdkOptional]
-  [expression]
+  [maybeCopyOf v][requireNonNull type]([expression], "[expression]")[/maybeCopyOf]
 [else if v.optionalType]
   [optionalOf v]([expression])
 [else]
@@ -2446,18 +2448,18 @@ this.[n] = [valueFromValue v][invokeSuper v].[v.names.get]()[/valueFromValue];
   [let shim][disambiguateField type 'initShim'][/let]
   [for v in type.constructorArguments, n = v.name]
 [if v.generateDefault and type.generateSafeDerived]
-    [shim].[v.names.init]([valueFromValueNoOptional v n]);
+    [shim].[v.names.init]([valueFromValueNoOptional type v n]);
 [else if v.hasVirtualImpl]
-    [rr.virtualImpl v] = [valueFromValueNoOptional v n];
+    [rr.virtualImpl v] = [valueFromValueNoOptional type v n];
 [else]
-    this.[n] = [valueFromValueNoOptional v n];
+    this.[n] = [valueFromValueNoOptional type v n];
 [/if]
   [/for]
     [generateConstructorDefaultAttributes type type.constructorOmited]
     [generateDerivedConstruction type type.constructorArguments]
 [else][-- Alternatively a lot simpler implementation]
   [for v in type.constructorArguments, n = v.name]
-    this.[n] = [valueFromValueNoOptional v n];
+    this.[n] = [valueFromValueNoOptional type v n];
   [/for]
 [/if]
     [generateAfterConstruction type false]

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -702,9 +702,9 @@ public [type.typeAbstract.relative] [v.names.with]([v.atNullability][v.type] val
 
   /**
    * Construct a new immutable {@code [type.name]} instance.
-  [for v in type.constructorArguments]
+[for v in type.constructorArguments]
    * @param [v.name] The value for the {@code [v.name]} attribute
-  [/for]
+[/for]
    * @return An immutable [type.name] instance
    */
   public static [type.generics.spaceAfter][type.typeValue] [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][v.atNullability][eachLine v.constructorParameterInjectedAnnotations][v.type] [v.name][/for]) {
@@ -714,21 +714,21 @@ public [type.typeAbstract.relative] [v.names.with]([v.atNullability][v.type] val
 
   /**
    * Construct a new immutable {@code [type.name]} instance.
-  [for v in type.constructorArguments]
+[for v in type.constructorArguments]
    * @param [v.name] The value for the {@code [v.name]} attribute
-  [/for]
+[/for]
    * @return An immutable [type.name] instance
    */
   public static [type.generics.spaceAfter][type.typeValue] [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][v.atNullability][eachLine v.constructorParameterInjectedAnnotations][constructorAcceptType v] [v.name][/for]) {
     return [validated type false]new [type.typeImmutable.relativeRaw][type.generics.diamond]([for v in type.constructorArguments][if not for.first], [/if][v.name][/for])[/validated];
   }
-
   [if type.hasOptionalConstructorArguments]
+
   /**
    * Construct a new immutable {@code [type.name]} instance.
-  [for v in type.constructorArguments]
+[for v in type.constructorArguments]
    * @param [v.name] The value for the {@code [v.name]} attribute
-  [/for]
+[/for]
    * @return An immutable [type.name] instance
    */
   public static [type.generics.spaceAfter][type.typeValue] [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][v.atNullability][eachLine v.constructorParameterInjectedAnnotations][if v.isOptionalType][unwrappedOptionalType v][else][constructorAcceptType v][/if] [v.name][/for]) {
@@ -2381,8 +2381,8 @@ this.[n] = [valueFromValue v][invokeSuper v].[v.names.get]()[/valueFromValue];
     [generateAfterConstruction type false]
   [/output.collapsible]}
 [/if]
-
 [if type.useConstructor andnot type.generateConstructorUseCopyConstructor]
+
   [if type.factoryOf.new]
   /**
    * Construct a new immutable {@code [type.name]} instance.
@@ -2420,9 +2420,9 @@ this.[n] = [valueFromValue v][invokeSuper v].[v.names.get]()[/valueFromValue];
 [/if]
     [generateAfterConstruction type false]
   }
-
 [-- Additional constructors for Optional types --]
 [if type.hasOptionalConstructorArguments]
+
   [if type.factoryOf.new]
   /**
    * Construct a new immutable {@code [type.name]} instance.
@@ -2463,6 +2463,7 @@ this.[n] = [valueFromValue v][invokeSuper v].[v.names.get]()[/valueFromValue];
 [/if]
 [/if]
 [if type.generateBuilderConstructor]
+
   private [type.typeImmutable.simple]([type.typeBuilderImpl.relative] builder) {
   [for v in getters if not (v.generateDerived or v.generateDefault), n = v.name]
     [if v.hasVirtualImpl]

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -2213,6 +2213,14 @@ return [type.factoryOf]([output.linesShortable][for v in type.settableAttributes
 
 [template valueToBuilder AttributeBuilder n String expression][if n.isCopyMethodOnValueInstance][expression].[n.getQualifiedValueToBuilderMethod]()[else][n.getQualifiedValueToBuilderMethod]([expression])[/if][/template]
 
+[template valueFrom Type type Attribute v String expression Boolean withoutOptional][output.trim]
+  [if withoutOptional]
+    [valueFromValueNoOptional type v expression]
+  [else]
+    [valueFromValue v expression]
+  [/if]
+[/output.trim][/template]
+
 [template valueFromValue Attribute v String expression][output.trim]
 [if v.encoding]
   [rr.from v expression]
@@ -2383,87 +2391,13 @@ this.[n] = [valueFromValue v][invokeSuper v].[v.names.get]()[/valueFromValue];
     [generateAfterConstruction type false]
   [/output.collapsible]}
 [/if]
-[-- There is a very similar block of code beneath this constructor generation
-    which needs to be taken into consideration when anything changes here]
 [if type.useConstructor andnot type.generateConstructorUseCopyConstructor]
 
-  [if type.factoryOf.new]
-  /**
-   * Construct a new immutable {@code [type.name]} instance.
-  [for v in type.constructorArguments]
-   * @param [v.name] The value for the {@code [v.name]} attribute[if v.nullable], can be {@code null}[/if]
-  [/for]
-   */
-  [eachLine type.constructorAnnotations]
-  [eachLine type.constructorInjectedAnnotations]
-  [suppressAnyCovariantCastForOptional type.constructorArguments]
-  public [type.typeImmutable.simple]([output.linesShortable][for v in type.constructorArguments][if not for.first],[/if]
-      [v.constructorParameterAnnotations][v.atNullability][constructorAcceptType v] [v.name][/for][/output.linesShortable]) {
-  [else]
-  [suppressAnyCovariantCastForOptional type.constructorArguments]
-  private [type.typeImmutable.simple]([output.linesShortable][for v in type.constructorArguments][if not for.first],[/if]
-      [v.atNullability][constructorAcceptType v] [v.name][/for][/output.linesShortable]) {
-  [/if]
-[if type.constructorOmited or (type.hasEncodingValueOrVirtualFields or (type.generateSafeDerived and type.hasDerivedAttributes))]
-  [let shim][disambiguateField type 'initShim'][/let]
-  [for v in type.constructorArguments, n = v.name]
-[if v.generateDefault and type.generateSafeDerived]
-    [shim].[v.names.init]([valueFromValue v n]);
-[else if v.hasVirtualImpl]
-    [rr.virtualImpl v] = [valueFromValue v n];
-[else]
-    this.[n] = [valueFromValue v n];
-[/if]
-  [/for]
-    [generateConstructorDefaultAttributes type type.constructorOmited]
-    [generateDerivedConstruction type type.constructorArguments]
-[else][-- Alternatively a lot simpler implementation]
-  [for v in type.constructorArguments, n = v.name]
-    this.[n] = [valueFromValue v n];
-  [/for]
-[/if]
-    [generateAfterConstruction type false]
-  }
+[generateConstructor type false constructorAcceptType]
 [-- Additional constructors for Optional types --]
 [if type.hasOptionalConstructorArguments]
 
-  [if type.factoryOf.new]
-  /**
-   * Construct a new immutable {@code [type.name]} instance.
-  [for v in type.constructorArguments]
-   * @param [v.name] The value for the {@code [v.name]} attribute[if v.nullable], can be {@code null}[/if]
-  [/for]
-   */
-  [eachLine type.constructorAnnotations]
-  [eachLine type.constructorInjectedAnnotations]
-  [suppressAnyCovariantCastForOptional type.constructorArguments]
-  public [type.typeImmutable.simple]([output.linesShortable][for v in type.constructorArguments][if not for.first],[/if]
-      [v.constructorParameterAnnotations][v.atNullability][if v.isOptionalType][unwrappedOptionalType v][else][constructorAcceptType v][/if] [v.name][/for][/output.linesShortable]) {
-  [else]
-  [suppressAnyCovariantCastForOptional type.constructorArguments]
-  private [type.typeImmutable.simple]([output.linesShortable][for v in type.constructorArguments][if not for.first],[/if]
-      [v.atNullability][if v.isOptionalType][unwrappedOptionalType v][else][constructorAcceptType v][/if] [v.name][/for][/output.linesShortable]) {
-  [/if]
-[if type.constructorOmited or (type.hasEncodingValueOrVirtualFields or (type.generateSafeDerived and type.hasDerivedAttributes))]
-  [let shim][disambiguateField type 'initShim'][/let]
-  [for v in type.constructorArguments, n = v.name]
-[if v.generateDefault and type.generateSafeDerived]
-    [shim].[v.names.init]([valueFromValueNoOptional type v n]);
-[else if v.hasVirtualImpl]
-    [rr.virtualImpl v] = [valueFromValueNoOptional type v n];
-[else]
-    this.[n] = [valueFromValueNoOptional type v n];
-[/if]
-  [/for]
-    [generateConstructorDefaultAttributes type type.constructorOmited]
-    [generateDerivedConstruction type type.constructorArguments]
-[else][-- Alternatively a lot simpler implementation]
-  [for v in type.constructorArguments, n = v.name]
-    this.[n] = [valueFromValueNoOptional type v n];
-  [/for]
-[/if]
-    [generateAfterConstruction type false]
-  }
+[generateConstructor type true constructorAcceptTypeNoOptional]
 [/if]
 [/if]
 [if type.generateBuilderConstructor]
@@ -2549,6 +2483,46 @@ this.[n] = [valueFromValue v][invokeSuper v].[v.names.get]()[/valueFromValue];
 [/for]
 [/template]
 
+[template generateConstructor Type type Boolean withoutOptional Invokable constructorAcceptTypeInvokable]
+  [if type.factoryOf.new]
+  /**
+   * Construct a new immutable {@code [type.name]} instance.
+  [for v in type.constructorArguments]
+   * @param [v.name] The value for the {@code [v.name]} attribute[if v.nullable], can be {@code null}[/if]
+  [/for]
+   */
+  [eachLine type.constructorAnnotations]
+  [eachLine type.constructorInjectedAnnotations]
+  [suppressAnyCovariantCastForOptional type.constructorArguments]
+  public [type.typeImmutable.simple]([output.linesShortable][for v in type.constructorArguments][if not for.first],[/if]
+      [v.constructorParameterAnnotations][v.atNullability][constructorAcceptTypeInvokable v] [v.name][/for][/output.linesShortable]) {
+  [else]
+  [suppressAnyCovariantCastForOptional type.constructorArguments]
+  private [type.typeImmutable.simple]([output.linesShortable][for v in type.constructorArguments][if not for.first],[/if]
+      [v.atNullability][constructorAcceptTypeInvokable v] [v.name][/for][/output.linesShortable]) {
+  [/if]
+[if type.constructorOmited or (type.hasEncodingValueOrVirtualFields or (type.generateSafeDerived and type.hasDerivedAttributes))]
+  [let shim][disambiguateField type 'initShim'][/let]
+  [for v in type.constructorArguments, n = v.name]
+[if v.generateDefault and type.generateSafeDerived]
+    [shim].[v.names.init]([valueFrom type v n withoutOptional]);
+[else if v.hasVirtualImpl]
+    [rr.virtualImpl v] = [valueFrom type v n withoutOptional];
+[else]
+    this.[n] = [valueFrom type v n withoutOptional];
+[/if]
+  [/for]
+    [generateConstructorDefaultAttributes type type.constructorOmited]
+    [generateDerivedConstruction type type.constructorArguments]
+[else][-- Alternatively a lot simpler implementation]
+  [for v in type.constructorArguments, n = v.name]
+    this.[n] = [valueFrom type v n withoutOptional];
+  [/for]
+[/if]
+    [generateAfterConstruction type false]
+  }
+[/template]
+
 [template generateSafeDerivedShim Type type]
 [for deriveds = v for v in type.implementedAttributes if v.generateDefault or v.generateDerived]
 
@@ -2612,6 +2586,14 @@ private [v.atNullability][v.type] [invokeSuperGet]() {
 [/for]
 [/for]
 [/template]
+
+[template constructorAcceptTypeNoOptional Attribute a][output.trim]
+  [if a.isOptionalType]
+    [unwrappedOptionalType a]
+  [else]
+    [constructorAcceptType a]
+  [/if]
+[/output.trim][/template]
 
 [template constructorAcceptType Attribute a][output.trim]
 [if a.encoding]

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -710,19 +710,6 @@ public [type.typeAbstract.relative] [v.names.with]([v.atNullability][v.type] val
   public static [type.generics.spaceAfter][type.typeValue] [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][v.atNullability][eachLine v.constructorParameterInjectedAnnotations][v.type] [v.name][/for]) {
     return [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][if v.requiresAlternativeStrictConstructor]([constructorAcceptType v]) [/if][v.name][/for]);
   }
-
-  [if type.hasOptionalConstructorArguments]
-  /**
-   * Construct a new immutable {@code [type.name]} instance.
-  [for v in type.constructorArguments]
-   * @param [v.name] The value for the {@code [v.name]} attribute
-  [/for]
-   * @return An immutable [type.name] instance
-   */
-  public static [type.generics.spaceAfter][type.typeValue] [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][v.atNullability][eachLine v.constructorParameterInjectedAnnotations][if v.isOptionalType][unwrappedOptionalType v][else][v.type][/if] [v.name][/for]) {
-    return [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][if v.requiresAlternativeStrictConstructor]([constructorAcceptType v]) [/if][if v.isOptionalType andnot v.isJdkOptional][optionalOf v]([v.name])[else if v.isJdkOptional and type.kind.isFactory][optionalOf v]([v.name])[else][v.name][/if][/for]);
-  }
-  [/if]
   [/if]
 
   /**

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -702,26 +702,52 @@ public [type.typeAbstract.relative] [v.names.with]([v.atNullability][v.type] val
 
   /**
    * Construct a new immutable {@code [type.name]} instance.
-[for v in type.constructorArguments]
+  [for v in type.constructorArguments]
    * @param [v.name] The value for the {@code [v.name]} attribute
-[/for]
+  [/for]
    * @return An immutable [type.name] instance
    */
   public static [type.generics.spaceAfter][type.typeValue] [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][v.atNullability][eachLine v.constructorParameterInjectedAnnotations][v.type] [v.name][/for]) {
     return [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][if v.requiresAlternativeStrictConstructor]([constructorAcceptType v]) [/if][v.name][/for]);
   }
+
+  [if type.hasOptionalConstructorArguments]
+  /**
+   * Construct a new immutable {@code [type.name]} instance.
+  [for v in type.constructorArguments]
+   * @param [v.name] The value for the {@code [v.name]} attribute
+  [/for]
+   * @return An immutable [type.name] instance
+   */
+  public static [type.generics.spaceAfter][type.typeValue] [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][v.atNullability][eachLine v.constructorParameterInjectedAnnotations][if v.isOptionalType][unwrappedOptionalType v][else][v.type][/if] [v.name][/for]) {
+    return [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][if v.requiresAlternativeStrictConstructor]([constructorAcceptType v]) [/if][if v.isOptionalType][optionalOf v]([v.name])[else][v.name][/if][/for]);
+  }
+  [/if]
   [/if]
 
   /**
    * Construct a new immutable {@code [type.name]} instance.
-[for v in type.constructorArguments]
+  [for v in type.constructorArguments]
    * @param [v.name] The value for the {@code [v.name]} attribute
-[/for]
+  [/for]
    * @return An immutable [type.name] instance
    */
   public static [type.generics.spaceAfter][type.typeValue] [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][v.atNullability][eachLine v.constructorParameterInjectedAnnotations][constructorAcceptType v] [v.name][/for]) {
     return [validated type false]new [type.typeImmutable.relativeRaw][type.generics.diamond]([for v in type.constructorArguments][if not for.first], [/if][v.name][/for])[/validated];
   }
+
+  [if type.hasOptionalConstructorArguments]
+  /**
+   * Construct a new immutable {@code [type.name]} instance.
+  [for v in type.constructorArguments]
+   * @param [v.name] The value for the {@code [v.name]} attribute
+  [/for]
+   * @return An immutable [type.name] instance
+   */
+  public static [type.generics.spaceAfter][type.typeValue] [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][v.atNullability][eachLine v.constructorParameterInjectedAnnotations][if v.isOptionalType][unwrappedOptionalType v][else][constructorAcceptType v][/if] [v.name][/for]) {
+    return [validated type false]new [type.typeImmutable.relativeRaw][type.generics.diamond]([for v in type.constructorArguments][if not for.first], [/if][if v.isOptionalType][optionalOf v]([v.name])[else][v.name][/if][/for])[/validated];
+  }
+  [/if]
 [/if]
 [if type.useValidation]
 

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -720,7 +720,7 @@ public [type.typeAbstract.relative] [v.names.with]([v.atNullability][v.type] val
    * @return An immutable [type.name] instance
    */
   public static [type.generics.spaceAfter][type.typeValue] [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][v.atNullability][eachLine v.constructorParameterInjectedAnnotations][if v.isOptionalType][unwrappedOptionalType v][else][v.type][/if] [v.name][/for]) {
-    return [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][if v.requiresAlternativeStrictConstructor]([constructorAcceptType v]) [/if][if v.isOptionalType][optionalOf v]([v.name])[else][v.name][/if][/for]);
+    return [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][if v.requiresAlternativeStrictConstructor]([constructorAcceptType v]) [/if][if v.isOptionalType andnot v.isJdkOptional][optionalOf v]([v.name])[else if v.isJdkOptional and type.kind.isFactory][optionalOf v]([v.name])[else][v.name][/if][/for]);
   }
   [/if]
   [/if]
@@ -745,7 +745,7 @@ public [type.typeAbstract.relative] [v.names.with]([v.atNullability][v.type] val
    * @return An immutable [type.name] instance
    */
   public static [type.generics.spaceAfter][type.typeValue] [type.names.of]([for v in type.constructorArguments][if not for.first], [/if][v.atNullability][eachLine v.constructorParameterInjectedAnnotations][if v.isOptionalType][unwrappedOptionalType v][else][constructorAcceptType v][/if] [v.name][/for]) {
-    return [validated type false]new [type.typeImmutable.relativeRaw][type.generics.diamond]([for v in type.constructorArguments][if not for.first], [/if][if v.isOptionalType][optionalOf v]([v.name])[else][v.name][/if][/for])[/validated];
+    return [validated type false]new [type.typeImmutable.relativeRaw][type.generics.diamond]([for v in type.constructorArguments][if not for.first], [/if][v.name][/for])[/validated];
   }
   [/if]
 [/if]
@@ -2244,6 +2244,18 @@ return [type.factoryOf]([output.linesShortable][for v in type.settableAttributes
 [/if]
 [/output.trim][/template]
 
+[template valueFromValueNoOptional Attribute v String expression][output.trim]
+[if v.encoding]
+  [valueFromValue v expression]
+[else if v.jdkOptional]
+  [expression]
+[else if v.optionalType]
+  [optionalOf v]([expression])
+[else]
+  [valueFromValue v expression]
+[/if]
+[/output.trim][/template]
+
 [template deepCopyOf Attribute v String expression][if v.isAttributeBuilder][convertToValueType v.getAttributeBuilderDescriptor]([expression])[else][v.attributeValueType.factoryCopyOf]([expression])[/if][/template]
 
 [template valueFromBuilder Attribute v String expressionPrefix][valueFromBuilderAlt v true expressionPrefix][/template]
@@ -2382,8 +2394,8 @@ this.[n] = [valueFromValue v][invokeSuper v].[v.names.get]()[/valueFromValue];
     [generateAfterConstruction type false]
   [/output.collapsible]}
 [/if]
-[if type.useConstructor andnot type.generateConstructorUseCopyConstructor]
 
+[if type.useConstructor andnot type.generateConstructorUseCopyConstructor]
   [if type.factoryOf.new]
   /**
    * Construct a new immutable {@code [type.name]} instance.
@@ -2421,9 +2433,49 @@ this.[n] = [valueFromValue v][invokeSuper v].[v.names.get]()[/valueFromValue];
 [/if]
     [generateAfterConstruction type false]
   }
+
+[-- Additional constructors for Optional types --]
+[if type.hasOptionalConstructorArguments]
+  [if type.factoryOf.new]
+  /**
+   * Construct a new immutable {@code [type.name]} instance.
+  [for v in type.constructorArguments]
+   * @param [v.name] The value for the {@code [v.name]} attribute[if v.nullable], can be {@code null}[/if]
+  [/for]
+   */
+  [eachLine type.constructorAnnotations]
+  [eachLine type.constructorInjectedAnnotations]
+  [suppressAnyCovariantCastForOptional type.constructorArguments]
+  public [type.typeImmutable.simple]([output.linesShortable][for v in type.constructorArguments][if not for.first],[/if]
+      [v.constructorParameterAnnotations][v.atNullability][if v.isOptionalType][unwrappedOptionalType v][else][constructorAcceptType v][/if] [v.name][/for][/output.linesShortable]) {
+  [else]
+  [suppressAnyCovariantCastForOptional type.constructorArguments]
+  private [type.typeImmutable.simple]([output.linesShortable][for v in type.constructorArguments][if not for.first],[/if]
+      [v.atNullability][if v.isOptionalType][unwrappedOptionalType v][else][constructorAcceptType v][/if] [v.name][/for][/output.linesShortable]) {
+  [/if]
+[if type.constructorOmited or (type.hasEncodingValueOrVirtualFields or (type.generateSafeDerived and type.hasDerivedAttributes))]
+  [let shim][disambiguateField type 'initShim'][/let]
+  [for v in type.constructorArguments, n = v.name]
+[if v.generateDefault and type.generateSafeDerived]
+    [shim].[v.names.init]([valueFromValueNoOptional v n]);
+[else if v.hasVirtualImpl]
+    [rr.virtualImpl v] = [valueFromValueNoOptional v n];
+[else]
+    this.[n] = [valueFromValueNoOptional v n];
+[/if]
+  [/for]
+    [generateConstructorDefaultAttributes type type.constructorOmited]
+    [generateDerivedConstruction type type.constructorArguments]
+[else][-- Alternatively a lot simpler implementation]
+  [for v in type.constructorArguments, n = v.name]
+    this.[n] = [valueFromValueNoOptional v n];
+  [/for]
+[/if]
+    [generateAfterConstruction type false]
+  }
+[/if]
 [/if]
 [if type.generateBuilderConstructor]
-
   private [type.typeImmutable.simple]([type.typeBuilderImpl.relative] builder) {
   [for v in getters if not (v.generateDerived or v.generateDefault), n = v.name]
     [if v.hasVirtualImpl]

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -2381,6 +2381,8 @@ this.[n] = [valueFromValue v][invokeSuper v].[v.names.get]()[/valueFromValue];
     [generateAfterConstruction type false]
   [/output.collapsible]}
 [/if]
+[-- There is a very similar block of code beneath this constructor generation
+    which needs to be taken into consideration when anything changes here]
 [if type.useConstructor andnot type.generateConstructorUseCopyConstructor]
 
   [if type.factoryOf.new]

--- a/value-processor/src/org/immutables/value/processor/Immutables.java
+++ b/value-processor/src/org/immutables/value/processor/Immutables.java
@@ -35,6 +35,9 @@ abstract class Immutables extends ValuesTemplate {
   @Generator.Typedef
   AttributeBuilderDescriptor AttributeBuilder;
 
+  @Generator.Typedef
+  Templates.Invokable Invokable;
+
   abstract Templates.Invokable arrayAsList();
 
   abstract Templates.Invokable arrayAsListSecondary();

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -140,6 +140,15 @@ public final class ValueType extends TypeIntrospectionBase implements HasStyleIn
     return false;
   }
 
+  public boolean hasOptionalConstructorArguments() {
+    for (ValueAttribute attribute : getConstructorArguments()) {
+      if (attribute.isOptionalType()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public boolean hasEncodingAttributes() {
     for (ValueAttribute a : attributes()) {
       if (a.isEncoding()) {


### PR DESCRIPTION
Hey!

This PR closes #800 

I tried my luck at the topic in Issue #800 and added the generation of additional static factory methods and constructors for Optional types. This allows the use of the unwrapped type in addition to the current implementation which requires the variable to be wrapped in an Optional when constructing the Immutables object.

Please have a look and tell me what you think and if there are any issues with the implementation or anything.

Best regards


