### PR TITLE
Return dynamic builder type instead of always 'this' in from methods.

### DIFF
--- a/value-fixture/src/org/immutables/fixture/modifiable/ModifiableAndImmutableWithBuilderSubclass.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/ModifiableAndImmutableWithBuilderSubclass.java
@@ -1,0 +1,15 @@
+package org.immutables.fixture.modifiable;
+
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Modifiable;
+import org.immutables.value.Value.Style;
+import org.immutables.value.Value.Style.BuilderVisibility;
+
+@Immutable
+@Modifiable
+@Style(builderVisibility = BuilderVisibility.PACKAGE)
+public interface ModifiableAndImmutableWithBuilderSubclass {
+  class Builder extends ImmutableModifiableAndImmutableWithBuilderSubclass.Builder {}
+
+  String getId();
+}

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1317,7 +1317,8 @@ public interface BuildFinal[type.generics] {
   [atCanIgnoreReturnValue type]
   [type.typeAbstract.access]final [builderReturnType type] [type.names.from]([type.typeAbstract.relative] instance) {
     [requireNonNull type](instance, "instance");
-    [dynamicFromModifiableCheck type 'instance' 'this']
+    [let dynamicFromReturnType][builderReturnThis type][/let]
+    [dynamicFromModifiableCheck type 'instance' dynamicFromReturnType]
     [for v in setters]
     [buildFromAttribute v]
     [/for]
@@ -1327,7 +1328,8 @@ public interface BuildFinal[type.generics] {
   [atCanIgnoreReturnValue type]
   public final [builderReturnType type] [type.names.from]([type.typeAbstract.relative] instance) {
     [requireNonNull type](instance, "instance");
-    [dynamicFromModifiableCheck type 'instance' 'this']
+    [let dynamicFromReturnType][builderReturnThis type][/let]
+    [dynamicFromModifiableCheck type 'instance' dynamicFromReturnType]
     [for v in setters]
     [buildFromAttribute v]
     [/for]


### PR DESCRIPTION
I noticed that with 2.7.2, I could not compile classes that are both `@Immutable` and `@Modifiable` that declare a `Builder` subclass. It was returning `this` even though the method signatures were changed to return `[builderReturnThis type]`.

I have added the test fixture blindly, on my machine I'm not able to compile with fixtures with the following cryptic error (let's see what the CI says). But installing a snapshot and trying it in my codebase confirmed the problem was fixed.

```
[INFO] org.immutables.encode .............................. SUCCESS [  0.452 s]
[INFO] org.immutables.value-fixture ....................... FAILURE [  0.164 s]
[INFO] org.immutables.trees ............................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  33.790 s
[INFO] Finished at: 2018-11-10T18:55:50+09:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project value-fixture: Could not resolve dependencies for project org.immutables:value-fixture:jar:2.7.3-SNAPSHOT: Failure to find org.immutables:encode:jar:tests:2.7.3-SNAPSHOT in http://repo.spring.io/libs-milestone/ was cached in the local repository, resolution will not be reattempted until the update interval of spring-milestones has elapsed or updates are forced -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :value-fixture
[18:55] (master) Anuraag:~/git/immutables % git checkout -b modifiable-immutable-builder
```