### PR TITLE
Add org.immutables.value.Generated annotation to nested classes #827

### DIFF
--- a/value-processor/src/org/immutables/value/processor/Gsons.generator
+++ b/value-processor/src/org/immutables/value/processor/Gsons.generator
@@ -133,6 +133,9 @@ public final class [typeAdaptersName] implements TypeAdapterFactory {
 [checkAttributes type]
 [for allAttributes = type.allMarshalingAttributes, t = type.typeAbstract, im = type.typeImmutable]
 
+[if type allowsClasspathAnnotation 'org.immutables.value.Generated']
+@org.immutables.value.Generated(from = "[type.typeAbstract.relativeRaw]", generator = "Gsons")
+[/if]
 @SuppressWarnings({"unchecked", "raw"}) // safe unchecked, types are verified in runtime
 private static class [type.name]TypeAdapter[type.generics] extends TypeAdapter<[t]> {
   [for a in allAttributes]
@@ -165,6 +168,9 @@ private static class [type.name]TypeAdapter[type.generics] extends TypeAdapter<[
 [if type.gsonTypeAdapters.fieldNamingStrategy andnot type.useConstructorOnly]
   [if allAttributes]
 
+  [if type allowsClasspathAnnotation 'org.immutables.value.Generated']
+  @org.immutables.value.Generated(from = "[type.typeAbstract.relativeRaw]", generator = "Gsons")
+  [/if]
   static class [type.name]NamingFields[type.generics] {
   [for a in allAttributes]
     public [a.type] [a.name];

--- a/value-processor/src/org/immutables/value/processor/Repositories.generator
+++ b/value-processor/src/org/immutables/value/processor/Repositories.generator
@@ -232,6 +232,9 @@ public Finder find(Criteria criteria) {
  * Configure exclusion and sort ordering for results using the family of {@code exclude*()} and {@code orderBy*()} attribute-specific methods.
  * @see [type.name]Repository#find(Criteria)
  */
+[if type allowsClasspathAnnotation 'org.immutables.value.Generated']
+@org.immutables.value.Generated(from = "[type.typeAbstract.relativeRaw]", generator = "Repositories")
+[/if]
 [atNotThreadSafe type]
 public static final class Finder extends Repositories.[if type.repository.readonly]Finder[else]FinderWithDelete[/if]<[type.typeDocument], Finder> {
   private final Serialization serialization;
@@ -294,6 +297,9 @@ public Indexer index() {
  * An indexer used to create an index on the {@code "[type.documentName]"} collection if it does not exist by one or more attributes.
  * @see DBCollection#ensure(DBObject, DBObject)
  */
+[if type allowsClasspathAnnotation 'org.immutables.value.Generated']
+@org.immutables.value.Generated(from = "[type.typeAbstract.relativeRaw]", generator = "Repositories")
+[/if]
 [atNotThreadSafe type]
 public static final class Indexer extends Repositories.Indexer<[type.typeDocument], Indexer> {
   private final Serialization serialization;
@@ -341,6 +347,9 @@ public Updater update(Criteria criteria) {
  * {@link #update(Criteria) Given} the criteria updater describes how to perform
  * update operations on sets of documents.
  */
+[if type allowsClasspathAnnotation 'org.immutables.value.Generated']
+@org.immutables.value.Generated(from = "[type.typeAbstract.relativeRaw]", generator = "Repositories")
+[/if]
 [atNotThreadSafe type]
 public static final class Updater extends Repositories.Updater<[type.typeDocument]> {
   private final Serialization serialization;
@@ -356,6 +365,9 @@ public static final class Updater extends Repositories.Updater<[type.typeDocumen
 
 [template generateReplacer Type type]
 
+[if type allowsClasspathAnnotation 'org.immutables.value.Generated']
+@org.immutables.value.Generated(from = "[type.typeAbstract.relativeRaw]", generator = "Repositories")
+[/if]
 [atNotThreadSafe type]
 public static final class Replacer extends Repositories.Replacer<[type.typeDocument], Replacer> {
   protected Replacer([type.name]Repository repository, [type.typeDocument] document, Constraints.ConstraintHost criteria, Constraints.Constraint ordering) {
@@ -366,6 +378,9 @@ public static final class Replacer extends Repositories.Replacer<[type.typeDocum
 
 [template generateModifier Type type]
 
+[if type allowsClasspathAnnotation 'org.immutables.value.Generated']
+@org.immutables.value.Generated(from = "[type.typeAbstract.relativeRaw]", generator = "Repositories")
+[/if]
 [atNotThreadSafe type]
 public static final class Modifier extends Repositories.Modifier<[type.typeDocument], Modifier> {
   private final Serialization serialization;
@@ -615,6 +630,9 @@ public Criteria criteria() {
  * {@code [type.name]Repository.Criteria} is a [type.name] document search query.
  * Call methods on the criteria to add constraints for search queries.
  */
+[if type allowsClasspathAnnotation 'org.immutables.value.Generated']
+@org.immutables.value.Generated(from = "[type.typeAbstract.relativeRaw]", generator = "Repositories")
+[/if]
 @javax.annotation.concurrent.Immutable
 @SuppressWarnings("unchecked")
 public static final class Criteria extends Repositories.Criteria {
@@ -792,6 +810,9 @@ public static final class Criteria extends Repositories.Criteria {
 [template generateSerializationHelpers Type type]
 
 [for allAttributes = type.allMarshalingAttributes]
+[if type allowsClasspathAnnotation 'org.immutables.value.Generated']
+@org.immutables.value.Generated(from = "[type.typeAbstract.relativeRaw]", generator = "Repositories")
+[/if]
 private static class Serialization {
   [for a in allAttributes]
     [if a.requiresMarshalingAdapter]
@@ -825,6 +846,9 @@ private static class Serialization {
   [/for]
   }
 
+  [if type allowsClasspathAnnotation 'org.immutables.value.Generated']
+  @org.immutables.value.Generated(from = "[type.typeAbstract.relativeRaw]", generator = "Repositories")
+  [/if]
   static final class [type.name]NamingFields[type.generics] {
   [for a in allAttributes]
     public [a.type] [a.name];


### PR DESCRIPTION
I've found more nested classes that need to be annotated with `org.immutables.value.Generated`.

* `*.GsonAdapters*.*NamingFields`
* `*.GsonAdapters*.*TypeAdapter`
* `*.*Repository.Criteria`
* `*.*Repository.Finder`
* `*.*Repository.Modifier`
* `*.*Repository.Replacer`
* `*.*Repository.Serialization`
* `*.*Repository.*NamingFields`

It would be great to fix that because tools like JaCoCo interpreting it.

@elucash I'm hungry for a new release with these changes.