### PR TITLE
buildFromAttribute: treat all non-primitive attributes as potentially nullable

### DIFF
--- a/value-fixture/src/org/immutables/fixture/nullable/BaseNullableAttribute.java
+++ b/value-fixture/src/org/immutables/fixture/nullable/BaseNullableAttribute.java
@@ -1,0 +1,22 @@
+package org.immutables.fixture.nullable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.immutables.value.Value;
+
+public interface BaseNullableAttribute {
+    @Nullable
+    String attribute();
+
+    @Value.Immutable
+    public interface NullableAttribute extends BaseNullableAttribute {
+    }
+
+    @Value.Immutable
+    public interface NonnullAttribute extends BaseNullableAttribute {
+        @Override
+        @Nonnull
+        String attribute();
+    }
+}

--- a/value-fixture/test/org/immutables/fixture/nullable/NullableAttributesTest.java
+++ b/value-fixture/test/org/immutables/fixture/nullable/NullableAttributesTest.java
@@ -257,4 +257,13 @@ public class NullableAttributesTest {
     check(r.i1()).isNull();
     check(r.l2()).isNull();
   }
+
+  @Test
+  public void sometimesNullableFrom() {
+    check(ImmutableNonnullAttribute.builder()
+        .attribute("foo")
+        .from(ImmutableNullableAttribute.builder().build())
+        .build())
+      .not().isNull();
+  }
 }

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -2201,14 +2201,10 @@ if ([for l in positions.longs][if not for.first] || [/if][disambiguateField type
   [if v.encoding]
 [rr.builderCopyFrom v](instance.[v.names.get]());
   [else if v.collectionType]
-    [if v.nullable]
 [v.atNullabilityLocal][v.type] [v.name]Value = instance.[v.names.get]();
 if ([v.name]Value != null) {
   [v.names.addAll]([v.name]Value);
 }
-    [else]
-[v.names.addAll](instance.[v.names.get]());
-    [/if]
   [else if v.mapType]
     [if v.nullable]
 [v.atNullabilityLocal][v.type] [v.name]Value = instance.[v.names.get]();
@@ -2223,7 +2219,7 @@ if ([v.name]Value != null) {
 if ([v.name]Optional.[optionalPresent v]) {
   [v.names.init]([v.name]Optional);
 }
-  [else if v.nullable]
+  [else if not v.primitive]
 [v.atNullabilityLocal][v.type] [v.name]Value = instance.[v.names.get]();
 if ([v.name]Value != null) {
   [v.names.init]([v.name]Value);


### PR DESCRIPTION
We generate Builder `from` methods for super-interfaces of the type we are generating.
There is no guarantee that the super-interface has the same characteristics, in particular, it may have a "wider" type that includes null.

buildFromAttribute uses the local type's idea of whether an attribute is null.

This means if you have a sub-interface that specializes an attribute to `@Nonnull`, it may incorrectly assume that the super-type *also* declared the attribute as `@Nonnull`, when in fact it is legitimate for it to be `@Nullable` (since it is a wider type).

This proposed change treats all reference attributes as potentially nullable while building.  There should (🤞) be no performance impact as the getters will be inlined and the JVM is very good at optimizing impossible null checks.

Please let me know if you see a better way to fix this, or an error with my logic.  Thanks!