### PR TITLE
Derived attributes should be transient

### DIFF
--- a/serial/test/org/immutables/serial/fixture/SerialTest.java
+++ b/serial/test/org/immutables/serial/fixture/SerialTest.java
@@ -42,7 +42,7 @@ public class SerialTest {
 
   @Test
   public void serializablePrehashReadResolve() throws Exception {
-    Method readResolve = ImmutableEnabledWithReadResolve.ImmutableSerialForm.class.getDeclaredMethod("readResolve");
+    Method readResolve = ImmutableEnabledWithReadResolve.class.getDeclaredMethod("readResolve");
     check(readResolve.getModifiers() & Modifier.PRIVATE).is(Modifier.PRIVATE);
   }
 }

--- a/serial/test/org/immutables/serial/fixture/SerialTest.java
+++ b/serial/test/org/immutables/serial/fixture/SerialTest.java
@@ -42,7 +42,7 @@ public class SerialTest {
 
   @Test
   public void serializablePrehashReadResolve() throws Exception {
-    Method readResolve = ImmutableEnabledWithReadResolve.class.getDeclaredMethod("readResolve");
+    Method readResolve = ImmutableEnabledWithReadResolve.ImmutableSerialForm.class.getDeclaredMethod("readResolve");
     check(readResolve.getModifiers() & Modifier.PRIVATE).is(Modifier.PRIVATE);
   }
 }

--- a/value-annotations/src/org/immutables/value/Value.java
+++ b/value-annotations/src/org/immutables/value/Value.java
@@ -103,6 +103,16 @@ public @interface Value {
      * @return if generate builder
      */
     boolean builder() default true;
+    
+    /**
+     * If {@code serialForm=true} and abstract value type implements {@link java.io.Serializable},
+     * causes generation of {@code ImmutableSerialForm} class and
+     * {@code writeReplace()} method that returns an instance of {@code ImmutableSerialForm}.
+     * In general it should be true by default so that deserialization of the value type cannot
+     * break invariants. Set to false by default as otherwise classes already implementing
+     * {@code }writeReplace()) would be broken.
+     */
+    boolean serialForm() default false;
   }
 
   /**

--- a/value-fixture/src/org/immutables/fixture/serial/SomeSer.java
+++ b/value-fixture/src/org/immutables/fixture/serial/SomeSer.java
@@ -16,6 +16,10 @@
 package org.immutables.fixture.serial;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.immutables.value.Value;
 
 @Value.Modifiable
@@ -37,4 +41,12 @@ public abstract class SomeSer implements Serializable {
   @Value.Modifiable
   @Value.Immutable(singleton = true)
   interface OthSer extends Serializable {}
+}
+
+@Value.Immutable
+abstract class CollectionSer implements Serializable {
+    abstract Set<String> strings();
+    abstract List<CollectionSer> list01();
+    abstract Map<Integer, String> intToStringMap();
+    abstract Set<Long> longCollection();
 }

--- a/value-fixture/src/org/immutables/fixture/serial/SomeSer.java
+++ b/value-fixture/src/org/immutables/fixture/serial/SomeSer.java
@@ -43,7 +43,7 @@ public abstract class SomeSer implements Serializable {
   interface OthSer extends Serializable {}
 }
 
-@Value.Immutable
+@Value.Immutable(serialForm = true)
 abstract class CollectionSer implements Serializable {
     abstract Set<String> strings();
     abstract List<CollectionSer> list01();

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -287,7 +287,7 @@ static class ImmutableSerialForm[type.generics] implements java.io.Serializable 
 	    builder.[v.names.init](this.[v.name]);
 	  }
     [else if v.collectionType]
-      builder.[v.names.add](this.[v.name]);
+      builder.[v.names.addv](this.[v.name]);
 	[else if v.mapType]
 	  for (int i = 0; i < [v.name]Keys.length; ++i) {
 	    builder.[v.names.put]([v.name]Keys['[']i[']'], [v.name]Values['[']i[']']);

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -237,6 +237,7 @@ implements java.io.Serializable {[/if]
 [template generateSerialization Type type]
 [serialVersionUID type]
 [if type.serial.simple]
+[if type.generateSerialForm]
 /**
  * Serialized form.
  */
