### PR TITLE
Make generated MongoDB repositories extensible

### DIFF
--- a/mongo/src/org/immutables/mongo/repository/Repositories.java
+++ b/mongo/src/org/immutables/mongo/repository/Repositories.java
@@ -99,7 +99,7 @@ public final class Repositories {
       return fieldNamingStrategy;
     }
 
-    private MongoCollection<T> collection() {
+    protected MongoCollection<T> collection() {
       return collection;
     }
 

--- a/mongo/src/org/immutables/mongo/repository/Repositories.java
+++ b/mongo/src/org/immutables/mongo/repository/Repositories.java
@@ -99,7 +99,7 @@ public final class Repositories {
       return fieldNamingStrategy;
     }
 
-    protected MongoCollection<T> collection() {
+    protected final MongoCollection<T> collection() {
       return collection;
     }
 

--- a/value-processor/src/org/immutables/value/processor/Repositories.generator
+++ b/value-processor/src/org/immutables/value/processor/Repositories.generator
@@ -68,7 +68,7 @@ import [starImport];
 [if type allowsClasspathAnnotation 'javax.annotation.concurrent.ThreadSafe']
 @javax.annotation.concurrent.ThreadSafe
 [/if]
-[type.typeDocument.access]final class [type.name]Repository extends Repositories.Repository<[type.typeDocument]> {
+[type.typeDocument.access]class [type.name]Repository extends Repositories.Repository<[type.typeDocument]> {
   private static final String DOCUMENT_COLLECTION_NAME = "[type.documentName]";
 
   private final Serialization serialization;


### PR DESCRIPTION
We have use cases in which we want to aggregate documents of generated repositories. Since the generator does not provide an API to build an Aggregation Pipeline, we write them by hand. In this case, we want to extend the generated repository with custom functionality where we need access to the used MongoCollection.