### PR TITLE
Mongo Adapter. Replace Fongo by Mongo Java Server (embedded mongo for tests)

### DIFF
--- a/mongo/pom.xml
+++ b/mongo/pom.xml
@@ -72,12 +72,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.fakemongo</groupId>
-      <artifactId>fongo</artifactId>
-      <version>2.1.0</version>
+      <groupId>de.bwaldvogel</groupId>
+      <artifactId>mongo-java-server</artifactId>
+      <version>1.13.0</version>
       <scope>test</scope>
     </dependency>
-    <!-- Fongo dependency -->
+    <!-- mongo-java-server dependency -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/mongo/test/org/immutables/mongo/fixture/JacksonRepoTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/JacksonRepoTest.java
@@ -30,17 +30,20 @@ import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.github.fakemongo.Fongo;
 import com.google.common.base.Optional;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import org.bson.*;
+import org.bson.BsonDocument;
+import org.bson.BsonNull;
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+import org.bson.UuidRepresentation;
 import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.UuidCodec;
-import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.types.ObjectId;
 import org.immutables.mongo.Mongo;
 import org.immutables.mongo.bson4jackson.BsonGenerator;
@@ -49,6 +52,7 @@ import org.immutables.mongo.bson4jackson.JacksonCodecs;
 import org.immutables.mongo.repository.RepositorySetup;
 import org.immutables.value.Value;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
@@ -64,14 +68,15 @@ import static org.immutables.check.Checkers.check;
  */
 public class JacksonRepoTest {
 
-  private JacksonRepository repository;
+  @Rule
+  public final MongoContext context = MongoContext.create();
 
+  private JacksonRepository repository;
   private MongoCollection<BsonDocument> collection;
 
   @Before
   public void setUp() throws Exception {
-    MongoDatabase database = new Fongo("myname").getDatabase("foo");
-
+    final MongoDatabase database = context.database();
     this.collection = database.getCollection("jackson").withDocumentClass(BsonDocument.class);
 
     SimpleModule module = new SimpleModule(); // for our local serializers of Date and ObjectId

--- a/mongo/test/org/immutables/mongo/fixture/MongoAsserts.java
+++ b/mongo/test/org/immutables/mongo/fixture/MongoAsserts.java
@@ -45,7 +45,7 @@ public final class MongoAsserts {
       String codeName = ((MongoCommandException) exception).getResponse().get("codeName").asString().getValue();
       int errorCode = ((MongoCommandException) exception).getErrorCode();
 
-      check(codeName).is("DuplicateKey");
+      // 11000 stands for DuplicateKeyException
       check(errorCode).is(11000);
 
       // all good here (can return)

--- a/mongo/test/org/immutables/mongo/fixture/flags/FlagsTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/flags/FlagsTest.java
@@ -31,6 +31,7 @@ public class FlagsTest {
     repo.findAll().deleteAll().getUnchecked();
     repo.findAll().deleteFirst().getUnchecked();
     repo.findAll().andModifyFirst().setName("foo").update();
+    repo.insert(ImmutableStandard.builder().id("id1").name("foo").build()).getUnchecked();
     repo.findAll().andReplaceFirst(ImmutableStandard.builder().id("id1").build()).upsert().getUnchecked();
 
   }


### PR DESCRIPTION
Traditionally we have used [Fongo](https://github.com/fakemongo/fongo) as our fake mongo server. Unfortunately,
development on that project has staled and it is not compatible with latest mongo driver versions (3.6+).

[Mongo Java Server](https://github.com/bwaldvogel/mongo-java-server) is more active and passed all integration tests.

Closes #929