### PR TITLE
Don't write file if content is identical

### DIFF
--- a/generator/src/org/immutables/generator/Output.java
+++ b/generator/src/org/immutables/generator/Output.java
@@ -310,12 +310,14 @@ public final class Output {
     void complete() {
       CharSequence sourceCode = extractSourceCode();
       try {
-        JavaFileObject sourceFile = key.originatingElement != null
-            ? getFiler().createSourceFile(key.toString(), key.originatingElement)
-            : getFiler().createSourceFile(key.toString());
+        if (!identicalFileIsAlreadyGenerated(sourceCode)) {
+            JavaFileObject sourceFile = key.originatingElement != null
+                ? getFiler().createSourceFile(key.toString(), key.originatingElement)
+                : getFiler().createSourceFile(key.toString());
 
-        try (Writer writer = sourceFile.openWriter()) {
-          writer.append(sourceCode);
+            try (Writer writer = sourceFile.openWriter()) {
+                writer.append(sourceCode);
+            }
         }
       } catch (FilerException ex) {
         if (identicalFileIsAlreadyGenerated(sourceCode)) {


### PR DESCRIPTION
I noticed we were recompiling some modules even without doing any changes, and traced it back to files generated by immutables that changed the mtime of the files. This PR attempts to speed up incremental compiles by not writing the file if the content is already the same.