### PR TITLE
ignore methods with parameters when comparing with super type

### DIFF
--- a/value-processor/src/org/immutables/value/processor/meta/FromSupertypesModel.java
+++ b/value-processor/src/org/immutables/value/processor/meta/FromSupertypesModel.java
@@ -166,7 +166,7 @@ public final class FromSupertypesModel {
 
   private @Nullable ExecutableElement findMethod(TypeElement typeElement, String getter) {
     for (ExecutableElement m : ElementFilter.methodsIn(typeElement.getEnclosedElements())) {
-      if (m.getSimpleName().contentEquals(getter)) {
+      if (m.getSimpleName().contentEquals(getter) && m.getParameters().isEmpty()) {
         return m;
       }
     }


### PR DESCRIPTION
if a class defines a method with the same name as a "getter" method but with parameters, and that method is declared before the getter, it will be used to compare the return type against the getter method defined in the parent class, if they don't match, the attribute will be ignored from the "from" builder.

although it's probably not a common use case to have methods with parameters named like a getter, only methods without parameters should be considered anyway. 

I couldn't find unit tests for this, so didn't edit any, but happy to add test cases if there are tests for this in another module.