### PR TITLE
Upgrade mongo java server to 1.14.0

### DIFF
--- a/mongo/pom.xml
+++ b/mongo/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>de.bwaldvogel</groupId>
       <artifactId>mongo-java-server</artifactId>
-      <version>1.13.0</version>
+      <version>1.14.0</version>
       <scope>test</scope>
     </dependency>
     <!-- mongo-java-server dependency -->

--- a/mongo/test/org/immutables/mongo/fixture/MongoAsserts.java
+++ b/mongo/test/org/immutables/mongo/fixture/MongoAsserts.java
@@ -45,8 +45,8 @@ public final class MongoAsserts {
       String codeName = ((MongoCommandException) exception).getResponse().get("codeName").asString().getValue();
       int errorCode = ((MongoCommandException) exception).getErrorCode();
 
-      // 11000 stands for DuplicateKeyException
-      check(errorCode).is(11000);
+      check(codeName).is("DuplicateKey");
+      check(errorCode).is(11000); // code 11000 stands for DuplicateKeyException
 
       // all good here (can return)
       return;


### PR DESCRIPTION
New version of the librabry fixes the issue with `codeName=DuplicateKey` for duplicate keys.
Different value was returned before which was inconsistent with real mongo DB.