@@ -313,6 +314,20 @@ private Object writeReplace() throws java.io.ObjectStreamException {
 private void readObject(final java.io.ObjectInputStream ois) throws java.io.IOException {
   throw new java.io.StreamCorruptedException("[type.name] instance can only be deserialized from its serial form.");
 }
+[else]
+  [if type.useSimpleReadResolve]
+
+private Object readResolve() throws java.io.ObjectStreamException {
+[if type.useSingletonOnly][-- don't care about validation here, just substitute --]
+  return INSTANCE;
+[else if type.usePrehashed and type.useCopyConstructor]
+  [generateReturnCopyRaw type '' '']
+[else]
+  return [validated type false]this[/validated];
+[/if]
+}
+  [/if]
+[/if]
 [/if]
 [if type.serial.structural]
 

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -237,18 +237,82 @@ implements java.io.Serializable {[/if]
 [template generateSerialization Type type]
 [serialVersionUID type]
 [if type.serial.simple]
-  [if type.useSimpleReadResolve]
-
-private Object readResolve() throws java.io.ObjectStreamException {
-[if type.useSingletonOnly][-- don't care about validation here, just substitute --]
-  return INSTANCE;
-[else if type.usePrehashed and type.useCopyConstructor]
-  [generateReturnCopyRaw type '' '']
-[else]
-  return [validated type false]this[/validated];
+/**
+ * Serialized form.
+ */
+[atGenerated type]
+[if type.generics]
+@SuppressWarnings("unchecked")
 [/if]
-}
+static class ImmutableSerialForm[type.generics] implements java.io.Serializable {
+  [for v in type.constructableAttributes]
+  [if v.optionalType]
+	private final [v.wrappedElementType] [v.name];
+  [else if v.collectionType]
+    private final [v.unwrappedElementType]['[]'] [v.name];
+  [else if v.mapType]
+    private final [v.wrappedElementType]['[]'] [v.name]Keys;
+    private final [v.wrappedSecondaryElementType]['[]'] [v.name]Values;
+  [else]
+	private final [v.type] [v.name];
   [/if]
+  [/for]
+  private ImmutableSerialForm(final [type.typeImmutable] instance)
+  {
+  	[for v in type.constructableAttributes]
+	  [if v.optionalType]
+	  	this.[v.name] = instance.[v.names.get]().[optionalPresent v] ? instance.[v.names.get]().[optionalGet v] : null;
+      [else if v.collectionType]
+        [if v.unwrappedElementPrimitiveType]
+        this.[v.name] = [guava].primitives.[toUpper v.unwrappedElementType]s.toArray(instance.[v.names.get]());
+        [else]
+        this.[v.name] = instance.[v.names.get]().toArray(new [v.unwrappedElementType]['[']instance.[v.names.get]().size()[']']);
+        [/if]
+	  [else if v.mapType]
+        this.[v.name]Keys = instance.[v.names.get]().keySet().toArray(new [v.wrappedElementType]['[']instance.[v.names.get]().keySet().size()[']']);
+        this.[v.name]Values = instance.[v.names.get]().values().toArray(new [v.wrappedSecondaryElementType]['[']instance.[v.names.get]().values().size()[']']);
+	  [else]
+	    this.[v.name] = instance.[v.names.get]();
+	  [/if]
+	[/for]
+  }
+  
+  private final Object readResolve() throws java.io.ObjectStreamException
+  {
+  [if type.useBuilder]
+    [type.typeBuilder] builder = [castBuildStagedBuilder type][type.factoryBuilder.relative]()[/castBuildStagedBuilder];
+  	[for v in type.constructableAttributes]
+    [if v.optionalType]
+	  if (this.[v.name] != null) {
+	    builder.[v.names.init](this.[v.name]);
+	  }
+    [else if v.collectionType]
+      builder.[v.names.add](this.[v.name]);
+	[else if v.mapType]
+	  for (int i = 0; i < [v.name]Keys.length; ++i) {
+	    builder.[v.names.put]([v.name]Keys['[']i[']'], [v.name]Values['[']i[']']);
+	  }
+    [else]
+      builder.[v.names.init](this.[v.name]);
+    [/if]
+	[/for]
+	return builder.[type.names.build]();
+  [else if type.useConstructor]
+    return [type.factoryOf.relative]([output.linesShortable][for v in type.constructorArguments][if not for.first],[/if]
+        [if v.collectionType or v.mapType][if v.nullable][v.name]Builder == null ? null : [/if][createBuiltCollection type v][v.name]Builder[/createBuiltCollection][else][v.name]Value[/if][/for]);[/output.linesShortable]
+  [else if type.useSingleton]
+    return [type.factoryInstance.relative]();
+  [else]
+    [output.error]Cannot generate code when there are no builder, constructor or singleton available[/output.error]
+  [/if]  
+  }
+}
+private Object writeReplace() throws java.io.ObjectStreamException {
+  return new ImmutableSerialForm(this);
+}
+private void readObject(final java.io.ObjectInputStream ois) throws java.io.IOException {
+  throw new java.io.StreamCorruptedException("[type.name] instance can only be deserialized from its serial form.");
+}
 [/if]
 [if type.serial.structural]
 

--- a/value-processor/src/org/immutables/value/processor/meta/ValueImmutableInfo.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueImmutableInfo.java
@@ -51,6 +51,10 @@ public abstract class ValueImmutableInfo implements ValueMirrors.Immutable {
   @Value.Parameter
   @Override
   public abstract boolean singleton();
+  
+  @Value.Parameter
+  @Override
+  public abstract boolean serialForm();
 
   static ImmutableValueImmutableInfo infoFrom(ImmutableMirror input) {
     return ImmutableValueImmutableInfo.theOf(
@@ -58,7 +62,8 @@ public abstract class ValueImmutableInfo implements ValueMirrors.Immutable {
         input.copy(),
         input.intern(),
         input.prehash(),
-        input.singleton())
+        input.singleton(),
+        input.serialForm())
         .withIsDefault(input.getAnnotationMirror().getElementValues().isEmpty());
   }
 }

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -36,6 +36,8 @@ public final class ValueMirrors {
     boolean prehash() default false;
 
     boolean builder() default true;
+    
+    boolean serialForm() default false;
   }
 
   @Mirror.Annotation("org.immutables.value.Value.Include")

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -597,6 +597,12 @@ public final class ValueType extends TypeIntrospectionBase implements HasStyleIn
         && immutableFeatures.intern()
         && !isUseSingletonOnly();
   }
+  
+  public boolean isGenerateSerialForm() {
+      return immutableFeatures.serialForm()
+              && serial.isEnabled()
+              && !serial.isStructural();
+  }
 
   public boolean isUsePrehashed() {
     return immutableFeatures.prehash()
@@ -1413,7 +1419,7 @@ public final class ValueType extends TypeIntrospectionBase implements HasStyleIn
     public boolean isEnabled() {
       return this != NONE;
     }
-
+    
     public boolean isStructural() {
       return this == STRUCTURAL
           || this == STRUCTURAL_IMPLEMENTS;


### PR DESCRIPTION
Fixes #968 
Work in progress as this is my first time playing with Immutables but I would like to discuss changes/how to contribute etc.

This PR introduces generation of ImmutableSerialForm class and writeReplace() method that returns an instance of this class.
ImmutableSerialForm.readResolve() uses the builder to create the deserialized instance.
readObject() method is also generated in the Immutable value class - it throws StreamCorruptedException to make sure noone tries to cheat by providing an stream with data bypassing the ImmutableSerialForm.

What's left (non-exhaustive list):
- it is not backwards compatible in case the abstract value type defines its own writeReplace or readObject method. I have no idea how to fix this - probably some additional annotation/attribute would be needed.
- it most probably does not handle constructor invocation correctly (just using the builder) and many potential special/corner cases.

Please let me know what to add/change. I am using this implementation in my own project right now and it is suitable **for me** :)