### PR TITLE
add Builder.from() support for direct ancestors with just one type parameter

### DIFF
--- a/value-fixture/src/org/immutables/fixture/generics/GenericCore.java
+++ b/value-fixture/src/org/immutables/fixture/generics/GenericCore.java
@@ -1,0 +1,17 @@
+package org.immutables.fixture.generics;
+
+import org.immutables.value.Value.Immutable;
+
+public interface GenericCore {
+  interface Core<T extends CharSequence> {
+    T getObject();
+  }
+
+  @Immutable
+  interface GenericChild<T extends CharSequence> extends Core<T> {}
+
+  @Immutable
+  interface GenericAdult<T extends CharSequence> extends Core<T> {
+    int getId();
+  }
+}

--- a/value-fixture/test/org/immutables/fixture/generics/GenericCoreTest.java
+++ b/value-fixture/test/org/immutables/fixture/generics/GenericCoreTest.java
@@ -1,0 +1,29 @@
+package org.immutables.fixture.generics;
+
+import static org.immutables.check.Checkers.check;
+
+import org.junit.Test;
+
+public class GenericCoreTest {
+  @Test
+  public void test() {
+    final String object = "foo";
+    final int id = 1;
+
+    ImmutableGenericChild<String> child = ImmutableGenericChild.<String>builder()
+        .object(object)
+        .build();
+
+    ImmutableGenericAdult<String> adultFromChild = ImmutableGenericAdult.<String>builder()
+        .from(child)
+        .id(id)
+        .build();
+
+    ImmutableGenericAdult<String> adultFromScratch = ImmutableGenericAdult.<String> builder()
+        .object(object)
+        .id(id)
+        .build();
+
+    check(adultFromChild).is(adultFromScratch);
+  }
+}

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -1394,7 +1394,8 @@ public final class ValueType extends TypeIntrospectionBase implements HasStyleIn
           report(),
           typeAbstract().toString(),
           getSettableAttributes(),
-          accessorMapping);
+          accessorMapping,
+          constitution.protoclass().processing().getTypeUtils());
     }
     return buildFromTypes;
   }


### PR DESCRIPTION
We use the [egg pattern](https://github.com/HubSpot/hubspot-immutables#egg-pattern) heavily at my company and this PR addresses an issue we've faced where `Builder.from()`'s are not generated for supertypes when all types have the same type parameter. To see what I mean, check out this test I added (https://github.com/immutables/immutables/compare/master...tpetr:generic-inherit?expand=1#diff-f5bc5bf0a9b538e82ec484267fceffdd) -- I need to be able to pass a `ImmutableGenericChild` to `ImmutableGenericAdult.Builder.from()`.

This PR adds support for direct supertypes where both classes have just one type parameter with matching bounds and names. I wasn't able to safely reason about anything more complicated than that 😓 

Let me know if this all makes sense or if there's anything I can do to make this more merge-able. Thanks!