### PR TITLE
Use projection to limit the amount of data that MongoDB sends

### DIFF
--- a/mongo/src/org/immutables/mongo/repository/Repositories.java
+++ b/mongo/src/org/immutables/mongo/repository/Repositories.java
@@ -376,8 +376,44 @@ public final class Repositories {
    */
   public static abstract class Projection<T> {
 
+    public static <T> Projection<T> of(final Class<T> resultType, String... fieldsToInclude) {
+      List<String> fields = fieldsToInclude == null
+              ? ImmutableList.<String> of()
+              : ImmutableList.copyOf(fieldsToInclude);
+      return of(resultType, fields);
+    }
+
+    public static <T> Projection<T> of(final Class<T> resultType, List<String> fieldsToInclude) {
+      final Bson fields = fieldsToInclude.isEmpty()
+              ? null
+              : Projections.fields(Projections.excludeId(), Projections.include(fieldsToInclude));
+      return of(resultType, fields);
+    }
+
+    public static <T> Projection<T> of(final Class<T> resultType, @Nullable final Bson projection) {
+      checkNotNull(resultType);
+      return new Projection<T>() {
+        @Nullable
+        @Override
+        protected Gson gson() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        protected Bson fields() {
+          return projection;
+        }
+
+        @Override
+        protected Class<T> resultType() {
+          return resultType;
+        }
+      };
+    }
+
     /**
-     * @return optional Gson instance to use to be able to to decode to the specified result documents
+     * @return optional {@link Gson} instance to use to be able to to decode to the specified result documents
      */
     @Nullable
     protected abstract Gson gson();

--- a/mongo/src/org/immutables/mongo/repository/Repositories.java
+++ b/mongo/src/org/immutables/mongo/repository/Repositories.java
@@ -279,12 +279,21 @@ public final class Repositories {
         final Projection<U> projection,
         final @Nonnegative int skip,
         final @Nonnegative int limit) {
+      @Nullable Bson query = criteria != null ? convertToBson(criteria) : null;
+      @Nullable Bson sort = !ordering.isNil() ? convertToBson(ordering) : null;
+      return doFetch(query, sort, projection, skip, limit);
+    }
+
+    protected final <U> FluentFuture<List<U>> doFetch(
+            final @Nullable Bson query,
+            final @Nullable Bson sort,
+            final Projection<U> projection,
+            final @Nonnegative int skip,
+            final @Nonnegative int limit) {
       return submit(new Callable<List<U>>() {
         @SuppressWarnings("resource")
         @Override
         public List<U> call() throws Exception {
-          @Nullable Bson query = criteria != null ? convertToBson(criteria) : null;
-
           MongoCollection<T> collection = collection();
 
           if(projection.codecRegistry() != null) {
@@ -298,8 +307,8 @@ public final class Repositories {
             cursor.projection(projection.fields());
           }
 
-          if (!ordering.isNil()) {
-            cursor.sort(convertToBson(ordering));
+          if (sort != null) {
+            cursor.sort(sort);
           }
 
           cursor.skip(skip);

--- a/mongo/src/org/immutables/mongo/repository/Repositories.java
+++ b/mongo/src/org/immutables/mongo/repository/Repositories.java
@@ -357,18 +357,18 @@ public final class Repositories {
       return new Projection<T>() {
         @Nullable
         @Override
-        protected CodecRegistry codecRegistry() {
+        public CodecRegistry codecRegistry() {
           return null;
         }
 
         @Nullable
         @Override
-        protected Bson fields() {
+        public Bson fields() {
           return projection;
         }
 
         @Override
-        protected Class<T> resultType() {
+        public Class<T> resultType() {
           return resultType;
         }
       };
@@ -378,18 +378,18 @@ public final class Repositories {
      * @return optional {@link CodecRegistry} to enable the decoding of an unknown type of result documents
      */
     @Nullable
-    protected abstract CodecRegistry codecRegistry();
+    public abstract CodecRegistry codecRegistry();
 
     /**
      * @return fields to include in the result documents
      */
     @Nullable
-    protected abstract Bson fields();
+    public abstract Bson fields();
 
     /**
      * @return type of the result documents
      */
-    protected abstract Class<T> resultType();
+    public abstract Class<T> resultType();
 
   }
 

--- a/mongo/src/org/immutables/mongo/repository/RepositorySetup.java
+++ b/mongo/src/org/immutables/mongo/repository/RepositorySetup.java
@@ -28,6 +28,8 @@ import com.mongodb.MongoClientURI;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.immutables.mongo.bson4gson.GsonCodecs;
@@ -236,8 +238,13 @@ public final class RepositorySetup {
               .registerTypeAdapterFactory(bsonAdapterFactory)
               .create();
 
+      // To enable the projection of fields to custom types the Document type must be deserialized
+      // with the default Mongo codec.
+      Codec<Document> documentCodec = MongoClient.getDefaultCodecRegistry().get(Document.class);
+      CodecRegistry firstClassCodecs = CodecRegistries.fromCodecs(documentCodec);
+
       // expose new Gson as CodecRegistry. Using fromRegistries() for caching
-      CodecRegistry codecRegistry = CodecRegistries.fromRegistries(GsonCodecs.codecRegistryFromGson(newGson));
+      CodecRegistry codecRegistry = CodecRegistries.fromRegistries(firstClassCodecs, GsonCodecs.codecRegistryFromGson(newGson));
 
       return codecRegistry(codecRegistry, new FieldNamingStrategy.GsonNamingStrategy(gson));
     }

--- a/mongo/test/org/immutables/mongo/fixture/MongoCursorIsClosedTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/MongoCursorIsClosedTest.java
@@ -37,7 +37,9 @@ public class MongoCursorIsClosedTest {
     MongoCollection<Entity> collection = mock(MongoCollection.class);
 
     when(db.getCollection(anyString(), any(Class.class))).thenReturn(collection);
+    when(collection.getDocumentClass()).thenReturn(Entity.class);
     when(collection.withCodecRegistry(any(CodecRegistry.class))).thenReturn(collection);
+    when(collection.withDocumentClass(any(Class.class))).thenReturn(collection);
 
     RepositorySetup setup = RepositorySetup.builder().database(db)
             .executor(MoreExecutors.newDirectExecutorService())

--- a/mongo/test/org/immutables/mongo/fixture/criteria/ProjectionTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/criteria/ProjectionTest.java
@@ -77,7 +77,7 @@ public class ProjectionTest {
     };
     Projection<NameAgeTuple> projection = new Projection<NameAgeTuple>() {
       @Override
-      protected CodecRegistry codecRegistry() {
+      public CodecRegistry codecRegistry() {
         Gson gson = new GsonBuilder().registerTypeAdapter(NameAgeTuple.class, new JsonDeserializer<NameAgeTuple>() {
           @Override
           public NameAgeTuple deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
@@ -91,12 +91,12 @@ public class ProjectionTest {
       }
 
       @Override
-      protected Bson fields() {
+      public Bson fields() {
         return Projections.fields(Projections.include("name", "age"));
       }
 
       @Override
-      protected Class<NameAgeTuple> resultType() {
+      public Class<NameAgeTuple> resultType() {
         return NameAgeTuple.class;
       }
     };

--- a/mongo/test/org/immutables/mongo/fixture/criteria/ProjectionTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/criteria/ProjectionTest.java
@@ -5,7 +5,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.*;
 import com.mongodb.client.model.Projections;
 import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
+import org.immutables.mongo.bson4gson.GsonCodecs;
 import org.immutables.mongo.fixture.MongoContext;
 import org.immutables.mongo.repository.Repositories.Projection;
 import org.immutables.value.Value;
@@ -75,8 +77,8 @@ public class ProjectionTest {
     };
     Projection<NameAgeTuple> projection = new Projection<NameAgeTuple>() {
       @Override
-      protected Gson gson() {
-        return new GsonBuilder().registerTypeAdapter(NameAgeTuple.class, new JsonDeserializer<NameAgeTuple>() {
+      protected CodecRegistry codecRegistry() {
+        Gson gson = new GsonBuilder().registerTypeAdapter(NameAgeTuple.class, new JsonDeserializer<NameAgeTuple>() {
           @Override
           public NameAgeTuple deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             JsonObject obj = json.getAsJsonObject();
@@ -85,6 +87,7 @@ public class ProjectionTest {
             return ImmutableNameAgeTuple.of(name, age);
           }
         }).create();
+        return GsonCodecs.codecRegistryFromGson(gson);
       }
 
       @Override

--- a/mongo/test/org/immutables/mongo/fixture/criteria/ProjectionTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/criteria/ProjectionTest.java
@@ -1,0 +1,75 @@
+package org.immutables.mongo.fixture.criteria;
+
+import com.google.common.base.Function;
+import org.bson.Document;
+import org.immutables.mongo.fixture.MongoContext;
+import org.immutables.mongo.repository.Repositories.Projection;
+import org.immutables.value.Value;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Date;
+
+import static org.immutables.check.Checkers.check;
+
+/**
+ * Test of excludes
+ */
+public class ProjectionTest {
+  @Rule
+  public final MongoContext context = MongoContext.create();
+
+  private final PersonRepository repository = new PersonRepository(context.setup());
+
+  @Test
+  public void projectWhenEmptyResult() throws Exception {
+    Function<Document, String> resultMapper = new Function<Document, String>() {
+      @Override
+      public String apply(Document document) {
+        return document.getString("name");
+      }
+    };
+    Projection<String> projection = Projection.of(resultMapper, "name");
+    check(repository.findAll().fetchFirst(projection).getUnchecked()).isAbsent();
+    check(repository.findAll().fetchAll(projection).getUnchecked()).isEmpty();
+  }
+
+  @Test
+  public void project() throws Exception {
+    Person adam = ImmutablePerson.builder().id("p1").name("adam").dateOfBirth(new Date())
+            .aliases(Arrays.asList("a1"))
+            .age(35)
+            .build();
+    Person john = ImmutablePerson.builder().id("p2").name("john").dateOfBirth(new Date())
+            .aliases(Arrays.asList("j1", "j2"))
+            .age(30)
+            .build();
+
+    repository.insert(adam).getUnchecked();
+    repository.insert(john).getUnchecked();
+
+    Function<Document, NameAgeTuple> resultMapper = new Function<Document, NameAgeTuple>() {
+      @Override
+      public NameAgeTuple apply(Document document) {
+        return ImmutableNameAgeTuple.of(document.getString("name"), document.getLong("age"));
+      }
+    };
+    Projection<NameAgeTuple> projection = Projection.of(resultMapper, "name", "age");
+
+    NameAgeTuple adamTuple = ImmutableNameAgeTuple.of("adam", 35);
+    NameAgeTuple johnTuple = ImmutableNameAgeTuple.of("john", 30);
+    check(repository.findAll().orderByName().fetchFirst(projection).getUnchecked().get()).is(adamTuple);
+    check(repository.findAll().fetchAll(projection).getUnchecked()).hasContentInAnyOrder(adamTuple, johnTuple);
+    check(repository.findAll().orderByName().skip(1).fetchAll(projection).getUnchecked()).hasContentInAnyOrder(johnTuple);
+  }
+
+  @Value.Immutable
+  interface NameAgeTuple {
+    @Value.Parameter(order = 0)
+    String name();
+    @Value.Parameter(order = 1)
+    long age();
+  }
+
+}


### PR DESCRIPTION
To limit the amount of data that MongoDB sends to applications, you can use a projection to specify the fields to include in the resulting documents that match the query filter. A mapper function will be applied to each document in the result set.

```Java
@Mongo.Repository
@Value.Immutable
@Gson.TypeAdapters
interface Person {
    @Mongo.Id
    String id();
    int age();
    List<String> aliases();
    Optional<Date> dateOfBirth();
    Optional<String> middleName();
    String name();
}

class SomeService {
    private final PersonRepository _repository;

    SomeService(RepositorySetup configuration) {
        _repository = new PersonRepository(configuration);
    }

    List<NameAndAge> nameAndAgeListOfPersonsAtLeast30() {
        PersonRepository.Criteria criteria = _repository.criteria().ageAtLeast(30);
        Projection<NameAndAge> projection = Projection.of(ImmutableNameAndAge.class, "name", "age");
        return _repository
                .find(criteria)
                .fetchAll(projection)
                .getUnchecked();
    }
}

@Value.Immutable
interface NameAndAge {
    @Value.Parameter(order = 0)
    String name();
    @Value.Parameter(order = 1)
    long age();
}
```