### PR TITLE
Support protocol buffer attributes

### DIFF
--- a/value-annotations/src/org/immutables/value/Value.java
+++ b/value-annotations/src/org/immutables/value/Value.java
@@ -1280,9 +1280,10 @@ public @interface Value {
      * <em>This is detection pattern, not formatting pattern. It defines how to recognize a nested
      * builder.</em>
      * Only applies if {@link #attributeBuilderDetection()} is {@code true}.
+     *
      * @return naming template
      */
-    String[] attributeBuilder() default {"*Builder", "builder", "new"};
+    String[] attributeBuilder() default {"Builder", "*Builder", "builder", "from", "build", "*Build", "new"};
 
     /**
      * Naming template for retrieving a nested builder.

--- a/value-fixture/src/org/immutables/fixture/builder/attribute_builders/ThirdPartyImmutableWithBuilderClassCopyMethod.java
+++ b/value-fixture/src/org/immutables/fixture/builder/attribute_builders/ThirdPartyImmutableWithBuilderClassCopyMethod.java
@@ -31,7 +31,7 @@ public class ThirdPartyImmutableWithBuilderClassCopyMethod {
       return new ThirdPartyImmutableWithBuilderClassCopyMethod(value);
     }
 
-    public static Builder builderFromValue(ThirdPartyImmutableWithBuilderClassCopyMethod immutable) {
+    public static Builder from(ThirdPartyImmutableWithBuilderClassCopyMethod immutable) {
       return new Builder().setValue(immutable.getValue());
     }
   }

--- a/value-fixture/src/org/immutables/fixture/builder/attribute_builders/ThirdPartyImmutableWithBuilderInstanceCopyMethod.java
+++ b/value-fixture/src/org/immutables/fixture/builder/attribute_builders/ThirdPartyImmutableWithBuilderInstanceCopyMethod.java
@@ -31,7 +31,7 @@ public class ThirdPartyImmutableWithBuilderInstanceCopyMethod {
       return new ThirdPartyImmutableWithBuilderInstanceCopyMethod(value);
     }
 
-    public Builder merge(ThirdPartyImmutableWithBuilderInstanceCopyMethod immutable) {
+    public Builder from(ThirdPartyImmutableWithBuilderInstanceCopyMethod immutable) {
       return setValue(immutable.getValue());
     }
   }

--- a/value-fixture/src/org/immutables/fixture/builder/attribute_builders/ThirdPartyImmutableWithValueClassCopyMethod.java
+++ b/value-fixture/src/org/immutables/fixture/builder/attribute_builders/ThirdPartyImmutableWithValueClassCopyMethod.java
@@ -11,7 +11,7 @@ public class ThirdPartyImmutableWithValueClassCopyMethod {
     return new Builder();
   }
 
-  public static Builder geterateNewBuilderFrom(ThirdPartyImmutableWithValueClassCopyMethod third) {
+  public static Builder generateNewBuilder(ThirdPartyImmutableWithValueClassCopyMethod third) {
     return generateNewBuilder().setValue(third.getValue());
   }
 
@@ -19,6 +19,7 @@ public class ThirdPartyImmutableWithValueClassCopyMethod {
   public String getValue() {
     return value;
   }
+
   public static class Builder {
 
     private String value;

--- a/value-fixture/src/org/immutables/fixture/builder/detection/NewTokenAttributeBuilderParent.java
+++ b/value-fixture/src/org/immutables/fixture/builder/detection/NewTokenAttributeBuilderParent.java
@@ -6,7 +6,7 @@ import org.immutables.value.Value.Style;
 @Immutable
 @Style(
     attributeBuilderDetection = true,
-    attributeBuilder = {"*Builder", "builder", "new"}
+    attributeBuilder = {"Builder", "*Builder", "builder", "from", "build", "*Build", "new"}
 )
 public abstract class NewTokenAttributeBuilderParent implements NestedDetection{
 }

--- a/value-fixture/src/org/immutables/fixture/builder/detection/NoNewTokenAttributeBuilderParent.java
+++ b/value-fixture/src/org/immutables/fixture/builder/detection/NoNewTokenAttributeBuilderParent.java
@@ -6,7 +6,7 @@ import org.immutables.value.Value.Style;
 @Immutable
 @Style(
     attributeBuilderDetection = true,
-    attributeBuilder = {"*Builder", "builder"}
+    attributeBuilder = {"Builder", "*Builder", "builder", "from", "build", "*Build"}
 )
 public abstract class NoNewTokenAttributeBuilderParent implements NestedDetection {
 }

--- a/value-fixture/src/org/immutables/fixture/builder/functional/AttributeBuilderBuilderI.java
+++ b/value-fixture/src/org/immutables/fixture/builder/functional/AttributeBuilderBuilderI.java
@@ -1,6 +1,7 @@
 package org.immutables.fixture.builder.functional;
 
 import java.util.List;
+
 import org.immutables.fixture.builder.attribute_builders.FirstPartyImmutable;
 import org.immutables.fixture.builder.attribute_builders.FirstPartyImmutableWithDifferentStyle;
 import org.immutables.fixture.builder.attribute_builders.ImmutableFirstPartyImmutable;

--- a/value-processor/src/org/immutables/value/processor/meta/Styles.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Styles.java
@@ -16,8 +16,10 @@
 package org.immutables.value.processor.meta;
 
 import com.google.common.base.CaseFormat;
-import javax.lang.model.SourceVersion;
 import org.immutables.generator.Naming;
+
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Name;
 
 public final class Styles {
   private final StyleInfo style;
@@ -245,6 +247,18 @@ public final class Styles {
 
         return false;
       }
+
+      public final boolean possibleAttributeBuilder(Name name) {
+        for (Naming pattern : scheme.attributeBuilder) {
+          String foundPattern = pattern.detect(name.toString());
+          if (!foundPattern.isEmpty()) {
+            return true;
+          }
+        }
+
+        return false;
+      }
+
     }
 
     public final class AttributeNames {

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -227,7 +227,7 @@ public final class ValueMirrors {
 
     boolean transientDerivedFields() default true;
 
-    String[] attributeBuilder() default {"*Builder", "builder", "new"};
+    String[] attributeBuilder() default {"Builder", "*Builder", "builder", "from", "build", "*Build", "new"};
 
     String getBuilder() default "*Builder";
 


### PR DESCRIPTION
    The discovery mechanism needs to be more strict for protocol buffers
    because there are several methods which have the right signature, but
    are not part of the builder API.

    First, we make sure all methods for an attribute builder match the
    specified Value#attributeBuilder patterns

    Second, we ensure that the return methods are equivalent using
    typeMirriors#isSameType. Using equals was working intermittently, and
    the documentation on equals says to use the isSameType instead.
