### PR TITLE
Use Guava static methods for better forward compatibilty.

### DIFF
--- a/generator-processor/src/org/immutables/generator/processor/Trees.java
+++ b/generator-processor/src/org/immutables/generator/processor/Trees.java
@@ -334,7 +334,7 @@ public class Trees {
     }
 
     public boolean isWhitespace() {
-      return CharMatcher.WHITESPACE.matchesAllOf(value());
+      return CharMatcher.whitespace().matchesAllOf(value());
     }
   }
 

--- a/generator/src/org/immutables/generator/Output.java
+++ b/generator/src/org/immutables/generator/Output.java
@@ -62,7 +62,7 @@ public final class Output {
     @Nullable
     public Invokable invoke(Invokation invokation, Object... parameters) {
       Messager messager = StaticEnvironment.processing().getMessager();
-      String message = CharMatcher.WHITESPACE.trimFrom(parameters[parameters.length - 1].toString());
+      String message = CharMatcher.whitespace().trimFrom(parameters[parameters.length - 1].toString());
       Element element = (Element) Iterators.find(
           Iterators.forArray(parameters),
           Predicates.instanceOf(Element.class),
@@ -80,7 +80,7 @@ public final class Output {
     @Override
     @Nullable
     public Invokable invoke(Invokation invokation, Object... parameters) {
-      String message = CharMatcher.WHITESPACE.trimFrom(parameters[0].toString());
+      String message = CharMatcher.whitespace().trimFrom(parameters[0].toString());
       // this is not a debug line, we are printing to system out
       System.out.println(message);
       return null;
@@ -126,7 +126,7 @@ public final class Output {
   public final Templates.Invokable trim = new OutputFilter() {
     @Override
     void apply(Invokation invokation, CharSequence content, @Nullable Templates.Invokable original) {
-      invokation.out(CharMatcher.WHITESPACE.trimFrom(content));
+      invokation.out(CharMatcher.whitespace().trimFrom(content));
     }
   };
 
@@ -135,7 +135,7 @@ public final class Output {
 
     @Override
     void apply(Invokation invokation, CharSequence content, @Nullable Templates.Invokable original) {
-      String collapsed = CharMatcher.WHITESPACE.trimAndCollapseFrom(content, ' ');
+      String collapsed = CharMatcher.whitespace().trimAndCollapseFrom(content, ' ');
       int estimatedLimitOnThisLine = LIMIT - invokation.consumer.getCurrentIndentation().length();
 
       if (collapsed.length() < estimatedLimitOnThisLine) {
@@ -153,7 +153,7 @@ public final class Output {
   public final Templates.Invokable collapsible = new OutputFilter() {
     @Override
     void apply(Invokation invokation, CharSequence content, @Nullable Templates.Invokable original) {
-      boolean hasNonWhitespace = !CharMatcher.WHITESPACE.matchesAllOf(content);
+      boolean hasNonWhitespace = !CharMatcher.whitespace().matchesAllOf(content);
       if (hasNonWhitespace) {
         if (original != null) {
           original.invoke(invokation);

--- a/generator/src/org/immutables/generator/Templates.java
+++ b/generator/src/org/immutables/generator/Templates.java
@@ -73,7 +73,7 @@ public final class Templates {
 
     public CharSequence getCurrentIndentation() {
       CharSequence sequence = currentLine();
-      return sequence.length() > 0 && CharMatcher.WHITESPACE.matchesAllOf(sequence)
+      return sequence.length() > 0 && CharMatcher.whitespace().matchesAllOf(sequence)
           ? sequence
           : indentation;
     }
@@ -105,7 +105,7 @@ public final class Templates {
     }
 
     private boolean wasBlankLine() {
-      return CharMatcher.WHITESPACE.matchesAllOf(currentLine());
+      return CharMatcher.whitespace().matchesAllOf(currentLine());
     }
 
     @Override

--- a/trees/test/org/immutables/trees/ast/SampleNodes.java
+++ b/trees/test/org/immutables/trees/ast/SampleNodes.java
@@ -234,7 +234,7 @@ public interface SampleNodes {
     public abstract String value();
 
     public boolean isWhitespace() {
-      return CharMatcher.WHITESPACE.matchesAllOf(value());
+      return CharMatcher.whitespace().matchesAllOf(value());
     }
   }
 

--- a/value-fixture/test/org/immutables/fixture/marshal/MarshallingTest.java
+++ b/value-fixture/test/org/immutables/fixture/marshal/MarshallingTest.java
@@ -68,7 +68,7 @@ public class MarshallingTest {
 
   @Test
   public void nullableMarshaling() {
-    check(CharMatcher.WHITESPACE.removeFrom(Marshaling.toJson(ImmutableHasNullable.of()))).is("{}");
+    check(CharMatcher.whitespace().removeFrom(Marshaling.toJson(ImmutableHasNullable.of()))).is("{}");
     check(Marshaling.fromJson("{}", ImmutableHasNullable.class)).is(ImmutableHasNullable.of());
     check(Marshaling.fromJson("{\"in\":1}", ImmutableHasNullable.class)).is(ImmutableHasNullable.of(1));
     check(Marshaling.fromJson("{\"def\":\"1\"}", ImmutableHasNullable.class))

--- a/value-fixture/test/org/immutables/fixture/nested/NestedValuesTest.java
+++ b/value-fixture/test/org/immutables/fixture/nested/NestedValuesTest.java
@@ -53,7 +53,7 @@ public class NestedValuesTest {
 
   @Test
   public void marshalingOfNested() {
-    check(CharMatcher.WHITESPACE.removeFrom(
+    check(CharMatcher.whitespace().removeFrom(
         Marshaling.toJson(
             ImmutableGroupedClasses.NestedOne.builder().build()))).is("{}");
   }

--- a/value-processor/src/org/immutables/value/processor/encode/Code.java
+++ b/value-processor/src/org/immutables/value/processor/encode/Code.java
@@ -32,7 +32,7 @@ final class Code {
   private Code() {}
 
   private static final CharMatcher DELIMITER = CharMatcher.anyOf("!\"#$%&'()*+,-./:;<=>?@[]^{|}~");
-  private static final CharMatcher WHITESPACE = CharMatcher.WHITESPACE;
+  private static final CharMatcher WHITESPACE = CharMatcher.whitespace();
   private static final CharMatcher LETTER_OR_DIGIT = CharMatcher.javaLetterOrDigit().or(CharMatcher.anyOf("$_"));
   private static final CharMatcher IDENTIFIER_START = CharMatcher.javaLetter().or(CharMatcher.anyOf("$_"));
 


### PR DESCRIPTION
Guava 26 removed the static constants being used by Immutables, which can make
it very difficult to use Immutables in a project with a newer Guava version.
Version 19 (which happily is already in use here) provided static methods to
replace the constants, so switch to using them.