### PR TITLE
Fix parent package traversal in JDK 9+

### DIFF
--- a/value-processor/src/org/immutables/value/processor/meta/Proto.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Proto.java
@@ -723,7 +723,7 @@ public class Proto {
     @Value.Lazy
     Optional<DeclaringPackage> namedParentPackage() {
       String parentPackageName = SourceNames.parentPackageName(element());
-      if (!parentPackageName.isEmpty()) {
+      while (!parentPackageName.isEmpty()) {
         @Nullable PackageElement parentPackage =
             environment().processing()
                 .getElementUtils()
@@ -737,6 +737,11 @@ public class Proto {
                   .element(parentPackage)
                   .build()));
         }
+
+        // With JDK 9+ package elements are only returned for packages with a
+        // `package-info.class` file. So although the parent may not be found,
+        // there may be "ancestor packages" further up the hierarchy.
+        parentPackageName = SourceNames.parentPackageName(parentPackageName);
       }
       return Optional.absent();
     }

--- a/value-processor/src/org/immutables/value/processor/meta/SourceNames.java
+++ b/value-processor/src/org/immutables/value/processor/meta/SourceNames.java
@@ -46,7 +46,10 @@ final class SourceNames {
   }
 
   static String parentPackageName(PackageElement element) {
-    String qualifiedName = element.getQualifiedName().toString();
+    return parentPackageName(element.getQualifiedName().toString());
+  }
+
+  static String parentPackageName(String qualifiedName) {
     int lastIndexOfDot = qualifiedName.lastIndexOf('.');
     if (lastIndexOfDot > 0) {
       return qualifiedName.substring(0, lastIndexOfDot);


### PR DESCRIPTION
Fixes #736.

Summary of our situation and how I came to this proposal: We have a small Maven module with a `com/company/package-info.java` file containing a company-wide `@Value.Style` configuration. Other Maven modules declare `@Value.Immutable` types in `com/company/foo/bar/baz` packages. With JDK 8 this works fine; with JDK 9-11 it works only after applying this patch. My understanding of  the problem is that with JDK 9+, Immutables only finds `com/company/foo/bar` as a parent of `com/company/foo/bar/baz` if the former contains a `package-info.java` file. The patch proposed here doesn't bail out when the parent is not found, but instead keeps traversing to the root, since packages higher up _may_ contain a `package-info.java` file.

@elucash I tested this change on a private project using JDK 9, 10 and 11. I wanted to add a test case, but since the project currently doesn't build with JDK 9 anyway (there are test failures in `org.immutables.gson`), that seems moot. Let me know if you disagree :)
