### PR TITLE
Allow opt-in to Gradle incremental processing support via -Aimmutable…

### DIFF
--- a/value-processor/src/META-INF/gradle/incremental.annotation.processors
+++ b/value-processor/src/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,2 @@
+org.immutables.processor.ProxyProcessor,dynamic
+org.immutables.value.processor.Processor,dynamic

--- a/value-processor/src/org/immutables/value/processor/Processor.java
+++ b/value-processor/src/org/immutables/value/processor/Processor.java
@@ -16,6 +16,7 @@
 package org.immutables.value.processor;
 
 import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import java.util.Set;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -48,6 +49,19 @@ import org.immutables.value.processor.meta.ValueUmbrellaMirror;
     EncodingMirror.QUALIFIED_NAME,
 })
 public final class Processor extends AbstractGenerator {
+
+  private static final String GRADLE_INCREMENTAL = "immutables.gradle.incremental";
+
+  @Override
+  public Set<String> getSupportedOptions() {
+    ImmutableSet.Builder<String> options = ImmutableSet.builder();
+    options.add(GRADLE_INCREMENTAL);
+    if (processingEnv.getOptions().containsKey(GRADLE_INCREMENTAL)) {
+      options.add("org.gradle.annotation.processing.isolating");
+    }
+    return options.build();
+  }
+
   @Override
   protected void process() {
 


### PR DESCRIPTION
…s.gradle.incremental

By providing a flag for opting in to incremental processing, users can try it out now and if there are any issues we'll be able to fix them (given the processor's fairly easy to reason about 1:n mapping of input to output, I guess no one should run into any in practice). Without the flag, there is no change in behavior for current users.

For #804 (not sure whether to consider it a fix since presumably it should be made default at some point).

