### PR TITLE
Improve `from` behavior for mandatory fields on partial Modifiable instances

### DIFF
--- a/value-fixture/src/org/immutables/fixture/modifiable/GenericHolder.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/GenericHolder.java
@@ -1,0 +1,29 @@
+/*
+   Copyright 2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.fixture.modifiable;
+
+import javax.annotation.Nullable;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Modifiable
+public interface GenericHolder<T> {
+    T mandatory();
+
+    @Nullable
+    T optional();
+}

--- a/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
+++ b/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
@@ -257,4 +257,15 @@ public class ModifiablesTest {
     final ModifiableBeanFriendly second = new ModifiableBeanFriendly().from(first);
     check(second.getId()).is(42);
   }
+
+  @Test
+  public void testGeneric() {
+    final GenericHolder<String> tester = ImmutableGenericHolder.<String>builder()
+            .from(ModifiableGenericHolder.<String>create().setOptional("optional"))
+            .mandatory("mandatory")
+            .build();
+
+    check(tester.mandatory()).is("mandatory");
+    check(tester.optional()).is("optional");
+  }
 }

--- a/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
+++ b/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
@@ -231,4 +231,30 @@ public class ModifiablesTest {
         .putMap("key", null)
         .addList((String) null);
   }
+
+  @Test
+  public void composeBuilders() {
+    final ModifiableBeanFriendly first = new ModifiableBeanFriendly();
+    first.setPrimary(true);
+    first.setId(42);
+    final ModifiableBeanFriendly second = new ModifiableBeanFriendly();
+    second.setPrimary(false);
+    second.setDescription("foo");
+    final ImmutableBeanFriendly result = ImmutableBeanFriendly.builder()
+      .from(first)
+      .from(second)
+      .build();
+    check(result.getId()).is(42);
+    check(!result.isPrimary());
+    check(result.getDescription()).is("foo");
+  }
+
+  @Test
+  public void copyPartialModifiable() {
+    final ModifiableBeanFriendly first = new ModifiableBeanFriendly();
+    first.setPrimary(true);
+    first.setId(42);
+    final ModifiableBeanFriendly second = new ModifiableBeanFriendly().from(first);
+    check(second.getId()).is(42);
+  }
 }

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1253,6 +1253,7 @@ public interface BuildFinal[type.generics] {
   @SuppressWarnings("unchecked")
 [/if]
   private void from(Object object) {
+    [dynamicFromModifiableCheck type 'object' '']
     [for l in bs.positions.longs]
     [atVar type]long bits[emptyIfZero l.index] = 0;
     [/for]
@@ -1298,6 +1299,7 @@ public interface BuildFinal[type.generics] {
   [atCanIgnoreReturnValue type]
   [type.typeAbstract.access]final [builderReturnType type] [type.names.from]([type.typeAbstract.relative] instance) {
     [requireNonNull type](instance, "instance");
+    [dynamicFromModifiableCheck type 'instance' 'this']
     [for v in setters]
     [buildFromAttribute v]
     [/for]
@@ -1307,8 +1309,25 @@ public interface BuildFinal[type.generics] {
   [atCanIgnoreReturnValue type]
   public final [builderReturnType type] [type.names.from]([type.typeAbstract.relative] instance) {
     [requireNonNull type](instance, "instance");
+    [dynamicFromModifiableCheck type 'instance' 'this']
     [for v in setters]
     [buildFromAttribute v]
+    [/for]
+    return [builderReturnThis type];
+  }
+  [/if]
+  [if type.kind.isModifiable]
+
+  /**
+   * Fill a builder with attribute values from the provided {@code [type.typeModifiable]} instance.
+   * @param instance The instance from which to copy values
+   * @return {@code this} builder for use in a chained invocation
+   */
+  [atCanIgnoreReturnValue type]
+  public final [builderReturnType type] [type.names.from]([type.typeModifiable] instance) {
+    [requireNonNull type](instance, "instance");
+    [for v in setters]
+    [buildFromMandatoryAttribute buildFromAttribute v 'instance']
     [/for]
     return [builderReturnThis type];
   }
