### PR TITLE
Make BSON representation of a criteria available

### DIFF
--- a/mongo/test/org/immutables/mongo/fixture/criteria/PersonCriteriaTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/criteria/PersonCriteriaTest.java
@@ -248,4 +248,10 @@ public class PersonCriteriaTest {
     check(repository.findAll().fetchAll().getUnchecked()).isEmpty();
     check(repository.find(criteria()).fetchAll().getUnchecked()).isEmpty();
   }
+
+  @Test
+  public void toBson() {
+    check(repository.toBson(repository.criteria())).is(new org.bson.Document());
+    check(repository.toBson(repository.criteria().age(35))).is(new org.bson.Document("age", 35));
+  }
 }

--- a/value-processor/src/org/immutables/value/processor/Repositories.generator
+++ b/value-processor/src/org/immutables/value/processor/Repositories.generator
@@ -43,6 +43,7 @@ import org.immutables.mongo.repository.internal.Support;
 
 import org.bson.codecs.Encoder;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 [for starImport in type.requiredSourceStarImports]
 import [starImport];
 [/for]
@@ -612,6 +613,11 @@ public static final class Modifier extends Repositories.Modifier<[type.typeDocum
  */
 public Criteria criteria() {
   return anyCriteria;
+}
+
+@com.google.common.annotations.Beta
+Bson toBson(Criteria criteria) {
+  return Support.convertToBson(criteria.constraint);
 }
 
 /**


### PR DESCRIPTION
I want to use the BSON representation of a `Criteria` instance in my custom extension of a generated repository.

For example, when I want to build a custom count method in my extended repository I do this:
```Java
@Immutable
@Repository
abstract class MyDoc {
    abstract String name();
}

class MyDocExtendedRepository extends MyDocRepository {

    MyDocExtendedRepository(RepositorySetup configuration) {
        super(configuration);
    }

    long count(String prefix) {
        Criteria criteria = criteria().nameStartsWith(prefix);
        return collection().countDocuments(criteria.toBson());
    }

}
```