### PR TITLE
incomplete criteria detection

### DIFF
--- a/criteria/common/test/org/immutables/criteria/Friend.java
+++ b/criteria/common/test/org/immutables/criteria/Friend.java
@@ -1,0 +1,9 @@
+package org.immutables.criteria;
+
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+@Criteria
+public interface Friend {
+  String nickName();
+}

--- a/criteria/common/test/org/immutables/criteria/Person.java
+++ b/criteria/common/test/org/immutables/criteria/Person.java
@@ -15,4 +15,5 @@ public interface Person {
 
   int age();
 
+  Friend friend();
 }

--- a/value-processor/src/org/immutables/value/processor/Criteria.generator
+++ b/value-processor/src/org/immutables/value/processor/Criteria.generator
@@ -132,6 +132,8 @@ StringCriteria<[type.name]Criteria, [type.name]>
 OptionalCriteria<[a.wrappedElementType], [type.name]Criteria, [type.name]>
 [else if a.comparable]
 ComparableCriteria<[a.wrappedElementType], [type.name]Criteria, [type.name]>
+[else if a.hasCriteria]
+[a.attributeValueType.name]Criteria
 [else]
 ObjectCriteria<[a.wrappedElementType], [type.name]Criteria, [type.name]>
 [/if]

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -1136,12 +1136,17 @@ public final class ValueAttribute extends TypeIntrospectionBase implements HasSt
     validateThrowsClause();
     validateTypeAndAnnotations();
 
+    initAttributeValueType();
+
     if (supportBuiltinContainerTypes()) {
-      initAttributeValueType();
       initImmutableCopyOf();
     }
 
     initAttributeBuilder();
+  }
+
+  public boolean hasCriteria() {
+    return attributeValueType != null && attributeValueType.isGenerateCriteria();
   }
 
   private Set<String> thrownCheckedExceptions = ImmutableSet.of();
@@ -1271,7 +1276,8 @@ public final class ValueAttribute extends TypeIntrospectionBase implements HasSt
   private void initAttributeValueType() {
 
     if ((style().deepImmutablesDetection()
-        || style().attributeBuilderDetection())
+        || style().attributeBuilderDetection()
+        || containingType.isGenerateCriteria())
         && containedTypeElement != null) {
       // prevent recursion in case we have the same type
       if (CachingElements.equals(containedTypeElement, containingType.element)) {


### PR DESCRIPTION
@asereda-gs here's what I was able to came up with wrt criteria detection. It has okeish detection, but in template I've put just to see, and it's not compiling generated code obviously with that `person/Friend` combination. This is not for direct merging obviously, but you can use it as a base

At first, I thought that we can avoid loading protoclass/value type model and get annotation (`CriteriaMirror.isPresent(this.containingTypeElement)` with some additional checks), but then when we need to know package/type name etc, we cannot just guess it, we need style infrastructure etc.