@@ -2477,6 +2496,25 @@ this.[n] = [valueFromValue v][invokeSuper v].[v.names.get]()[/valueFromValue];
   [generateObjectUtilityMethods type]
   [generateJacksonMapped type]
 [/for]
+[/template]
+
+[template public buildFromMandatoryAttribute Invokable buildAttribute Attribute v String varName]
+[if v.isMandatory]
+if ([varName].[v.names.isSet]()) {
+  [buildAttribute v]
+}
+[else]
+[buildAttribute v]
+[/if]
+[/template]
+
+[template public dynamicFromModifiableCheck Type type String varName String returnValue]
+[if type.kind.isModifiable]
+if ([varName] instanceof [type.typeModifiable.relativeRaw][type.generics.unknown]) {
+  [type.names.from](([type.typeModifiable]) [varName]);
+  return[if returnValue] [returnValue][/if];
+}
+[/if]
 [/template]
 
 [template generateSafeDerivedShim Type type]

--- a/value-processor/src/org/immutables/value/processor/Immutables.java
+++ b/value-processor/src/org/immutables/value/processor/Immutables.java
@@ -35,6 +35,9 @@ abstract class Immutables extends ValuesTemplate {
   @Generator.Typedef
   AttributeBuilderDescriptor AttributeBuilder;
 
+  @Generator.Typedef
+  Templates.Invokable Invokable;
+
   abstract Templates.Invokable arrayAsList();
 
   abstract Templates.Invokable arrayAsListSecondary();
@@ -54,4 +57,8 @@ abstract class Immutables extends ValuesTemplate {
   abstract Templates.Invokable primitiveHashCode();
 
   abstract Templates.Invokable javadocGenerics();
+
+  abstract Templates.Invokable dynamicFromModifiableCheck();
+
+  abstract Templates.Invokable buildFromMandatoryAttribute();
 }

--- a/value-processor/src/org/immutables/value/processor/Modifiables.generator
+++ b/value-processor/src/org/immutables/value/processor/Modifiables.generator
@@ -401,8 +401,27 @@ private void from(Object object) {
  */
 public [thisReturnType type] [type.names.from]([type.typeAbstract] instance) {
   [im.requireNonNull type](instance, "instance");
+  [im.dynamicFromModifiableCheck type 'instance' 'this']
 [for v in type.settableAttributes]
   [buildFromAttribute v]
+[/for]
+  [thisReturn type]
+}
+
+/**
+ * Fill this modifiable instance with attribute values from the provided {@link [type.typeAbstract.relativeRaw]} instance.
+ * Regular attribute values will be overridden, i.e. replaced with ones of an instance.
+ * Any of the instance's absent optional values will not be copied (will not override current values).
+[if type.hasSettableCollection or type.hasSettableMapping]
+ * Collection elements and entries will be added, not replaced.
+[/if]
+ * @param instance The instance from which to copy values
+ * @return {@code this} for use in a chained invocation
+ */
+public [thisReturnType type] [type.names.from]([type.typeModifiable] instance) {
+  [im.requireNonNull type](instance, "instance");
+[for v in type.settableAttributes]
+  [im.buildFromMandatoryAttribute buildFromAttribute v 'instance']
 [/for]
   [thisReturn type]
 }

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -218,6 +218,10 @@ public final class ValueType extends TypeIntrospectionBase implements HasStyleIn
     return constitution.typeImmutable();
   }
 
+  public NameForms typeModifiable() {
+    return constitution.typeModifiable();
+  }
+
   public NameForms typeEnclosing() {
     return constitution.typeEnclosing();
   }


### PR DESCRIPTION
Currently the Modifiable implementations check if a field has been set and throw if not, which prevents a partial Modifiable object seeding a new builder.

This PR adds a Builder and Modifiable `from` overload for the Modifiable type, as well as a dynamic `instanceof` check since we can't rely on people statically calling the overload.  The overload then checks `isSet` on mandatory attributes before attempting to copy them, avoiding the exception.