### PR TITLE
Add context (payload) to expression visitor

### DIFF
--- a/criteria/common/src/org/immutables/criteria/InMemoryExpressionEvaluator.java
+++ b/criteria/common/src/org/immutables/criteria/InMemoryExpressionEvaluator.java
@@ -54,10 +54,10 @@ public class InMemoryExpressionEvaluator<T> implements Predicate<T> {
   public boolean test(T instance) {
     Objects.requireNonNull(instance, "instance");
     final LocalVisitor visitor = new LocalVisitor(instance);
-    return Boolean.TRUE.equals(expression.accept(visitor));
+    return Boolean.TRUE.equals(expression.accept(visitor, null));
   }
 
-  private static class LocalVisitor implements ExpressionVisitor<Object> {
+  private static class LocalVisitor implements ExpressionVisitor<Object, Void> {
 
     private final ValueExtractor<Object> extractor;
 
@@ -66,14 +66,14 @@ public class InMemoryExpressionEvaluator<T> implements Predicate<T> {
     }
 
     @Override
-    public Object visit(Call<?> call) {
+    public Object visit(Call<?> call, Void context) {
       final Operator op = call.getOperator();
       final List<Expression<?>> args = call.getArguments();
 
       if (op == Operators.EQUAL || op == Operators.NOT_EQUAL) {
         Preconditions.checkArgument(args.size() == 2, "Size should be 2 for %s but was %s", op, args.size());
-        final Object left = args.get(0).accept(this);
-        final Object right = args.get(1).accept(this);
+        final Object left = args.get(0).accept(this, null);
+        final Object right = args.get(1).accept(this, null);
 
         if (left == UNKNOWN || right == UNKNOWN) {
           return UNKNOWN;
@@ -85,12 +85,12 @@ public class InMemoryExpressionEvaluator<T> implements Predicate<T> {
 
       if (op == Operators.IN || op == Operators.NOT_IN) {
         Preconditions.checkArgument(args.size() == 2, "Size should be 2 for %s but was %s", op, args.size());
-        final Object left = args.get(0).accept(this);
+        final Object left = args.get(0).accept(this, null);
         if (left == UNKNOWN) {
           return UNKNOWN;
         }
         @SuppressWarnings("unchecked")
-        final Iterable<Object> right = (Iterable<Object>) args.get(1).accept(this);
+        final Iterable<Object> right = (Iterable<Object>) args.get(1).accept(this, null);
         Preconditions.checkNotNull(right, "not expected to be null %s", args.get(1));
         final Stream<Object> stream = StreamSupport.stream(right.spliterator(), false);
 
@@ -99,7 +99,7 @@ public class InMemoryExpressionEvaluator<T> implements Predicate<T> {
 
       if (op == Operators.IS_ABSENT || op == Operators.IS_PRESENT) {
         Preconditions.checkArgument(args.size() == 1, "Size should be 1 for %s but was %s", op, args.size());
-        final Object left = args.get(0).accept(this);
+        final Object left = args.get(0).accept(this, null);
 
         if (left instanceof java.util.Optional) {
           Optional<?> opt = (java.util.Optional<?>) left;
@@ -123,7 +123,7 @@ public class InMemoryExpressionEvaluator<T> implements Predicate<T> {
         Preconditions.checkArgument(!args.isEmpty(), "empty args for %s", op);
         boolean prev = Boolean.TRUE;
         for (Expression<?> exp:args) {
-          Object result = exp.accept(this);
+          Object result = exp.accept(this, null);
           if (Boolean.FALSE.equals(result)) {
             return Boolean.FALSE;
           } else if (result == null || result == UNKNOWN) {
@@ -140,7 +140,7 @@ public class InMemoryExpressionEvaluator<T> implements Predicate<T> {
         Preconditions.checkArgument(!args.isEmpty(), "empty args for %s", op);
         boolean prev = Boolean.FALSE;
         for (Expression<?> exp:args) {
-          Object result = exp.accept(this);
+          Object result = exp.accept(this, null);
           if (Boolean.TRUE.equals(result)) {
             return Boolean.TRUE;
           } else if (result == null || result == UNKNOWN) {
@@ -160,12 +160,12 @@ public class InMemoryExpressionEvaluator<T> implements Predicate<T> {
         Preconditions.checkArgument(args.size() == 2, "Size should be 2 for %s but was %s", op, args.size());
 
         @SuppressWarnings("unchecked")
-        Comparable<Object> left = (Comparable<Object>) args.get(0).accept(this);
+        Comparable<Object> left = (Comparable<Object>) args.get(0).accept(this, null);
         if (left == UNKNOWN || left == null) {
           return UNKNOWN;
         }
         @SuppressWarnings("unchecked")
-        Comparable<Object> right = (Comparable<Object>) args.get(1).accept(this);
+        Comparable<Object> right = (Comparable<Object>) args.get(1).accept(this, null);
         if (right == UNKNOWN || right == null) {
           return UNKNOWN;
         }
@@ -187,12 +187,12 @@ public class InMemoryExpressionEvaluator<T> implements Predicate<T> {
     }
 
     @Override
-    public Object visit(Literal<?> literal) {
+    public Object visit(Literal<?> literal, Void context) {
       return literal.value();
     }
 
     @Override
-    public Object visit(Path<?> path) {
+    public Object visit(Path<?> path, Void context) {
       return extractor.extract(path.path());
     }
   }

--- a/criteria/common/src/org/immutables/criteria/constraints/DebugExpressionVisitor.java
+++ b/criteria/common/src/org/immutables/criteria/constraints/DebugExpressionVisitor.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * Used to output expression tree as string. Useful for debugging expressions.
  */
-public class DebugExpressionVisitor<Void> implements ExpressionVisitor<Void> {
+public class DebugExpressionVisitor<Void> implements ExpressionVisitor<Void, Void> {
 
   private final PrintWriter writer;
 
@@ -18,27 +18,27 @@ public class DebugExpressionVisitor<Void> implements ExpressionVisitor<Void> {
   }
 
   @Override
-  public Void visit(Call<?> call) {
+  public Void visit(Call<?> call, Void context) {
     writer.println();
     writer.print(String.join("", Collections.nCopies(depth * 2, " ")));
     writer.print("call op=" + call.getOperator());
     for (Expression<?> expr: call.getArguments()) {
       depth++;
-      expr.accept(this);
+      expr.accept(this, null);
       depth--;
     }
     return null;
   }
 
   @Override
-  public Void visit(Literal<?> literal) {
+  public Void visit(Literal<?> literal, Void context) {
     writer.print(" literal=");
     writer.print(literal.value());
     return null;
   }
 
   @Override
-  public Void visit(Path<?> path) {
+  public Void visit(Path<?> path, Void context) {
     writer.print(" path=");
     writer.print(path.path());
     return null;

--- a/criteria/common/src/org/immutables/criteria/constraints/DnfExpression.java
+++ b/criteria/common/src/org/immutables/criteria/constraints/DnfExpression.java
@@ -30,8 +30,8 @@ class DnfExpression<T> implements Expression<T> {
 
   @Nullable
   @Override
-  public <R> R accept(ExpressionVisitor<R> visitor) {
-    return simplify().accept(visitor);
+  public <R, C> R accept(ExpressionVisitor<R, C> visitor, @Nullable C context) {
+    return simplify().accept(visitor, context);
   }
 
   private Expression<T> simplify() {

--- a/criteria/common/src/org/immutables/criteria/constraints/Expression.java
+++ b/criteria/common/src/org/immutables/criteria/constraints/Expression.java
@@ -11,6 +11,6 @@ import javax.annotation.Nullable;
 public interface Expression<T> {
 
   @Nullable
-  <R> R accept(ExpressionVisitor<R> visitor);
+  <R, C> R accept(ExpressionVisitor<R, C> visitor, @Nullable C context);
 
 }

--- a/criteria/common/src/org/immutables/criteria/constraints/ExpressionVisitor.java
+++ b/criteria/common/src/org/immutables/criteria/constraints/ExpressionVisitor.java
@@ -1,11 +1,18 @@
 package org.immutables.criteria.constraints;
 
-public interface ExpressionVisitor<V> {
+import javax.annotation.Nullable;
 
-  V visit(Call<?> call);
+/**
+ *
+ * @param <V> visitor return type
+ * @param <C> context type
+ */
+public interface ExpressionVisitor<V, C> {
 
-  V visit(Literal<?> literal);
+  V visit(Call<?> call, @Nullable C context);
 
-  V visit(Path<?> path);
+  V visit(Literal<?> literal, @Nullable C context);
+
+  V visit(Path<?> path, @Nullable C context);
 
 }

--- a/criteria/common/src/org/immutables/criteria/constraints/Expressions.java
+++ b/criteria/common/src/org/immutables/criteria/constraints/Expressions.java
@@ -26,8 +26,8 @@ public final class Expressions {
 
       @Nullable
       @Override
-      public <R> R accept(ExpressionVisitor<R> visitor) {
-        return visitor.visit(this);
+      public <R, C> R accept(ExpressionVisitor<R, C> visitor, @Nullable C context) {
+        return visitor.visit(this, context);
       }
     };
   }
@@ -41,8 +41,8 @@ public final class Expressions {
 
       @Nullable
       @Override
-      public <R> R accept(ExpressionVisitor<R> visitor) {
-        return visitor.visit(this);
+      public <R, C> R accept(ExpressionVisitor<R, C> visitor, @Nullable C context) {
+        return visitor.visit(this, context);
       }
     };
   }
@@ -118,8 +118,8 @@ public final class Expressions {
 
       @Nullable
       @Override
-      public <R> R accept(ExpressionVisitor<R> visitor) {
-        return visitor.visit(this);
+      public <R, C> R accept(ExpressionVisitor<R, C> visitor, @Nullable C context) {
+        return visitor.visit(this, context);
       }
     };
   }

--- a/criteria/common/src/org/immutables/criteria/constraints/NilExpression.java
+++ b/criteria/common/src/org/immutables/criteria/constraints/NilExpression.java
@@ -15,7 +15,7 @@ final class NilExpression<T> implements Expression<T> {
 
   @Nullable
   @Override
-  public <R> R accept(ExpressionVisitor<R> visitor) {
+  public <R, C> R accept(ExpressionVisitor<R, C> visitor, @Nullable C context) {
     throw new UnsupportedOperationException(String.format("Can't visit %s", getClass().getSimpleName()));
   }
 

--- a/criteria/common/test/org/immutables/criteria/ReflectionTest.java
+++ b/criteria/common/test/org/immutables/criteria/ReflectionTest.java
@@ -79,7 +79,7 @@ public class ReflectionTest {
             .firstName.isEqualTo("John");
 
     StringWriter out = new StringWriter();
-    crit.expression().accept(new DebugExpressionVisitor<>(new PrintWriter(out)));
+    crit.expression().accept(new DebugExpressionVisitor<>(new PrintWriter(out)), null);
     check(out.toString()).isNonEmpty();
   }
 


### PR DESCRIPTION
In future it may be useful to expose some context during expression evaluation.