### PR TITLE
Apply criteria on Optional attributes

### DIFF
--- a/criteria/common/src/org/immutables/criteria/constraints/OptionalCriteria.java
+++ b/criteria/common/src/org/immutables/criteria/constraints/OptionalCriteria.java
@@ -18,11 +18,14 @@ package org.immutables.criteria.constraints;
 
 import org.immutables.criteria.DocumentCriteria;
 
+import java.util.Optional;
+import java.util.function.Consumer;
+
 /**
  * Criteria for optional attributes.
  */
-// TODO what should be the type of V be in ObjectCriteria ? java8.util.Optional<V> or guava.Optional<V> ?
-public class OptionalCriteria<R extends DocumentCriteria<R>, V> extends ObjectCriteria<R, V> {
+// TODO do we really need to extend from ObjectCriteria ? perhaps just make ValueCriteria ?
+public class OptionalCriteria<R extends DocumentCriteria<R>, V, S extends ValueCriteria<R, V>> extends ObjectCriteria<R, Optional<V>> {
 
   public OptionalCriteria(CriteriaContext<R> context) {
     super(context);
@@ -34,6 +37,14 @@ public class OptionalCriteria<R extends DocumentCriteria<R>, V> extends ObjectCr
 
   public R isAbsent() {
     return create(e -> Expressions.call(Operators.IS_ABSENT, e));
+  }
+
+  public S value() {
+    throw new UnsupportedOperationException();
+  }
+
+  public R value(Consumer<S> consumer) {
+    throw new UnsupportedOperationException();
   }
 
 }

--- a/criteria/common/test/org/immutables/criteria/ReflectionTest.java
+++ b/criteria/common/test/org/immutables/criteria/ReflectionTest.java
@@ -64,7 +64,9 @@ public class ReflectionTest {
     PersonCriteria.create()
             .friends.any().nickName.isNotEmpty()
             .friends.any(f -> f.nickName.isNotEmpty().isMarried.isTrue())
-            .aliases.none().contains("foo");
+            .aliases.none().contains("foo")
+            .lastName.value().isNotEmpty();
+
   }
 
   @Test

--- a/value-processor/src/org/immutables/value/processor/Criteria.generator
+++ b/value-processor/src/org/immutables/value/processor/Criteria.generator
@@ -136,7 +136,12 @@ BooleanCriteria<R>
 [else if a.stringType]
 StringCriteria<R>
 [else if a.optionalType]
-OptionalCriteria<R, [a.wrappedElementType]>
+[if a.hasSimpleScalarElementType]
+[-- TODO need to make it work with any scalar criteria. Eg. BooleanCriteria / ComparableCriteria --]
+OptionalCriteria<R, [a.wrappedElementType], StringCriteria<R>>
+[else if a.hasCriteria]
+OptionalCriteria<R, [a.wrappedElementType], [a.unwrappedElementType]Criteria<R>>
+[/if]
 [else if a.comparable]
 ComparableCriteria<R, [a.wrappedElementType]>
 [else if a.hasCriteria]


### PR DESCRIPTION
Optional criterias can be "unwrapped" into element specific criteria(s) (eg. string)

```
Optional<String> lastName;

lastName.value().startsWith("J")
```