### PR TITLE
Mongo Adapter. Remove redundant code in JacksonRepoTest

### DIFF
--- a/mongo/test/org/immutables/mongo/fixture/JacksonRepoTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/JacksonRepoTest.java
@@ -82,11 +82,8 @@ public class JacksonRepoTest {
     module.addDeserializer(UUID.class, new UUIDDeserializer(UuidRepresentation.JAVA_LEGACY));
 
     ObjectMapper mapper = new ObjectMapper()
-            .registerModule(JacksonCodecs.module(
-                CodecRegistries.fromRegistries(
-                    MongoClient.getDefaultCodecRegistry()
-                )
-            ))
+        // to support bson types like: Document, BsonValue etc.
+        .registerModule(JacksonCodecs.module(MongoClient.getDefaultCodecRegistry()))
         .registerModule(new GuavaModule())
         .registerModule(module);
 


### PR DESCRIPTION
Previous contribution had unnecessary wrapping in CodecRegistries. 