### PR TITLE
Issue #603 - automatically add `@JsonIgnore` to the `class Json` builder for derived functions.

### DIFF
--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -2670,6 +2670,9 @@ static final [output.linesShortable]class Json[type.generics]
   [signature] { throw new UnsupportedOperationException(); }
 [/for]
 [for v in type.allAccessibleAttributes]
+  [if v.isGenerateDerived]
+  @com.fasterxml.jackson.annotation.JsonIgnore
+  [/if]
   @Override[-- we actually don't need this implementation, signature is good enough --]
   [v.toSignature] { throw new UnsupportedOperationException(); }
 [/for]

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -581,6 +581,10 @@ public final class ValueAttribute extends TypeIntrospectionBase implements HasSt
         && !containingType.serial.isSimple();
   }
 
+  public boolean isGenerateDerived() {
+    return isGenerateDerived;
+  }
+
   public boolean isGenerateEnumMap() {
     return typeKind.isEnumMap();
   }


### PR DESCRIPTION
Since derived functions are calculated fields that are outputted when serialized to json, they
shouldn't be attempted to be deserialized from the Json structure.