### PR TITLE
Support for Jackson serialization in Mongo Adapter.

### DIFF
--- a/mongo/pom.xml
+++ b/mongo/pom.xml
@@ -90,5 +90,21 @@
       <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.8.11</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.8.11.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-guava</artifactId>
+      <version>2.8.11</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/mongo/src/org/immutables/mongo/Wrapper.java
+++ b/mongo/src/org/immutables/mongo/Wrapper.java
@@ -14,11 +14,11 @@
    limitations under the License.
 */
 
-package org.immutables.mongo.bson4gson;
+package org.immutables.mongo;
 
 /**
  * Allows retrieving delegates to access non-standard methods which
- * are usually not exposed by standard interface.
+ * are usually not exposed by common interface.
  */
 public interface Wrapper<T> {
 

--- a/mongo/src/org/immutables/mongo/bson4gson/BsonReader.java
+++ b/mongo/src/org/immutables/mongo/bson4gson/BsonReader.java
@@ -21,6 +21,7 @@ import com.google.gson.stream.JsonToken;
 import org.bson.AbstractBsonReader;
 import org.bson.AbstractBsonReader.State;
 import org.bson.BsonType;
+import org.immutables.mongo.Wrapper;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;

--- a/mongo/src/org/immutables/mongo/bson4gson/BsonWriter.java
+++ b/mongo/src/org/immutables/mongo/bson4gson/BsonWriter.java
@@ -17,6 +17,7 @@ package org.immutables.mongo.bson4gson;
 
 import com.google.gson.internal.LazilyParsedNumber;
 import org.bson.types.Decimal128;
+import org.immutables.mongo.Wrapper;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.Closeable;
@@ -176,9 +177,7 @@ public class BsonWriter extends com.google.gson.stream.JsonWriter implements Wra
       final BigDecimal decimal = (BigDecimal) value;
       try {
         return value(new Decimal128(decimal));
-      } catch (NumberFormatException|AssertionError ex) {
-        // Decimal128 throws AssertionError instead of NumberFormatException for out of range values
-        // see https://jira.mongodb.org/browse/JAVA-2937
+      } catch (NumberFormatException ex) {
         // fallback to serializing to string
         return value(decimal.toPlainString());
       }
@@ -189,9 +188,7 @@ public class BsonWriter extends com.google.gson.stream.JsonWriter implements Wra
         // BigDecimal is a wrapper for BigInteger anyway
         BigDecimal decimal = new BigDecimal(integer);
         return value(new Decimal128(decimal));
-      } catch (NumberFormatException|AssertionError ex) {
-        // Decimal128 throws AssertionError instead of NumberFormatException for out of range values
-        // see https://jira.mongodb.org/browse/JAVA-2937
+      } catch (NumberFormatException ex) {
         // fallback to serializing to string
         return value(integer.toString());
       }

--- a/mongo/src/org/immutables/mongo/bson4gson/GsonCodecs.java
+++ b/mongo/src/org/immutables/mongo/bson4gson/GsonCodecs.java
@@ -36,9 +36,9 @@ import java.io.IOException;
  * <a href="https://github.com/google/gson">Gson</a> standard classes like
  * {@link TypeAdapter} / {@link Codec}(s).
  */
