### PR TITLE
Push expression visitor implementation to upper class (as default interface method)

### DIFF
--- a/criteria/common/README.md
+++ b/criteria/common/README.md
@@ -16,7 +16,7 @@ Conversion between criteria and native query is happening at runtime using visit
     user.friends.allMatch(FriendCriteria.create().age().greaterThan(22));
    
     // something similar for optionals
-    ```
+    ``` 
 2. Combining criterias (using `AND`s / `OR`s)
 3. Nested criterias
 4. Projections

--- a/criteria/common/src/org/immutables/criteria/DocumentCriteria.java
+++ b/criteria/common/src/org/immutables/criteria/DocumentCriteria.java
@@ -16,6 +16,14 @@
 
 package org.immutables.criteria;
 
+import org.immutables.criteria.constraints.Call;
+import org.immutables.criteria.constraints.Expression;
+import org.immutables.criteria.constraints.ExpressionVisitor;
+import org.immutables.criteria.constraints.Literal;
+import org.immutables.criteria.constraints.Path;
+
+import javax.annotation.Nullable;
+
 /**
  * Base class of Criteria API. Right now used as a marker interface.
  * Generated code extends this class.
@@ -23,6 +31,28 @@ package org.immutables.criteria;
  * @param <C> Criteria self-type, allowing {@code this}-returning methods to avoid needing subclassing
  * @param <T> type of the document being evaluated by this criteria
  */
-public interface DocumentCriteria<C extends DocumentCriteria<C, T>, T> {
+public interface DocumentCriteria<C extends DocumentCriteria<C, T>, T> extends Expression<T> {
 
+  /**
+   * Expose expression used by this criteria
+   */
+  Expression<T> expression();
+
+  @Nullable
+  @Override
+  default <R> R accept(ExpressionVisitor<R> visitor) {
+    final Expression<T> expression = expression();
+
+    if (expression instanceof Path) {
+      return visitor.visit((Path<?>) expression);
+    } else if (expression instanceof Call) {
+      return visitor.visit((Call<?>) expression);
+    } else if (expression instanceof Literal) {
+      return visitor.visit((Literal<?>) expression);
+    }
+
+    throw new UnsupportedOperationException(String.format("Unknown expression type %s for %s",
+            expression.getClass().getName(), getClass()));
+
+  }
 }

--- a/value-processor/src/org/immutables/value/processor/Criteria.generator
+++ b/value-processor/src/org/immutables/value/processor/Criteria.generator
@@ -65,8 +65,7 @@ import [starImport];
 [/if]
 @javax.annotation.concurrent.Immutable
 [atGenerated type]
-[type.typeDocument.access]final class [type.name]Criteria implements DocumentCriteria<[type.name]Criteria, [type.typeDocument]>,
-                                        Expression<[type.name]> {
+[type.typeDocument.access]final class [type.name]Criteria implements DocumentCriteria<[type.name]Criteria, [type.typeDocument]> {
 
    private final Expression<[type.name]> expression;
 
@@ -90,19 +89,10 @@ import [starImport];
         return new [type.name]Criteria(Expressions.<[type.name]>path(""));
    }
 
-  @Override
-  public <R> R accept(ExpressionVisitor<R> visitor) {
-     if (expression instanceof Path) {
-       return visitor.visit((Path<?>) expression);
-     } else if (expression instanceof Call) {
-       return visitor.visit((Call<?>) expression);
-     } else if (expression instanceof Literal) {
-       return visitor.visit((Literal<?>) expression);
-     }
-
-     throw new UnsupportedOperationException(String.format("Unknown expression type %s for %s",
-             expression.getClass().getName(), getClass()));
-  }
+   @Override
+   public Expression<[type.name]> expression() {
+       return this.expression;
+   }
 
    /**
     * Used to construct this criteria based on existing {@link Constraints.Constraint}


### PR DESCRIPTION
This is mainly done to minimize logic inside generated code