### PR TITLE
Update copyright year to 2018 (in java and xml headers)

### DIFF
--- a/android-stub/pom.xml
+++ b/android-stub/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2016 Immutables Authors and Contributors
+   Copyright 2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/annotate/pom.xml
+++ b/annotate/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2016 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2016 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/builder/src/org/immutables/builder/Builder.java
+++ b/builder/src/org/immutables/builder/Builder.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2015-2017 Immutables Authors and Contributors
+   Copyright 2015-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/encode/pom.xml
+++ b/encode/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright 2016 Immutables Authors and Contributors
+   Copyright 2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/func/pom.xml
+++ b/func/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2016 Immutables Authors and Contributors
+   Copyright 2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/generator-fixture/pom.xml
+++ b/generator-fixture/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2016 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/generator-processor/pom.xml
+++ b/generator-processor/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2016 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2016 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/generator/src/org/immutables/generator/AnnotationMirrors.java
+++ b/generator/src/org/immutables/generator/AnnotationMirrors.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2014-2015 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2016 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/metainf/pom.xml
+++ b/metainf/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2016 Immutables Authors and Contributors
+   Copyright 2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/metainf/src/org/immutables/metainf/processor/Metaservices.java
+++ b/metainf/src/org/immutables/metainf/processor/Metaservices.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2015-2017 Immutables Authors and Contributors
+   Copyright 2015-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mirror/pom.xml
+++ b/mirror/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2015 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/pom.xml
+++ b/mongo/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2015 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/Wrapper.java
+++ b/mongo/src/org/immutables/mongo/Wrapper.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/bson4gson/BsonReader.java
+++ b/mongo/src/org/immutables/mongo/bson4gson/BsonReader.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/bson4gson/BsonWriter.java
+++ b/mongo/src/org/immutables/mongo/bson4gson/BsonWriter.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/bson4gson/GsonCodecs.java
+++ b/mongo/src/org/immutables/mongo/bson4gson/GsonCodecs.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/bson4gson/package-info.java
+++ b/mongo/src/org/immutables/mongo/bson4gson/package-info.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/concurrent/FluentFuture.java
+++ b/mongo/src/org/immutables/mongo/concurrent/FluentFuture.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/concurrent/FluentFutures.java
+++ b/mongo/src/org/immutables/mongo/concurrent/FluentFutures.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/concurrent/package-info.java
+++ b/mongo/src/org/immutables/mongo/concurrent/package-info.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/repository/Repositories.java
+++ b/mongo/src/org/immutables/mongo/repository/Repositories.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2017 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/repository/RepositorySetup.java
+++ b/mongo/src/org/immutables/mongo/repository/RepositorySetup.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/repository/internal/Constraints.java
+++ b/mongo/src/org/immutables/mongo/repository/internal/Constraints.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/repository/internal/Support.java
+++ b/mongo/src/org/immutables/mongo/repository/internal/Support.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/repository/internal/package-info.java
+++ b/mongo/src/org/immutables/mongo/repository/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/repository/package-info.java
+++ b/mongo/src/org/immutables/mongo/repository/package-info.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/types/Id.java
+++ b/mongo/src/org/immutables/mongo/types/Id.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/src/org/immutables/mongo/types/package-info.java
+++ b/mongo/src/org/immutables/mongo/types/package-info.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mongo/test/org/immutables/mongo/fixture/flags/package-info.java
+++ b/mongo/test/org/immutables/mongo/fixture/flags/package-info.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ordinal/pom.xml
+++ b/ordinal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2015 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ordinal/src/org/immutables/ordinal/ImmutableOrdinalSet.java
+++ b/ordinal/src/org/immutables/ordinal/ImmutableOrdinalSet.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ordinal/src/org/immutables/ordinal/InterningOrdinalDomain.java
+++ b/ordinal/src/org/immutables/ordinal/InterningOrdinalDomain.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ordinal/src/org/immutables/ordinal/OrdinalDomain.java
+++ b/ordinal/src/org/immutables/ordinal/OrdinalDomain.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ordinal/src/org/immutables/ordinal/OrdinalValue.java
+++ b/ordinal/src/org/immutables/ordinal/OrdinalValue.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ordinal/src/org/immutables/ordinal/package-info.java
+++ b/ordinal/src/org/immutables/ordinal/package-info.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ordinal/test/org/immutables/ordinal/Domain.java
+++ b/ordinal/test/org/immutables/ordinal/Domain.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ordinal/test/org/immutables/ordinal/Ord.java
+++ b/ordinal/test/org/immutables/ordinal/Ord.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ordinal/test/org/immutables/ordinal/OrdinalSetTest.java
+++ b/ordinal/test/org/immutables/ordinal/OrdinalSetTest.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ordinal/test/org/immutables/ordinal/SillyOrdinal.java
+++ b/ordinal/test/org/immutables/ordinal/SillyOrdinal.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright 2013-2016 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/serial/pom.xml
+++ b/serial/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2015 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2015 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/testing/src/org/immutables/check/Checkers.java
+++ b/testing/src/org/immutables/check/Checkers.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/testing/src/org/immutables/check/IterableChecker.java
+++ b/testing/src/org/immutables/check/IterableChecker.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/testing/src/org/immutables/check/ObjectChecker.java
+++ b/testing/src/org/immutables/check/ObjectChecker.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/testing/src/org/immutables/check/OptionalChecker.java
+++ b/testing/src/org/immutables/check/OptionalChecker.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/testing/src/org/immutables/check/StringChecker.java
+++ b/testing/src/org/immutables/check/StringChecker.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/testing/src/org/immutables/check/package-info.java
+++ b/testing/src/org/immutables/check/package-info.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/testing/test/org/immutables/check/CheckersTest.java
+++ b/testing/test/org/immutables/check/CheckersTest.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/trees/pom.xml
+++ b/trees/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2016 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/utility/pom.xml
+++ b/utility/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2016 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/pom.xml
+++ b/value-fixture/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014-2016 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyAbstract.java
+++ b/value-fixture/src/org/immutables/fixture/SillyAbstract.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyEntity.java
+++ b/value-fixture/src/org/immutables/fixture/SillyEntity.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyIntWrap.java
+++ b/value-fixture/src/org/immutables/fixture/SillyIntWrap.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyInterned.java
+++ b/value-fixture/src/org/immutables/fixture/SillyInterned.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyMapHolder.java
+++ b/value-fixture/src/org/immutables/fixture/SillyMapHolder.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyMapTup.java
+++ b/value-fixture/src/org/immutables/fixture/SillyMapTup.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyMarshalingRoutines.java
+++ b/value-fixture/src/org/immutables/fixture/SillyMarshalingRoutines.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyPolyHost.java
+++ b/value-fixture/src/org/immutables/fixture/SillyPolyHost.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyPolyHost2.java
+++ b/value-fixture/src/org/immutables/fixture/SillyPolyHost2.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyStructure.java
+++ b/value-fixture/src/org/immutables/fixture/SillyStructure.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyStructureWithId.java
+++ b/value-fixture/src/org/immutables/fixture/SillyStructureWithId.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillySub1.java
+++ b/value-fixture/src/org/immutables/fixture/SillySub1.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillySub2.java
+++ b/value-fixture/src/org/immutables/fixture/SillySub2.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillySub3.java
+++ b/value-fixture/src/org/immutables/fixture/SillySub3.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyTuplie.java
+++ b/value-fixture/src/org/immutables/fixture/SillyTuplie.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyValidatedBuiltValue.java
+++ b/value-fixture/src/org/immutables/fixture/SillyValidatedBuiltValue.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyValidatedConstructedValue.java
+++ b/value-fixture/src/org/immutables/fixture/SillyValidatedConstructedValue.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/SillyValue.java
+++ b/value-fixture/src/org/immutables/fixture/SillyValue.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/encoding/defs/OptionalList2.java
+++ b/value-fixture/src/org/immutables/fixture/encoding/defs/OptionalList2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/value-fixture/src/org/immutables/fixture/subpack/SillySubstructure.java
+++ b/value-fixture/src/org/immutables/fixture/subpack/SillySubstructure.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/test/org/immutables/fixture/ValuesTest.java
+++ b/value-fixture/test/org/immutables/fixture/ValuesTest.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/test/org/immutables/fixture/jackson/ObjectMappedTest.java
+++ b/value-fixture/test/org/immutables/fixture/jackson/ObjectMappedTest.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2014-2017 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-fixture/test/org/immutables/fixture/marshal/MarshallingTest.java
+++ b/value-fixture/test/org/immutables/fixture/marshal/MarshallingTest.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-processor/pom.xml
+++ b/value-processor/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-   Copyright 2014 Immutables Authors and Contributors
+   Copyright 2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-processor/src/org/immutables/value/processor/Gsons.generator
+++ b/value-processor/src/org/immutables/value/processor/Gsons.generator
@@ -1,5 +1,5 @@
 [--
-   Copyright 2014-2016 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-processor/src/org/immutables/value/processor/Repositories.generator
+++ b/value-processor/src/org/immutables/value/processor/Repositories.generator
@@ -1,5 +1,5 @@
 [--
-   Copyright 2014-2015 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-processor/src/org/immutables/value/processor/meta/Constitution.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Constitution.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2014-2015 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttributeFunctions.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttributeFunctions.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2014 Immutables Authors and Contributors
+   Copyright 2013-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/value/pom.xml
+++ b/value/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright 2014-2016 Immutables Authors and Contributors
+   Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Change java and xml (pom.xml) headers to include current year