### PR TITLE
Stand-alone Criteria API to query different data-sources (initial draft)

### DIFF
--- a/criteria/README.md
+++ b/criteria/README.md
@@ -1,0 +1,26 @@
+This module generates Criteria classes based on immutable model.
+
+Generated classes allow type-safe query building which can be evaluated on destination data-source.
+
+Conversion between criteria and native query is happening at runtime using visitor pattern.
+
+### Missing functionality / Remaining Questions : 
+1. (sub-)Criteria on Iterables. Example 
+    ```java
+    user.friends.anyMatch(FriendCriteria.create().age().greaterThan(22));
+    user.friends.noneMatch(FriendCriteria.create().age().greaterThan(22))
+    user.friends.allMatch(FriendCriteria.create().age().greaterThan(22));
+   
+    // something similar for optionals
+    ```
+2. Combining criterias (using `AND`s / `OR`s)
+3. Nested criterias
+4. Projections
+5. Aggregations
+6. DSL is not restrictive enough.
+   ```java
+   // one can write something like this
+   criteria.or().or().or();
+   criteria.age().greaterThan(111).or().or(); // or this
+   ```
+7. How are we better than [QueryDSL](http://www.querydsl.com/) ?

--- a/criteria/pom.xml
+++ b/criteria/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+   Copyright 2014-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>immutables</artifactId>
+    <groupId>org.immutables</groupId>
+    <version>2.7.6-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>criteria</artifactId>
+  <name>${project.groupId}.${project.artifactId}</name>
+  <description>
+    Annotation and runtime support to generate criteria classes based on immutables model
+  </description>
+
+  <dependencies>
+    <dependency>
+      <!-- Guava and jsr 305 annotations are used as required utility.-->
+      <groupId>org.immutables.dependency</groupId>
+      <artifactId>utility</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <!-- compile only meta-inf/services generator -->
+      <groupId>org.immutables</groupId>
+      <artifactId>metainf</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>testing</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/criteria/src/org/immutables/criteria/Criteria.java
+++ b/criteria/src/org/immutables/criteria/Criteria.java
@@ -1,0 +1,35 @@
+/*
+   Copyright 2013-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package org.immutables.criteria;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Immutable classes annotated with this annotation will have Criteria class automatically generated.
+ *
+ * <p>New class can be used to query various data-sources like Mongo, Elastic etc. in a type-safe manner.</p>
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Criteria {
+
+}

--- a/criteria/src/org/immutables/criteria/Disjunction.java
+++ b/criteria/src/org/immutables/criteria/Disjunction.java
@@ -1,0 +1,26 @@
+/*
+   Copyright 2013-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package org.immutables.criteria;
+
+/**
+ * Combines criteria(s) using logical {@code OR}.
+ */
+public interface Disjunction<C extends DocumentCriteria<C, T>, T> {
+
+  DocumentCriteria<C, T> or();
+
+}

--- a/criteria/src/org/immutables/criteria/DocumentCriteria.java
+++ b/criteria/src/org/immutables/criteria/DocumentCriteria.java
@@ -1,0 +1,28 @@
+/*
+   Copyright 2013-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package org.immutables.criteria;
+
+/**
+ * Base class of Criteria API. Right now used as a marker interface.
+ * Generated code extends this class.
+ *
+ * @param <C> Criteria self-type, allowing {@code this}-returning methods to avoid needing subclassing
+ * @param <T> type of the document being evaluated by this criteria
+ */
+public interface DocumentCriteria<C extends DocumentCriteria<C, T>, T> {
+
+}

--- a/criteria/src/org/immutables/criteria/ValueCriteria.java
+++ b/criteria/src/org/immutables/criteria/ValueCriteria.java
@@ -1,0 +1,27 @@
+/*
+   Copyright 2013-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package org.immutables.criteria;
+
+/**
+ * Base class for direct attribute comparison (like {@code foo = 'bar'}).
+ *
+ * @param <C> Criteria self-type, allowing {@code this}-returning methods to avoid needing subclassing
+ * @param <T> type of the document being evaluated by this criteria
+ */
+public interface ValueCriteria<C extends DocumentCriteria<C, T>, T> {
+
+}

--- a/criteria/src/org/immutables/criteria/constraints/BooleanCriteria.java
+++ b/criteria/src/org/immutables/criteria/constraints/BooleanCriteria.java
@@ -1,0 +1,38 @@
+/*
+   Copyright 2013-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.criteria.constraints;
+
+
+import org.immutables.criteria.DocumentCriteria;
+
+/**
+ * Very simple criteria for booleans just has {@code true} / {@code false} checks.
+ */
+public class BooleanCriteria<C extends DocumentCriteria<C, T>, T> extends ObjectCriteria<Boolean, C, T> {
+
+  public BooleanCriteria(String name, Constraints.Constraint constraint, CriteriaCreator<C, T> creator) {
+    super(name, constraint, creator);
+  }
+
+  public C isTrue() {
+    return creator.create(constraint.equal(name, false, Boolean.TRUE));
+  }
+
+  public C isFalse() {
+    return creator.create(constraint.equal(name, false, Boolean.FALSE));
+  }
+
+}

--- a/criteria/src/org/immutables/criteria/constraints/ComparableCriteria.java
+++ b/criteria/src/org/immutables/criteria/constraints/ComparableCriteria.java
@@ -1,0 +1,76 @@
+/*
+   Copyright 2013-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.criteria.constraints;
+
+
+import com.google.common.collect.Range;
+import org.immutables.criteria.DocumentCriteria;
+
+/**
+ * Criteria for comparables (like {@code >, <=, >} and ranges).
+ */
+public class ComparableCriteria<V extends Comparable<V>, C extends DocumentCriteria<C, T>, T>
+        extends ObjectCriteria<V, C, T> {
+
+  public ComparableCriteria(String name, Constraints.Constraint constraint, CriteriaCreator<C, T> creator) {
+    super(name, constraint, creator);
+  }
+
+  /**
+   * Checks that attribute is in {@code range}.
+   */
+  public C isIn(Range<V> range) {
+    return creator.create(constraint.range(name, false, range));
+  }
+
+  /**
+   * Checks that attribute is <i>not</i> in {@code range}.
+   */
+  public C isNotIn(Range<V> range) {
+    return creator.create(constraint.range(name, true, range));
+  }
+
+  /**
+   * Checks that attribute is less than (but not equal to) {@code upper}.
+   * <p>Use {@link #isAtMost(Comparable)} for less <i>or equal</i> comparison</p>
+   */
+  public C isLessThan(V upper) {
+    return isIn(Range.lessThan(upper));
+  }
+
+  /**
+   * Checks that attribute is greater than (but not equal to)  {@code lower}.
+   * <p>Use {@link #isAtLeast(Comparable)} for greater <i>or equal</i> comparison</p>
+   */
+  public C isGreaterThan(V lower) {
+    return isIn(Range.greaterThan(lower));
+  }
+
+  /**
+   * Checks that attribute is less than or equal to {@code upperInclusive}.
+   */
+  public C isAtMost(V upperInclusive) {
+    return isIn(Range.atMost(upperInclusive));
+  }
+
+  /**
+   * Checks that attribute is greater or equal to {@code lowerInclusive}.
+   */
+  public C isAtLeast(V lowerInclusive) {
+    return isIn(Range.atLeast(lowerInclusive));
+  }
+
+}

--- a/criteria/src/org/immutables/criteria/constraints/Constraints.java
+++ b/criteria/src/org/immutables/criteria/constraints/Constraints.java
@@ -1,0 +1,227 @@
+/*
+   Copyright 2013-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.criteria.constraints;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
+
+import javax.annotation.Nullable;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Support class for constraints
+ */
+public final class Constraints {
+
+  private Constraints() {}
+
+  /**
+   * This "host" could accepts {@link ConstraintVisitor}s. Allows evaluation of criterias.
+   */
+  public interface ConstraintHost {
+    <V extends ConstraintVisitor<V>> V accept(V visitor);
+  }
+
+  public interface ConstraintVisitor<V extends ConstraintVisitor<V>> {
+    V in(String name, boolean negate, Iterable<?> values);
+
+    V equal(String name, boolean negate, @Nullable Object value);
+
+    V range(String name, boolean negate, Range<?> range);
+
+    V size(String name, boolean negate, int size);
+
+    V present(String name, boolean negate);
+
+    V match(String name, boolean negate, Pattern pattern);
+
+    V nested(String name, ConstraintHost constraints);
+
+    V disjunction();
+  }
+
+
+  private static final class InConstraint extends ConsConstraint {
+    InConstraint(Constraint tail, String name, boolean negate, Iterable<?> value) {
+      super(tail, name, negate, ImmutableSet.copyOf(value));
+    }
+
+    @Override
+    <V extends ConstraintVisitor<V>> V dispatch(V visitor) {
+      return visitor.in(name, negate, (Iterable<?>) value);
+    }
+  }
+
+  private static final class EqualToConstraint extends ConsConstraint {
+    EqualToConstraint(Constraint tail, String name, boolean negate, Object value) {
+      super(tail, name, negate, value);
+    }
+
+    @Override
+    <V extends ConstraintVisitor<V>> V dispatch(V visitor) {
+      return visitor.equal(name, negate, value);
+    }
+  }
+
+  private static final class RangeConstraint extends ConsConstraint {
+    RangeConstraint(Constraint tail, String name, boolean negate, Range<?> value) {
+      super(tail, name, negate, checkNotNull(value));
+    }
+
+    @Override
+    <V extends ConstraintVisitor<V>> V dispatch(V visitor) {
+      return visitor.range(name, negate, (Range<?>) value);
+    }
+  }
+
+  private static final class SizeConstraint extends ConsConstraint {
+    SizeConstraint(Constraint tail, String name, boolean negate, int value) {
+      super(tail, name, negate, value);
+    }
+
+    @Override
+    <V extends ConstraintVisitor<V>> V dispatch(V visitor) {
+      return visitor.size(name, negate, (Integer) value);
+    }
+  }
+
+  private static final class PresenseConstraint extends ConsConstraint {
+    PresenseConstraint(Constraint tail, String name, boolean negate) {
+      super(tail, name, negate, null);
+    }
+
+    @Override
+    <V extends ConstraintVisitor<V>> V dispatch(V visitor) {
+      return visitor.present(name, negate);
+    }
+  }
+
+  private static final class NestedConstraint extends ConsConstraint {
+    NestedConstraint(Constraint tail, String name, ConstraintHost value) {
+      super(tail, name, false, value);
+    }
+
+    @Override
+    <V extends ConstraintVisitor<V>> V dispatch(V visitor) {
+      return visitor.nested(name, (ConstraintHost) value);
+    }
+  }
+
+  private static final class DisjunctionConstraint extends Constraint {
+    private final Constraint tail;
+
+    DisjunctionConstraint(Constraint tail) {
+      this.tail = tail;
+    }
+
+    @Override
+    public <V extends ConstraintVisitor<V>> V accept(V visitor) {
+      return tail.accept(visitor).disjunction();
+    }
+  }
+
+  private static final Constraint NIL = new Constraint() {
+    @Override
+    public final <V extends ConstraintVisitor<V>> V accept(V visitor) {
+      return visitor;
+    }
+
+    @Override
+    public boolean isNil() {
+      return true;
+    }
+  };
+
+  public static Constraint nilConstraint() {
+    return NIL;
+  }
+
+  public abstract static class Constraint implements ConstraintVisitor<Constraint>, ConstraintHost {
+
+    public boolean isNil() {
+      return false;
+    }
+
+    @Override
+    public Constraint in(String name, boolean negate, Iterable<?> values) {
+      return new InConstraint(this, name, negate, values);
+    }
+
+    @Override
+    public Constraint equal(String name, boolean negate, @Nullable Object value) {
+      return new EqualToConstraint(this, name, negate, value);
+    }
+
+    @Override
+    public Constraint range(String name, boolean negate, Range<?> range) {
+      return new RangeConstraint(this, name, negate, range);
+    }
+
+    @Override
+    public Constraint size(String name, boolean negate, int size) {
+      return new SizeConstraint(this, name, negate, size);
+    }
+
+    @Override
+    public Constraint present(String name, boolean negate) {
+      return new PresenseConstraint(this, name, negate);
+    }
+
+    @Override
+    public Constraint match(String name, boolean negate, Pattern pattern) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Constraint disjunction() {
+      return new DisjunctionConstraint(this);
+    }
+
+    @Override
+    public Constraint nested(String name, ConstraintHost constraints) {
+      return new NestedConstraint(this, name, constraints);
+    }
+  }
+
+  private abstract static class ConsConstraint extends Constraint {
+    final Constraint tail;
+    final String name;
+    final boolean negate;
+    @Nullable
+    final Object value;
+
+    ConsConstraint(
+            Constraint tail,
+            String name,
+            boolean negate,
+            @Nullable Object value) {
+      this.tail = checkNotNull(tail);
+      this.name = checkNotNull(name);
+      this.value = value;
+      this.negate = negate;
+    }
+
+    @Override
+    public final <V extends ConstraintVisitor<V>> V accept(V visitor) {
+      return dispatch(tail.accept(visitor));
+    }
+
+    abstract <V extends ConstraintVisitor<V>> V dispatch(V visitor);
+  }
+
+}

--- a/criteria/src/org/immutables/criteria/constraints/CriteriaCreator.java
+++ b/criteria/src/org/immutables/criteria/constraints/CriteriaCreator.java
@@ -1,0 +1,27 @@
+/*
+   Copyright 2013-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.criteria.constraints;
+
+import org.immutables.criteria.DocumentCriteria;
+
+/**
+ * Creates document criteria from a constraint.
+ */
+public interface CriteriaCreator<C extends DocumentCriteria<C, T>, T> {
+
+  C create(Constraints.Constraint constraint);
+
+}

--- a/criteria/src/org/immutables/criteria/constraints/ObjectCriteria.java
+++ b/criteria/src/org/immutables/criteria/constraints/ObjectCriteria.java
@@ -1,0 +1,86 @@
+/*
+   Copyright 2013-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package org.immutables.criteria.constraints;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import org.immutables.criteria.DocumentCriteria;
+import org.immutables.criteria.ValueCriteria;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Comparing directly values of an attribute.
+ *
+ * @param <V> attribute type for which criteria is applied
+ * @param <C> Criteria self-type, allowing {@code this}-returning methods to avoid needing subclassing
+ * @param <T> type of the document being evaluated by this criteria
+ */
+public class ObjectCriteria<V, C extends DocumentCriteria<C, T>, T> implements ValueCriteria<C, T> {
+
+  final String name;
+  final Constraints.Constraint constraint;
+  final CriteriaCreator<C, T> creator;
+
+  ObjectCriteria(String name, Constraints.Constraint constraint, CriteriaCreator<C, T> creator) {
+    this.name = Preconditions.checkNotNull(name, "name");
+    this.constraint = Preconditions.checkNotNull(constraint, "constraint");
+    this.creator = Preconditions.checkNotNull(creator, "creator");
+  }
+
+  public C isEqualTo(V value) {
+    return creator.create(constraint.equal(name, false, value));
+  }
+
+  public C isNotEqualTo(V value) {
+    return creator.create(constraint.equal(name, true, value));
+  }
+
+  public C isIn(V v1, V v2, V ... rest) {
+    final List<V> values = new ArrayList<>(2 + rest.length);
+    values.add(v1);
+    values.add(v2);
+    for (V v: rest) {
+      values.add(v);
+    }
+
+    return isIn(values);
+  }
+
+  public C isNotIn(V v1, V v2, V ... rest) {
+    final List<V> values = new ArrayList<>(2 + rest.length);
+    values.add(v1);
+    values.add(v2);
+    for (V v: rest) {
+      values.add(v);
+    }
+
+    return isNotIn(values);
+  }
+
+  public C isIn(Iterable<? super V> values) {
+    Preconditions.checkNotNull(values, "values");
+    return creator.create(constraint.in(name, false, ImmutableList.copyOf(values)));
+  }
+
+  public C isNotIn(Iterable<? super V> values) {
+    Preconditions.checkNotNull(values, "values");
+    return creator.create(constraint.in(name, true, ImmutableList.copyOf(values)));
+  }
+
+}

--- a/criteria/src/org/immutables/criteria/constraints/OptionalCriteria.java
+++ b/criteria/src/org/immutables/criteria/constraints/OptionalCriteria.java
@@ -1,0 +1,39 @@
+/*
+   Copyright 2013-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package org.immutables.criteria.constraints;
+
+import org.immutables.criteria.DocumentCriteria;
+
+/**
+ * Criteria for optional attributes.
+ */
+// TODO what should be the type of V be in ObjectCriteria ? java8.util.Optional<V> or guava.Optional<V> ?
+public class OptionalCriteria<V, C extends DocumentCriteria<C, T>, T> extends ObjectCriteria<V, C, T> {
+
+  public OptionalCriteria(String name, Constraints.Constraint constraint, CriteriaCreator<C, T> creator) {
+    super(name, constraint, creator);
+  }
+
+  public C isPresent() {
+    return creator.create(constraint.present(name, false));
+  }
+
+  public C isEmpty() {
+    return creator.create(constraint.present(name, true));
+  }
+
+}

--- a/criteria/src/org/immutables/criteria/constraints/ReflectionEvaluator.java
+++ b/criteria/src/org/immutables/criteria/constraints/ReflectionEvaluator.java
@@ -1,0 +1,199 @@
+/*
+   Copyright 2013-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package org.immutables.criteria.constraints;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Range;
+import org.immutables.criteria.DocumentCriteria;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Evaluator (predicate) based on reflection. Uses criteria visitor API to construct the predicate.
+ * <p>Probably most useful in testing scenarios</p>
+ */
+public class ReflectionEvaluator<C extends DocumentCriteria<C, T>, T> implements Predicate<T> {
+
+  private final DocumentCriteria<C, T> criteria;
+
+  private ReflectionEvaluator(DocumentCriteria<C, T> criteria) {
+    this.criteria = Preconditions.checkNotNull(criteria, "criteria");
+  }
+
+  /**
+   * Factory method to create refection-based evaluator.
+   */
+  public static <C extends DocumentCriteria<C, T>, T> ReflectionEvaluator<C, T> of(DocumentCriteria<C, T> criteria) {
+    return new ReflectionEvaluator<>(criteria);
+  }
+
+  @Override
+  public boolean apply(T input) {
+    Preconditions.checkNotNull(input, "input");
+    final Constraints.ConstraintHost host = (Constraints.ConstraintHost) criteria;
+    final LocalVisitor<T> visitor = new LocalVisitor<>(new FieldExtractor<T>(input));
+    host.accept(visitor);
+    return visitor.result();
+  }
+
+  interface ValueExtractor<T> {
+    @Nullable
+    Object extract(String name);
+  }
+
+  private static class FieldExtractor<T> implements ValueExtractor<T> {
+    private final T object;
+    private final Class<T> klass;
+
+    private FieldExtractor(T object) {
+      this.object = object;
+      this.klass = (Class<T>) object.getClass();
+    }
+
+    @Nullable
+    @Override
+    public Object extract(String name) {
+      try {
+        // TODO caching
+        final Field field = klass.getDeclaredField(name);
+        if (!field.isAccessible()) {
+          field.setAccessible(true);
+        }
+        return field.get(object);
+      } catch (NoSuchFieldException | IllegalAccessException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private static class LocalVisitor<T> implements Constraints.ConstraintVisitor<LocalVisitor<T>> {
+
+    private final ValueExtractor<T> extractor;
+    private boolean previous;
+    private boolean current;
+
+    private LocalVisitor(ValueExtractor<T> extractor) {
+      this.extractor = Preconditions.checkNotNull(extractor, "extractor");
+      this.previous = false;
+      this.current = true;
+    }
+
+    private boolean skipEvaluation() {
+      return previous || !current;
+    }
+
+    private boolean result() {
+      return previous || current;
+    }
+
+    @Override
+    public LocalVisitor<T> in(String name, boolean negate, Iterable<?> values) {
+      if (skipEvaluation()) {
+        return this;
+      }
+
+      final Object extracted = extractor.extract(name);
+
+      final boolean result = Iterables.any(values, new Predicate<Object>() {
+        @Override
+        public boolean apply(@Nullable Object input) {
+          return Objects.equals(extracted, input);
+        }
+      });
+
+      current = negate != result;
+      return this;
+    }
+
+    @Override
+    public LocalVisitor<T> equal(String name, boolean negate, @Nullable Object value) {
+      if (skipEvaluation()) {
+        return this;
+      }
+      final Object extracted = extractor.extract(name);
+      final boolean result = Objects.equals(value, extracted);
+      current = negate != result;
+      return this;
+    }
+
+    @Override
+    public LocalVisitor<T> range(String name, boolean negate, Range range) {
+      if (skipEvaluation()) {
+        return this;
+      }
+
+      final Object extracted = extractor.extract(name);
+      final boolean result;
+      if (extracted == null) {
+        result = false;
+      } else if (extracted instanceof Comparable) {
+        result = range.contains((Comparable<?>) extracted);
+      } else {
+        throw new IllegalArgumentException(String.format("Not a comparable %s: %s", extracted.getClass(), extracted));
+      }
+
+      current = negate != result;
+      return this;
+    }
+
+    @Override
+    public LocalVisitor<T> size(String name, boolean negate, int size) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LocalVisitor<T> present(String name, boolean negate) {
+      if (skipEvaluation()) {
+        return this;
+      }
+
+      final Object extracted = extractor.extract(name);
+      final boolean result;
+      if (extracted instanceof Optional) {
+        result = ((Optional) extracted).isPresent();
+      } else {
+        // probably java8 Optional
+        result = extracted != null;
+      }
+      current = negate != result;
+      return this;
+    }
+
+    @Override
+    public LocalVisitor<T> match(String name, boolean negate, Pattern pattern) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LocalVisitor<T> nested(String name, Constraints.ConstraintHost constraints) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LocalVisitor<T> disjunction() {
+      previous = current;
+      current = true;
+      return this;
+    }
+  }
+}

--- a/criteria/src/org/immutables/criteria/constraints/StringCriteria.java
+++ b/criteria/src/org/immutables/criteria/constraints/StringCriteria.java
@@ -1,0 +1,50 @@
+/*
+   Copyright 2013-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package org.immutables.criteria.constraints;
+
+import org.immutables.criteria.DocumentCriteria;
+
+/**
+ * String specific criterias like {@code isEmpty}, {@code contains} etc.
+ */
+public class StringCriteria<C extends DocumentCriteria<C, T>, T> extends ComparableCriteria<String, C, T> {
+
+  public StringCriteria(String name, Constraints.Constraint constraint, CriteriaCreator<C, T> creator) {
+    super(name, constraint, creator);
+  }
+
+  public C isEmpty() {
+    return creator.create(constraint.equal(name, false, ""));
+  }
+
+  public C isNotEmpty() {
+    return creator.create(constraint.equal(name, true, ""));
+  }
+
+  public C contains(CharSequence other) {
+    throw new UnsupportedOperationException();
+  }
+
+  public C startsWith(CharSequence prefix) {
+    throw new UnsupportedOperationException();
+  }
+
+  public C endsWith(CharSequence suffix) {
+    throw new UnsupportedOperationException();
+  }
+
+}

--- a/criteria/test/org/immutables/criteria/fixture/Person.java
+++ b/criteria/test/org/immutables/criteria/fixture/Person.java
@@ -1,0 +1,19 @@
+package org.immutables.criteria.fixture;
+
+import com.google.common.base.Optional;
+import org.immutables.criteria.Criteria;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Criteria
+public interface Person {
+
+  String firstName();
+
+  Optional<String> lastName();
+
+  boolean isMarried();
+
+  int age();
+
+}

--- a/criteria/test/org/immutables/criteria/fixture/ReflectionTest.java
+++ b/criteria/test/org/immutables/criteria/fixture/ReflectionTest.java
@@ -1,0 +1,58 @@
+package org.immutables.criteria.fixture;
+
+import org.immutables.criteria.constraints.ReflectionEvaluator;
+import org.junit.Test;
+
+import static org.immutables.check.Checkers.check;
+
+public class ReflectionTest {
+
+  @Test
+  public void reflection() {
+    final PersonCriteria crit = PersonCriteria.create();
+    final ImmutablePerson person = ImmutablePerson.builder().firstName("John").age(22).isMarried(false).build();
+
+    check(evaluate(crit, person));
+    check(!evaluate(crit.age.isEqualTo(11), person));
+    check(evaluate(crit.age.isEqualTo(11), person.withAge(11)));
+    check(evaluate(crit.age.isEqualTo(22).firstName.isEqualTo("John"), person));
+    check(!evaluate(crit.age.isEqualTo(22).firstName.isEqualTo("Marry"), person));
+    check(evaluate(crit.age.isEqualTo(22).firstName.isEqualTo("Marry").or()
+            .firstName.isEqualTo("John"), person));
+
+    check(!evaluate(crit.age.isIn(1, 2, 3), person));
+    check(evaluate(crit.age.isIn(22, 23, 24), person));
+    check(!evaluate(crit.isMarried.isTrue(), person));
+    check(evaluate(crit.isMarried.isFalse(), person));
+    check(evaluate(crit.isMarried.isEqualTo(false), person));
+
+    check(evaluate(crit.age.isAtLeast(22), person));
+    check(!evaluate(crit.age.isAtLeast(23), person));
+    check(evaluate(crit.lastName.isEmpty(), person));
+    check(!evaluate(crit.lastName.isPresent(), person));
+    check(evaluate(crit.lastName.isPresent(), person.withLastName("Smith")));
+    check(!evaluate(crit.lastName.isEmpty(), person.withLastName("Smith")));
+  }
+
+  @Test
+  public void disjunction() {
+    final PersonCriteria crit = PersonCriteria.create();
+    final ImmutablePerson person = ImmutablePerson.builder().firstName("John").age(22).isMarried(false).build();
+
+    check(evaluate(crit.age.isEqualTo(21).or().age.isEqualTo(22), person));
+    check(!evaluate(crit.age.isEqualTo(1).or().age.isEqualTo(2), person));
+    check(evaluate(crit.age.isEqualTo(1).or().firstName.isEqualTo("John"), person));
+    check(!evaluate(crit.age.isEqualTo(1).or().firstName.isNotEqualTo("John"), person));
+  }
+
+  @Test
+  public void weird() {
+    // hmm weird DSL
+    PersonCriteria.create().or().or().age.isLessThan(2);
+    PersonCriteria.create().age.isLessThan(2).or().or();
+  }
+
+  private static boolean evaluate(PersonCriteria criteria, Person person) {
+    return ReflectionEvaluator.of(criteria).apply(person);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <module>builder</module>
     <module>android-stub</module>
     <module>gson</module>
+    <module>criteria</module>
     <module>mongo</module>
     <module>func</module>
     <module>value-processor</module>

--- a/value-processor/src/org/immutables/value/processor/Criteria.generator
+++ b/value-processor/src/org/immutables/value/processor/Criteria.generator
@@ -1,0 +1,132 @@
+[--
+   Copyright 2014-2018 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+--]
+[template public generate]
+  [for type in values.values if type.generateCriteria]
+    [if type.kind.isValue andnot type.generics]
+[output.java type.package (type.name 'Criteria') type.element]
+[type.sourceHeader]
+[generateCriteria type]
+[/output.java]
+    [else]
+[output.error]
+Use @Criteria to annotate @Value.Immutable abstract value types with no type variables
+[/output.error]
+    [/if]
+  [/for]
+[/template]
+
+[template generateCriteria Type type]
+[if type.package]
+package [type.package];
+[/if]
+
+import org.immutables.criteria.Disjunction;
+import org.immutables.criteria.DocumentCriteria;
+import org.immutables.criteria.ValueCriteria;
+import org.immutables.criteria.constraints.CriteriaCreator;
+import org.immutables.criteria.constraints.Constraints;
+import org.immutables.criteria.constraints.OptionalCriteria;
+import org.immutables.criteria.constraints.ObjectCriteria;
+import org.immutables.criteria.constraints.StringCriteria;
+import org.immutables.criteria.constraints.BooleanCriteria;
+import org.immutables.criteria.constraints.ComparableCriteria;
+
+import com.google.common.base.Preconditions;
+
+[for starImport in type.requiredSourceStarImports]
+import [starImport];
+[/for]
+
+/**
+ * A {@code [type.name]Criteria} provides type-safe API for retrieving documents
+ * from a generic data-source.
+ * <p>This class is immutable and thus thread-safe.</p>
+ */
+[if type allowsClasspathAnnotation 'javax.annotation.concurrent.ThreadSafe']
+@javax.annotation.concurrent.ThreadSafe
+[/if]
+@javax.annotation.concurrent.Immutable
+[atGenerated type]
+[type.typeDocument.access]final class [type.name]Criteria implements DocumentCriteria<[type.name]Criteria, [type.typeDocument]>,
+                                        Disjunction<[type.name]Criteria, [type.name]>, Constraints.ConstraintHost {
+
+   private final Constraints.Constraint constraint;
+
+   // public fields
+   [for a in type.allMarshalingAttributes]
+   [if not a.collectionType]
+   public final [criteriaType a type] [a.name];
+   [/if]
+   [/for]
+
+   private [type.name]Criteria(Constraints.Constraint constraint) {
+       this.constraint = Preconditions.checkNotNull(constraint, "constraint");
+   [for a in type.allMarshalingAttributes]
+   [if not a.collectionType]
+       this.[a.name] = new [criteriaType a type]("[a.name]", constraint, creator());
+   [/if]
+   [/for]
+   }
+
+   public static [type.name]Criteria create() {
+        return new [type.name]Criteria(Constraints.nilConstraint());
+   }
+
+   @Override
+   public <V extends Constraints.ConstraintVisitor<V>> V accept(V visitor) {
+       return constraint.accept(visitor);
+   }
+
+   @Override
+   public [type.name]Criteria or() {
+       return new [type.name]Criteria(constraint.disjunction());
+   }
+
+   /**
+    * Used to construct this criteria based on existing {@link Constraints.Constraint}
+    */
+   private static CriteriaCreator<[type.name]Criteria, [type.name]> creator() {
+      return new CriteriaCreator<[type.name]Criteria, [type.name]>() {
+         @Override
+         public [type.name]Criteria create(Constraints.Constraint constraint) {
+            return new [type.name]Criteria(constraint);
+         }
+      };
+   }
+
+}
+[/template]
+
+
+[template criteriaType Attribute a Type type][output.trim]
+[if a.boolean]
+BooleanCriteria<[type.name]Criteria, [type.name]>
+[else if a.stringType]
+StringCriteria<[type.name]Criteria, [type.name]>
+[else if a.optionalType]
+OptionalCriteria<[a.wrappedElementType], [type.name]Criteria, [type.name]>
+[else if a.comparable]
+ComparableCriteria<[a.wrappedElementType], [type.name]Criteria, [type.name]>
+[else]
+ObjectCriteria<[a.wrappedElementType], [type.name]Criteria, [type.name]>
+[/if]
+[/output.trim][/template]
+
+[template atGenerated Type type]
+[if type allowsClasspathAnnotation 'org.immutables.value.Generated']
+@org.immutables.value.Generated(from = "[type.typeAbstract.relativeRaw]", generator = "Criteria")
+[/if]
+[/template]

--- a/value-processor/src/org/immutables/value/processor/Criteria.java
+++ b/value-processor/src/org/immutables/value/processor/Criteria.java
@@ -1,0 +1,21 @@
+/*
+   Copyright 2014 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.value.processor;
+
+import org.immutables.generator.Generator;
+
+@Generator.Template
+abstract class Criteria extends ValuesTemplate {}

--- a/value-processor/src/org/immutables/value/processor/Processor.java
+++ b/value-processor/src/org/immutables/value/processor/Processor.java
@@ -77,6 +77,9 @@ public final class Processor extends AbstractGenerator {
     if (round.environment().hasGsonLib()) {
       invoke(new Generator_Gsons().usingValues(values).generate());
     }
+    if (round.environment().hasCriteriaModule()) {
+      invoke(new Generator_Criteria().usingValues(values).generate());
+    }
     if (round.environment().hasMongoModule()) {
       invoke(new Generator_Repositories().usingValues(values).generate());
     }

--- a/value-processor/src/org/immutables/value/processor/Repositories.generator
+++ b/value-processor/src/org/immutables/value/processor/Repositories.generator
@@ -861,7 +861,6 @@ this.[a.name][if secondary]Secondary[/if]Encoder = this.registry.get([if seconda
   [/if]
 [/for]
 [/template]
-
 [template wrapMarshalable Attribute a][if a.requiresMarshalingAdapter]Support.writable(serialization.[a.name]Encoder, [else]Support.writable([/if][/template]
 
 [template wrapSecondaryMarshalable Attribute a][if a.requiresMarshalingSecondaryAdapter]Support.writable(serialization.[a.name]SecondaryEncoder, [else]Support.writable([/if][/template]

--- a/value-processor/src/org/immutables/value/processor/meta/CriteriaMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/CriteriaMirrors.java
@@ -1,0 +1,28 @@
+/*
+   Copyright 2015 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.value.processor.meta;
+
+import org.immutables.mirror.Mirror;
+
+public final class CriteriaMirrors {
+  private CriteriaMirrors() {}
+
+  @Mirror.Annotation("org.immutables.criteria.Criteria")
+  public @interface Criteria {
+
+  }
+
+}

--- a/value-processor/src/org/immutables/value/processor/meta/Proto.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Proto.java
@@ -329,6 +329,12 @@ public class Proto {
       return findElement(Proto.JACKSON_DESERIALIZE) != null;
     }
 
+
+    @Value.Lazy
+    public boolean hasCriteriaModule() {
+      return findElement(CriteriaMirror.qualifiedName()) != null;
+    }
+
     @Value.Lazy
     public boolean hasMongoModule() {
       return findElement(RepositoryMirror.qualifiedName()) != null;
@@ -909,6 +915,11 @@ public class Proto {
     }
 
     @Value.Lazy
+    public Optional<CriteriaMirror> criteria() {
+      return CriteriaMirror.find(element());
+    }
+
+    @Value.Lazy
     public Optional<RepositoryMirror> repository() {
       return RepositoryMirror.find(element());
     }
@@ -1200,6 +1211,16 @@ public class Proto {
      * @return declaring type
      */
     public abstract Optional<DeclaringType> declaringType();
+
+    @Value.Lazy
+    public Optional<CriteriaMirror> criteria() {
+      if (!declaringType().isPresent()) {
+        return Optional.absent();
+      }
+      return kind().isIncluded() || kind().isDefinedValue()
+              ? declaringType().get().criteria()
+              : Optional.<CriteriaMirror>absent();
+    }
 
     @Value.Lazy
     public Optional<RepositoryMirror> repository() {

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -432,6 +432,10 @@ public final class ValueType extends TypeIntrospectionBase implements HasStyleIn
     return !kind().isNested();
   }
 
+  public boolean isGenerateCriteria() {
+    return constitution.protoclass().criteria().isPresent();
+  }
+
   public boolean isGenerateRepository() {
     return constitution.protoclass().repository().isPresent();
   }


### PR DESCRIPTION
First draft of Criteria API. Please don't merge it yet.

Generate criteria class based on existing model and evaluate it using visitor pattern.

Right now only reflection based evaluator is provided. 

### Missing functionality / Remaining Questions : 
1. (sub-)Criteria on Iterables. Example 
    ```java
    user.friends.anyMatch(FriendCriteria.create().age().greaterThan(22));
    user.friends.noneMatch(FriendCriteria.create().age().greaterThan(22))
    user.friends.allMatch(FriendCriteria.create().age().greaterThan(22));
   
    // something similar for optionals
    ```
2. Combining criterias (using `AND`s / `OR`s)
3. Nested criterias
4. Projections
5. Aggregations
5. Comparison between fields: `field1 = field2` 
6. DSL is not restrictive enough.
   ```java
   // one can write something like this
   criteria.or().or().or();
   criteria.age().greaterThan(111).or().or(); // or this
   ```
7. How are we better / worse than [QueryDSL](http://www.querydsl.com/) ?
8. Allow user to define (inject) custom (native) queries like [geo spacial](https://docs.mongodb.com/manual/geospatial-queries/)