-public final class Codecs {
+public final class GsonCodecs {
 
-  private Codecs() {
+  private GsonCodecs() {
   }
 
   /**

--- a/mongo/src/org/immutables/mongo/bson4jackson/BsonGenerator.java
+++ b/mongo/src/org/immutables/mongo/bson4jackson/BsonGenerator.java
@@ -1,0 +1,182 @@
+/*
+   Copyright 2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.mongo.bson4jackson;
+
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.base.GeneratorBase;
+import com.google.common.base.Preconditions;
+import org.bson.BsonWriter;
+import org.bson.types.Decimal128;
+import org.immutables.mongo.Wrapper;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Delegates all streaming API to {@link BsonWriter}.
+ */
+@NotThreadSafe
+public class BsonGenerator extends GeneratorBase implements Wrapper<BsonWriter> {
+
+  private final BsonWriter writer;
+
+  BsonGenerator(int jsonFeatures, ObjectCodec codec, BsonWriter writer) {
+    super(jsonFeatures, codec);
+    this.writer = Preconditions.checkNotNull(writer, "writer");
+  }
+
+  @Override
+  public void writeStartArray() throws IOException {
+    writer.writeStartArray();
+  }
+
+  @Override
+  public void writeEndArray() throws IOException {
+    writer.writeEndArray();
+  }
+
+  @Override
+  public void writeStartObject() throws IOException {
+    writer.writeStartDocument();
+  }
+
+  @Override
+  public void writeEndObject() throws IOException {
+    writer.writeEndDocument();
+  }
+
+  @Override
+  public void writeFieldName(String name) throws IOException {
+    writer.writeName(name);
+  }
+
+  @Override
+  public void writeString(String text) throws IOException {
+    writer.writeString(text);
+  }
+
+  @Override
+  public void writeString(char[] text, int offset, int len) throws IOException {
+    writer.writeString(new String(text, offset, len));
+  }
+
+  @Override
+  public void writeRawUTF8String(byte[] text, int offset, int length) throws IOException {
+    writer.writeString(new String(text, offset, length));
+  }
+
+  @Override
+  public void writeUTF8String(byte[] text, int offset, int length) throws IOException {
+    writer.writeString(new String(text, offset, length));
+  }
+
+  @Override
+  public void writeRaw(String text) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void writeRaw(String text, int offset, int len) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void writeRaw(char[] text, int offset, int len) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void writeRaw(char c) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void writeBinary(Base64Variant bv, byte[] data, int offset, int len) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void writeNumber(int number) throws IOException {
+    writer.writeInt32(number);
+  }
+
+  @Override
+  public void writeNumber(long number) throws IOException {
+    writer.writeInt64(number);
+  }
+
+  @Override
+  public void writeNumber(BigInteger number) throws IOException {
+    writeNumber(new BigDecimal(number));
+  }
+
+  @Override
+  public void writeNumber(double number) throws IOException {
+    writer.writeDouble(number);
+  }
+
+  @Override
+  public void writeNumber(float number) throws IOException {
+    writer.writeDouble(number);
+  }
+
+  @Override
+  public void writeNumber(BigDecimal number) throws IOException {
+    try {
+      writer.writeDecimal128(new Decimal128(number));
+    } catch (NumberFormatException e) {
+      writer.writeString(number.toString());
+    }
+  }
+
+  @Override
+  public void writeNumber(String encodedValue) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void writeBoolean(boolean state) throws IOException {
+    writer.writeBoolean(state);
+  }
+
+  @Override
+  public void writeNull() throws IOException {
+    writer.writeNull();
+  }
+
+  @Override
+  public void flush() throws IOException {
+    writer.flush();
+  }
+
+  @Override
+  protected void _releaseBuffers() {
+
+  }
+
+  @Override
+  protected void _verifyValueWrite(String typeMsg) throws IOException {
+
+  }
+
+  @Override
+  public BsonWriter unwrap() {
+    return writer;
+  }
+}

--- a/mongo/src/org/immutables/mongo/bson4jackson/BsonParser.java
+++ b/mongo/src/org/immutables/mongo/bson4jackson/BsonParser.java
@@ -1,0 +1,286 @@
+/*
+   Copyright 2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.mongo.bson4jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.base.ParserBase;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.google.common.base.Preconditions;
+import org.bson.AbstractBsonReader;
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.immutables.mongo.Wrapper;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Delegates all streaming API to {@link BsonReader}
+ */
+@NotThreadSafe
+public class BsonParser extends ParserBase implements Wrapper<BsonReader> {
+
+  private final AbstractBsonReader reader;
+
+  /**
+   * The ObjectCodec used to parse the Bson object(s)
+   */
+  private ObjectCodec _codec;
+
+
+  BsonParser(IOContext ctxt, int jsonFeatures, AbstractBsonReader reader) {
+    super(ctxt, jsonFeatures);
+    this.reader = Preconditions.checkNotNull(reader, "reader");
+  }
+
+  @Override
+  protected void _closeInput() throws IOException {
+    if (isEnabled(JsonParser.Feature.AUTO_CLOSE_SOURCE)) {
+      reader.close();
+    }
+    _closed = true;
+  }
+
+  @Override
+  public ObjectCodec getCodec() {
+    return _codec;
+  }
+
+  @Override
+  public void setCodec(ObjectCodec codec) {
+    this._codec = codec;
+  }
+
+  private AbstractBsonReader.State state() {
+    return reader.getState();
+  }
+
+  @Override
+  public String nextFieldName() throws IOException {
+    if (next() == JsonToken.FIELD_NAME) {
+      return reader.readName();
+    }
+
+    return null;
+  }
+
+  @Override
+  public String getCurrentName() throws IOException {
+    if (state() == AbstractBsonReader.State.NAME) {
+      return nextFieldName();
+    } else if (state() == AbstractBsonReader.State.VALUE) {
+      return reader.getCurrentName();
+    }
+
+    return null;
+  }
+
+  @Override
+  public Number getNumberValue() throws IOException {
+    final BsonType type = type();
+    switch (type) {
+      case DOUBLE:
+        return reader.readDouble();
+      case INT32:
+        return reader.readInt32();
+      case INT64:
+        return reader.readInt64();
+      case DECIMAL128:
+        return reader.readDecimal128().bigDecimalValue();
+      case STRING:
+        return new BigDecimal(reader.readString());
+    }
+
+    throw new IllegalStateException(String.format("Can't convert %s to %s", type, Number.class.getName()));
+  }
+
+  @Override
+  public BigInteger getBigIntegerValue() throws IOException {
+    final Number value = getNumberValue();
+
+    if (value instanceof BigInteger) {
+      return (BigInteger) value;
+    } else if (value instanceof BigDecimal) {
+      return ((BigDecimal) value).toBigInteger();
+    }
+
+    return BigInteger.valueOf(value.longValue());
+  }
+
+  @Override
+  public float getFloatValue() throws IOException {
+    return getNumberValue().floatValue();
+  }
+
+  @Override
+  public double getDoubleValue() throws IOException {
+    return getNumberValue().doubleValue();
+  }
+
+  @Override
+  public int getIntValue() throws IOException {
+    return getNumberValue().intValue();
+  }
+
+  @Override
+  public long getLongValue() throws IOException {
+    return getNumberValue().longValue();
+  }
+
+  @Override
+  public BigDecimal getDecimalValue() throws IOException {
+    final BsonType type = type();
+    switch (type) {
+      case DOUBLE:
+        return BigDecimal.valueOf(getNumberValue().doubleValue());
+      case INT32:
+        return new BigDecimal(getNumberValue().intValue());
+      case INT64:
+        return BigDecimal.valueOf(getNumberValue().longValue());
+      case DECIMAL128:
+      case STRING:
+        return (BigDecimal) getNumberValue();
+    }
+
+    throw new IllegalStateException(String.format("Can't convert %s to %s", type, BigDecimal.class.getName()));
+  }
+
+  private BsonType type() {
+    return reader.getCurrentBsonType();
+  }
+
+  @Override
+  public NumberType getNumberType() throws IOException {
+    final BsonType type = type();
+    switch (type) {
+      case DOUBLE:
+        return NumberType.DOUBLE;
+      case INT32:
+        return NumberType.INT;
+      case INT64:
+        return NumberType.LONG;
+      case DECIMAL128:
+        return NumberType.BIG_DECIMAL;
+    }
+
+    throw new IllegalStateException(String.format("Not a number type %s", type));
+  }
+
+  @Override
+  public JsonToken nextToken() throws IOException {
+    return _currToken = next();
+  }
+
+  private JsonToken next() throws IOException {
+    while (state() == AbstractBsonReader.State.TYPE) {
+      reader.readBsonType();
+    }
+
+    switch (state()) {
+      case INITIAL:
+        reader.readStartDocument();
+        return JsonToken.START_OBJECT;
+      case NAME:
+        return JsonToken.FIELD_NAME;
+      case END_OF_DOCUMENT:
+        reader.readEndDocument();
+        return JsonToken.END_OBJECT;
+      case END_OF_ARRAY:
+        reader.readEndArray();
+        return JsonToken.END_ARRAY;
+      case DONE:
+        return null;
+      case VALUE:
+        return toJsonToken(type());
+    }
+
+    throw new IllegalStateException(String.format("Unexpected state: %s currentType: %s", state(), type()));
+  }
+
+  private JsonToken toJsonToken(BsonType type) {
+    switch (type) {
+      case END_OF_DOCUMENT:
+        reader.readEndDocument();
+        return JsonToken.END_OBJECT;
+      case DOCUMENT:
+        reader.readStartDocument();
+        return JsonToken.START_OBJECT;
+      case ARRAY:
+        reader.readStartArray();
+        return JsonToken.START_ARRAY;
+      case OBJECT_ID:
+        return JsonToken.VALUE_EMBEDDED_OBJECT;
+      case BOOLEAN:
+        final boolean value  = reader.readBoolean();
+        return value ? JsonToken.VALUE_TRUE : JsonToken.VALUE_FALSE;
+      case DATE_TIME:
+        return JsonToken.VALUE_EMBEDDED_OBJECT;
+      case NULL:
+        reader.readNull();
+        return JsonToken.VALUE_NULL;
+      case REGULAR_EXPRESSION:
+        return JsonToken.VALUE_EMBEDDED_OBJECT;
+      case SYMBOL:
+      case STRING:
+        return JsonToken.VALUE_STRING;
+      case INT32:
+      case INT64:
+        return JsonToken.VALUE_NUMBER_INT;
+      case DECIMAL128:
+        return JsonToken.VALUE_NUMBER_FLOAT;
+      case DOUBLE:
+        return JsonToken.VALUE_NUMBER_FLOAT;
+    }
+
+    throw new IllegalStateException(String.format("Unknown type %s", type));
+  }
+
+  @Override
+  public String getText() throws IOException {
+    final BsonType type = type();
+    if (type == BsonType.SYMBOL) {
+      return reader.readSymbol();
+    } else if (type == BsonType.STRING) {
+      return reader.readString();
+    }
+
+    throw new IllegalStateException(String.format("Bad BSON type: %s expected String or Symbol", type));
+  }
+
+  @Override
+  public char[] getTextCharacters() throws IOException {
+    return getText().toCharArray();
+  }
+
+  @Override
+  public int getTextLength() throws IOException {
+    return getText().length();
+  }
+
+  @Override
+  public int getTextOffset() throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BsonReader unwrap() {
+    return reader;
+  }
+}

--- a/mongo/src/org/immutables/mongo/bson4jackson/JacksonCodecs.java
+++ b/mongo/src/org/immutables/mongo/bson4jackson/JacksonCodecs.java
@@ -1,0 +1,161 @@
+/*
+   Copyright 2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package org.immutables.mongo.bson4jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.util.BufferRecycler;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.Serializers;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.google.common.annotations.Beta;
+import com.google.common.base.Preconditions;
+import org.bson.AbstractBsonReader;
+import org.bson.BsonReader;
+import org.bson.BsonWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecConfigurationException;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import java.io.IOException;
+
+/**
+ * Utility class to convert to / from {@link CodecRegistry} and {@link ObjectMapper}.
+ *
+ * <p>Please note that Jackson support is currently experimental.
+ */
+@Beta
+public final class JacksonCodecs {
+
+  private JacksonCodecs() {}
+
+  public static CodecRegistry registryFromMapper(final ObjectMapper mapper) {
+    Preconditions.checkNotNull(mapper, "mapper");
+    return new CodecRegistry() {
+      @Override
+      public <T> Codec<T> get(final Class<T> clazz) {
+        final JavaType javaType = TypeFactory.defaultInstance().constructType(clazz);
+        if (!mapper.canSerialize(clazz) || !mapper.canDeserialize(javaType)) {
+          throw new CodecConfigurationException(String.format("%s (javaType: %s) not supported by Jackson Mapper", clazz, javaType));
+        }
+        return new JacksonCodec<>(clazz, mapper);
+      }
+    };
+  }
+
+  public static <T> JsonSerializer<T> serializer(final Codec<T> codec) {
+    return new CodecSerializer<>(codec);
+  }
+
+  public static Serializers serializers(final CodecRegistry registry) {
+    return new Serializers.Base() {
+      @Override
+      public JsonSerializer<?> findSerializer(SerializationConfig config, JavaType type, BeanDescription beanDesc) {
+        try {
+          Codec<?> codec = registry.get(type.getRawClass());
+          return serializer(codec);
+        } catch (CodecConfigurationException e) {
+          return null;
+        }
+      }
+    };
+  }
+
+  public static Module module(final CodecRegistry registry) {
+    Preconditions.checkNotNull(registry, "registry");
+    return new Module() {
+      @Override
+      public String getModuleName() {
+        return JacksonCodecs.class.getSimpleName();
+      }
+
+      @Override
+      public Version version() {
+        return Version.unknownVersion();
+      }
+
+      @Override
+      public void setupModule(SetupContext context) {
+        context.addSerializers(serializers(registry));
+      }
+    };
+  }
+
+  private static class CodecSerializer<T> extends StdSerializer<T> {
+
+    private final Codec<T> codec;
+
+    private CodecSerializer(Codec<T> codec) {
+      super(codec.getEncoderClass());
+      this.codec = codec;
+    }
+
+    @Override
+    public void serialize(T value, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
+      BsonWriter writer = ((BsonGenerator) gen).unwrap();
+      codec.encode(writer, value, EncoderContext.builder().build());
+    }
+  }
+
+  private static class JacksonCodec<T> implements Codec<T> {
+
+    private final Class<T> clazz;
+    private final ObjectMapper mapper;
+
+    private JacksonCodec(Class<T> clazz, ObjectMapper mapper) {
+      this.clazz = Preconditions.checkNotNull(clazz, "clazz");
+      this.mapper = Preconditions.checkNotNull(mapper, "mapper");
+    }
+
+    @Override
+    public T decode(BsonReader reader, DecoderContext decoderContext) {
+      final IOContext ioContext = new IOContext(new BufferRecycler(), null, false);
+      final BsonParser parser = new BsonParser(ioContext, 0, (AbstractBsonReader) reader);
+      try {
+        return (T) mapper.readValue(parser, getEncoderClass());
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public void encode(BsonWriter writer, T value, EncoderContext encoderContext) {
+      final BsonGenerator generator = new BsonGenerator(0, mapper, writer);
+      try {
+        mapper.writerFor(getEncoderClass()).writeValue(generator, value);
+      } catch (IOException e) {
+        throw new RuntimeException("Couldn't serialize [" + value + "] as " + getEncoderClass(), e);
+      }
+    }
+
+    @Override
+    public Class<T> getEncoderClass() {
+      return clazz;
+    }
+  }
+}

--- a/mongo/src/org/immutables/mongo/bson4jackson/package-info.java
+++ b/mongo/src/org/immutables/mongo/bson4jackson/package-info.java
@@ -1,0 +1,24 @@
+/*
+   Copyright 2013-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/**
+ * <p>This package adds support for <a href="http://bsonspec.org/">BSON</a> to
+ * <a href="https://github.com/FasterXML/jackson">Jackson</a> library.
+ *
+ * <p>Jackson support is currently experimental and subject to change (or removal).
+ */
+package org.immutables.mongo.bson4jackson;
+

--- a/mongo/src/org/immutables/mongo/repository/RepositorySetup.java
+++ b/mongo/src/org/immutables/mongo/repository/RepositorySetup.java
@@ -30,7 +30,7 @@ import com.mongodb.WriteConcern;
 import com.mongodb.client.MongoDatabase;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
-import org.immutables.mongo.bson4gson.Codecs;
+import org.immutables.mongo.bson4gson.GsonCodecs;
 import org.immutables.mongo.repository.Repositories.Repository;
 import org.immutables.mongo.types.TypeAdapters;
 
@@ -223,7 +223,7 @@ public final class RepositorySetup {
       // Will be used as a factory for BSON types (if Gson does not have one). By default, uses
       // TypeAdapter(s) from Gson if they're explicitly defined (not a ReflectiveTypeAdapter).
       // Otherwise delegate to BSON codec.
-      TypeAdapterFactory bsonAdapterFactory = Codecs.delegatingTypeAdapterFactory(
+      TypeAdapterFactory bsonAdapterFactory = GsonCodecs.delegatingTypeAdapterFactory(
               MongoClient.getDefaultCodecRegistry()
       );
 
@@ -238,7 +238,7 @@ public final class RepositorySetup {
               .create();
 
       // expose new Gson as CodecRegistry. Using fromRegistries() for caching
-      CodecRegistry codecRegistry = CodecRegistries.fromRegistries(Codecs.codecRegistryFromGson(newGson));
+      CodecRegistry codecRegistry = CodecRegistries.fromRegistries(GsonCodecs.codecRegistryFromGson(newGson));
 
       return codecRegistry(codecRegistry, new FieldNamingStrategy.GsonNamingStrategy(gson));
     }

--- a/mongo/src/org/immutables/mongo/repository/internal/Constraints.java
+++ b/mongo/src/org/immutables/mongo/repository/internal/Constraints.java
@@ -18,10 +18,8 @@ package org.immutables.mongo.repository.internal;
 import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
-
-import javax.annotation.Nullable;
 import java.util.regex.Pattern;
-
+import javax.annotation.Nullable;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/mongo/test/org/immutables/mongo/bson4gson/GsonCodecsTest.java
+++ b/mongo/test/org/immutables/mongo/bson4gson/GsonCodecsTest.java
@@ -14,16 +14,16 @@ import java.util.Date;
 
 import static org.immutables.check.Checkers.check;
 
-public class CodecsTest {
+public class GsonCodecsTest {
 
   @Test
   public void reflectiveTypeAdapter() {
-    check(!Codecs.isReflectiveTypeAdapter(new GsonBuilder().create().getAdapter(BigDecimal.class)));
+    check(!GsonCodecs.isReflectiveTypeAdapter(new GsonBuilder().create().getAdapter(BigDecimal.class)));
   }
 
   @Test
   public void dateCodec() throws IOException {
-    TypeAdapter<Date> adapter = Codecs.typeAdapterFromCodec(new DateCodec());
+    TypeAdapter<Date> adapter = GsonCodecs.typeAdapterFromCodec(new DateCodec());
     Date date = new Date();
     BsonDocument doc = new BsonDocument();
     BsonDocumentWriter writer = new BsonDocumentWriter(doc);

--- a/mongo/test/org/immutables/mongo/bson4jackson/BsonParserTest.java
+++ b/mongo/test/org/immutables/mongo/bson4jackson/BsonParserTest.java
@@ -1,0 +1,151 @@
+/*
+   Copyright 2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package org.immutables.mongo.bson4jackson;
+
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.util.BufferRecycler;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.bson.BsonBinaryReader;
+import org.bson.BsonBinaryWriter;
+import org.bson.BsonWriter;
+import org.bson.io.BasicOutputBuffer;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static org.immutables.check.Checkers.check;
+
+public class BsonParserTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void array() throws Exception {
+    compare("[]");
+    compare("[[]]");
+    compare("[[[]]]");
+    compare("[[], []]");
+    compare("[[], [[]]]");
+    compare("[[], [[]], []]");
+    compare("[1]");
+    compare("[1, 2]");
+    compare("[1, 2, 3]");
+    compare("[true]");
+    compare("[true, true]");
+    compare("[true, true, false]");
+    compare("[0.11, 11.22, 3]");
+    compare("[\"foo\"]");
+    compare("[\"\"]");
+    compare("[\"\", \"\"]");
+    compare("[\"\", \"foo\"]");
+    compare("[\"foo\", \"bar\"]");
+    compare("[1, true, 0, 1.111]");
+    compare("[null]");
+    compare("[null, 1, false]");
+    compare("[0.0, -1.2, 3]");
+    compare("[[0], [1]]");
+    compare("[[0], [], 1]");
+    compare("[true, [], []]");
+    compare("[{}]");
+    compare("[{}, {}]");
+    compare("[{}, {}, {}]");
+    compare("[{\"a\": 1}, {\"b\": null}, {\"c\": false}]");
+    compare("[{\"0\": 1}, [], {\"1\": null}, {}]");
+  }
+
+  @Test
+  public void scalar() throws Exception {
+    compare("0");
+    compare("0.0");
+    compare("-1");
+    compare("-200");
+    compare(Long.toString(Long.MIN_VALUE));
+    compare(Long.toString(Long.MAX_VALUE));
+    compare(Integer.toString(Integer.MIN_VALUE));
+    compare(Integer.toString(Integer.MAX_VALUE));
+    compare(Byte.toString(Byte.MIN_VALUE));
+    compare(Byte.toString(Byte.MAX_VALUE));
+    compare(Short.toString(Short.MIN_VALUE));
+    compare(Short.toString(Short.MAX_VALUE));
+    compare("0.1");
+    compare("-0.1111");
+    compare("-2.222");
+    compare("0.11111111111");
+    compare("true");
+    compare("false");
+    compare("null");
+    compare("\"foo\"");
+    compare("\"\"");
+    compare("\"null\"");
+  }
+
+  @Test
+  public void object() throws Exception {
+    compare("{}");
+    compare("{\"foo\": \"bar\"}");
+    compare("{\"foo\": 1}");
+    compare("{\"foo\": true}");
+    compare("{\"foo\": 0.1}");
+    compare("{\"foo\": null}");
+    compare("{\"foo\": {}}");
+    compare("{\"foo\": []}");
+    compare("{\"foo\": [{}]}");
+    compare("{\"foo\": [{}, {}]}");
+    compare("{\"foo\": [1, 2, 3]}");
+    compare("{\"foo\": [null]}");
+    compare("{\"foo\": \"\"}");
+    compare("{\"foo\": \"2017-09-09\"}");
+    compare("{\"foo\": {\"bar\": \"qux\"}}");
+    compare("{\"foo\": 1, \"bar\": 2}");
+    compare("{\"foo\": [], \"bar\": {}}");
+    compare("{\"foo\": {\"bar\": {\"baz\": true}}}");
+  }
+
+  /**
+   * Converts string to json
+   */
+  private void compare(String string) throws IOException {
+
+    JsonNode expected = mapper.readTree(string);
+
+    // BSON likes encoding full document (not simple elements like BsonValue)
+    if (!expected.isObject()) {
+      ObjectNode temp = mapper.createObjectNode();
+      temp.set("ignore", expected);
+      expected = temp;
+    }
+
+    BasicOutputBuffer buffer = new BasicOutputBuffer();
+    BsonWriter writer = new BsonBinaryWriter(buffer);
+
+    BsonGenerator generator = new BsonGenerator(0, mapper, writer);
+    // write
+    mapper.writeValue(generator, expected);
+
+    BsonBinaryReader reader = new BsonBinaryReader(ByteBuffer.wrap(buffer.toByteArray()));
+    IOContext ioContext = new IOContext(new BufferRecycler(), null, false);
+    BsonParser parser = new BsonParser(ioContext, 0, reader);
+
+    // read
+    JsonNode actual = mapper.readValue(parser, JsonNode.class);
+    check(actual).is(expected);
+  }
+
+}

--- a/mongo/test/org/immutables/mongo/fixture/JacksonRepoTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/JacksonRepoTest.java
@@ -1,0 +1,249 @@
+/*
+   Copyright 2016 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package org.immutables.mongo.fixture;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.github.fakemongo.Fongo;
+import com.google.common.base.Optional;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.BsonDocument;
+import org.bson.BsonNull;
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+import org.bson.types.ObjectId;
+import org.immutables.gson.Gson;
+import org.immutables.mongo.Mongo;
+import org.immutables.mongo.bson4jackson.BsonGenerator;
+import org.immutables.mongo.bson4jackson.BsonParser;
+import org.immutables.mongo.bson4jackson.JacksonCodecs;
+import org.immutables.mongo.repository.RepositorySetup;
+import org.immutables.value.Value;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Date;
+
+import static org.immutables.check.Checkers.check;
+
+/**
+ * Tests for repository using <a href="https://github.com/FasterXML/jackson">Jackson</a> library.
+ * @see JacksonCodecs
+ */
+@Gson.TypeAdapters // TODO perhaps compile warning (for missing @Gson annotation) can be removed ?
+public class JacksonRepoTest {
+
+  private JacksonRepository repository;
+
+  private MongoCollection<BsonDocument> collection;
+
+  @Before
+  public void setUp() throws Exception {
+    MongoDatabase database = new Fongo("myname").getDatabase("foo");
+
+    this.collection = database.getCollection("jackson").withDocumentClass(BsonDocument.class);
+
+    SimpleModule module = new SimpleModule(); // for our local serializers of Date and ObjectId
+    module.addDeserializer(Date.class, new DateDeserializer());
+    module.addSerializer(new DateSerializer());
+    module.addDeserializer(ObjectId.class, new ObjectIdDeserializer());
+    module.addSerializer(new ObjectIdSerializer());
+
+    ObjectMapper mapper = new ObjectMapper()
+            .registerModule(JacksonCodecs.module(MongoClient.getDefaultCodecRegistry()))
+            .registerModule(new GuavaModule())
+            .registerModule(module);
+
+    RepositorySetup setup = RepositorySetup.builder()
+            .database(database)
+            .codecRegistry(JacksonCodecs.registryFromMapper(mapper))
+            .executor(MoreExecutors.newDirectExecutorService())
+            .build();
+
+    this.repository = new JacksonRepository(setup);
+  }
+
+  @Test
+  public void withDate() {
+    final Date date = new Date();
+    final ObjectId id = ObjectId.get();
+    final Jackson expected = ImmutableJackson.builder()
+            .id(id)
+            .prop1("prop1")
+            .prop2("22")
+            .date(new Date(date.getTime()))
+            .build();
+
+    repository.insert(expected).getUnchecked();
+
+    check(collection.count()).is(1L);
+
+    final Jackson actual = repository.findAll().fetchAll().getUnchecked().get(0);
+    check(expected).is(actual);
+
+    final BsonDocument doc = collection.find().first();
+    check(doc.keySet()).hasContentInAnyOrder("_id", "prop1", "prop2", "date");
+    check(doc.get("date").asDateTime().getValue()).is(date.getTime());
+    check(doc.get("_id").asObjectId().getValue()).is(id);
+  }
+
+  /**
+   * persist empty Optional of Date
+   */
+  @Test
+  public void nullDate() {
+    final Jackson expected = ImmutableJackson.builder()
+            .id(ObjectId.get())
+            .prop1("prop11")
+            .prop2("prop22")
+            .build();
+
+    repository.insert(expected).getUnchecked();
+
+    final Jackson actual = repository.findAll()
+            .fetchAll().getUnchecked().get(0);
+
+    check(expected.date().asSet()).isEmpty();
+    check(expected).is(actual);
+    final BsonDocument doc = collection.find().first();
+    check(doc.keySet()).hasContentInAnyOrder("_id", "prop1", "prop2", "date");
+    check(doc.get("date")).is(BsonNull.VALUE);
+  }
+
+  @Test
+  public void criteria() {
+    final Date date = new Date();
+
+    final ObjectId id = ObjectId.get();
+    final Jackson expected = ImmutableJackson.builder()
+            .id(id)
+            .prop1("prop11")
+            .prop2("prop22")
+            .date(date)
+            .build();
+
+    repository.insert(expected).getUnchecked();
+
+    check(repository.find(repository.criteria().prop1("prop11")).fetchAll().getUnchecked()).hasContentInAnyOrder(expected);
+    check(repository.find(repository.criteria().prop1("missing")).fetchAll().getUnchecked()).isEmpty();
+    check(repository.find(repository.criteria().prop2("prop22")).fetchAll().getUnchecked()).hasContentInAnyOrder(expected);
+    check(repository.find(repository.criteria().id(id)).fetchAll().getUnchecked()).hasContentInAnyOrder(expected);
+    check(repository.find(repository.criteria().date(date)).fetchAll().getUnchecked()).hasContentInAnyOrder(expected);
+    check(repository.find(repository.criteria().date(new Date(42))).fetchAll().getUnchecked()).isEmpty();
+  }
+
+  @Mongo.Repository
+  @Value.Immutable
+  @JsonDeserialize(as = ImmutableJackson.class)
+  @JsonSerialize(as = ImmutableJackson.class)
+  interface Jackson {
+
+    @Mongo.Id
+    @JsonProperty("_id")
+    ObjectId id();
+
+    String prop1();
+
+    // TODO Allow querying on changed properties via @JsonPropery("changedProp2")
+    String prop2();
+
+    Optional<Date> date();
+  }
+
+  /**
+   * Custom deserializer for {@link BsonType#OBJECT_ID}
+   */
+  private static class ObjectIdDeserializer extends StdScalarDeserializer<ObjectId> {
+
+    private ObjectIdDeserializer() {
+      super(ObjectId.class);
+    }
+
+    @Override
+    public ObjectId deserialize(JsonParser parser, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+      final BsonReader reader = ((BsonParser) parser).unwrap();
+      return reader.readObjectId();
+    }
+  }
+
+  /**
+   * Custom serializer for {@link BsonType#OBJECT_ID}
+   */
+  private static class ObjectIdSerializer extends StdScalarSerializer<ObjectId> {
+
+    private ObjectIdSerializer() {
+      super(ObjectId.class);
+    }
+
+    @Override
+    public void serialize(ObjectId value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+      final BsonWriter writer = ((BsonGenerator) gen).unwrap();
+      writer.writeObjectId(value);
+    }
+  }
+
+  /**
+   * Custom deserializer for {@link BsonType#DATE_TIME}
+   */
+  private static class DateDeserializer extends StdScalarDeserializer<Date> {
+
+    private DateDeserializer() {
+      super(Date.class);
+    }
+
+    @Override
+    public Date deserialize(JsonParser parser, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+      final BsonReader reader = ((BsonParser) parser).unwrap();
+      return new Date(reader.readDateTime());
+    }
+  }
+
+  /**
+   * Custom serializer to test {@link BsonType#DATE_TIME} in BSON
+   */
+  private static class DateSerializer extends StdScalarSerializer<Date> {
+
+    private DateSerializer() {
+      super(Date.class);
+    }
+
+    @Override
+    public void serialize(Date value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+      final BsonWriter writer = ((BsonGenerator) gen).unwrap();
+      writer.writeDateTime(value.getTime());
+    }
+  }
+
+
+}


### PR DESCRIPTION
Add separate JsonParser (wrapper for [BsonReader](http://mongodb.github.io/mongo-java-driver/3.7/javadoc/org/bson/BsonReader.html)) and JsonGenerator (wrapper for [BsonWriter](http://mongodb.github.io/mongo-java-driver/3.7/javadoc/org/bson/BsonWriter.html)) which delegates streaming operations to mongo java driver.

Add custom CodecRegistry which instantiates Codec(s) based on existing ObjectMapper (serializers / deserializers). All jackson specific classes are located in `bson4jackson` package.

Move Gson classes into separate package (`bson4gson`).

This feature is currently considered experimental (@Beta).

Closes immutables/immutables#835