### PR TITLE
Criteria. First Sketches of Mongo Adapter

### DIFF
--- a/criteria/common/pom.xml
+++ b/criteria/common/pom.xml
@@ -58,4 +58,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/criteria/mongo/README.md
+++ b/criteria/mongo/README.md
@@ -1,0 +1,1 @@
+Mongo Adapter. Uses [reactive streams](https://mongodb.github.io/mongo-java-driver-reactivestreams/) driver.

--- a/criteria/mongo/pom.xml
+++ b/criteria/mongo/pom.xml
@@ -24,20 +24,46 @@
     <artifactId>criteria-mongo</artifactId>
     <name>${project.groupId}.${project.artifactId}</name>
     <description>
-        Criteria support for MongoDB
+      Mongo Adapter for Criteria
     </description>
 
     <dependencies>
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>criteria-common</artifactId>
+            <type>jar</type>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <!-- Required. -->
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-            <version>${mongo-java-driver.version}</version>
+            <artifactId>mongodb-driver-reactivestreams</artifactId>
+            <version>${mongodb-driver-reactivestreams.version}</version>
         </dependency>
+        <dependency>
+            <groupId>de.bwaldvogel</groupId>
+            <artifactId>mongo-java-server</artifactId>
+            <version>${mongo-java-server.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>criteria-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.reactivex.rxjava2</groupId>
+            <artifactId>rxjava</artifactId>
+            <version>${rxjava2.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/criteria/mongo/src/org/immutables/criteria/mongo/MongoRepository.java
+++ b/criteria/mongo/src/org/immutables/criteria/mongo/MongoRepository.java
@@ -1,0 +1,34 @@
+package org.immutables.criteria.mongo;
+
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.Success;
+import org.bson.conversions.Bson;
+import org.immutables.criteria.constraints.Expressional;
+import org.reactivestreams.Publisher;
+
+import java.util.Objects;
+
+/**
+ * Allows to query mongo documents using criteria API.
+ *
+ * <p>Based on <a href="https://mongodb.github.io/mongo-java-driver-reactivestreams/">Mongo reactive streams driver</a>
+ */
+class MongoRepository<T> {
+
+  private final MongoCollection<T> collection;
+
+  MongoRepository(MongoCollection<T> collection) {
+    this.collection = Objects.requireNonNull(collection, "collection");
+  }
+
+
+  public Publisher<T> query(Expressional<T> expressional) {
+    final Bson filter = Mongos.toBson(collection.getCodecRegistry(), expressional.expression());
+    return collection.find(filter);
+  }
+
+  public Publisher<Success> insert(T entity) {
+    return collection.insertOne(entity);
+  }
+
+}

--- a/criteria/mongo/src/org/immutables/criteria/mongo/MongoVisitor.java
+++ b/criteria/mongo/src/org/immutables/criteria/mongo/MongoVisitor.java
@@ -1,0 +1,102 @@
+package org.immutables.criteria.mongo;
+
+import com.google.common.base.Preconditions;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWriter;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.BsonWriter;
+import org.bson.codecs.Encoder;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.immutables.criteria.constraints.Call;
+import org.immutables.criteria.constraints.Expression;
+import org.immutables.criteria.constraints.ExpressionVisitor;
+import org.immutables.criteria.constraints.Literal;
+import org.immutables.criteria.constraints.Operator;
+import org.immutables.criteria.constraints.Operators;
+import org.immutables.criteria.constraints.Path;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Generates mongo query using visitor API.
+ */
+class MongoVisitor implements ExpressionVisitor<BsonValue, Void> {
+
+  private final CodecRegistry registry;
+
+  MongoVisitor(CodecRegistry registry) {
+    this.registry = Objects.requireNonNull(registry, "registry");
+  }
+
+  @Override
+  public BsonValue visit(Call<?> call, @Nullable Void context) {
+    final Operator op = call.getOperator();
+    final List<Expression<?>> args = call.getArguments();
+
+    if (op == Operators.EQUAL || op == Operators.NOT_EQUAL) {
+      Preconditions.checkArgument(args.size() == 2, "Size should be 2 for %s but was %s", op, args.size());
+      Preconditions.checkArgument(args.get(0) instanceof Path, "first argument should be path access");
+      Preconditions.checkArgument(args.get(1) instanceof Literal, "second argument should be literal");
+
+      BsonValue field = args.get(0).accept(this, null);
+      BsonValue value = args.get(1).accept(this, null);
+      Preconditions.checkNotNull(field, "field");
+      Preconditions.checkNotNull(value, "value");
+
+      BsonDocument doc = new BsonDocument();
+      doc.put(field.asString().getValue(), op == Operators.NOT_EQUAL ? new BsonDocument("$ne", value) : value);
+
+      return doc;
+    }
+
+    if (op == Operators.AND || op == Operators.OR) {
+      final BsonDocument doc = new BsonDocument();
+
+      final BsonArray array = call.getArguments().stream()
+              .map(a -> a.accept(this, null))
+              .collect(Collectors.toCollection(BsonArray::new));
+
+      doc.put(op == Operators.AND ? "$and" : "$or", array);
+
+      return doc;
+    }
+
+    throw new UnsupportedOperationException(String.format("Not yet supported (%s): %s", call.getOperator(), call));
+  }
+
+  @Override
+  public BsonValue visit(Literal<?> literal, @Nullable Void context) {
+    final Object value = literal.value();
+
+    if (value == null) {
+      return BsonNull.VALUE;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    final Encoder<Object> encoder = (Encoder<Object>) registry.get(value.getClass());
+
+    final BsonDocument bson = new BsonDocument();
+    final BsonWriter writer = new BsonDocumentWriter(bson);
+    // Bson doesn't allow to write directly scalars / primitives, they have to be embedded in a
+    // document.
+    writer.writeStartDocument();
+    writer.writeName("$");
+    encoder.encode(writer, value, EncoderContext.builder().build());
+    writer.writeEndDocument();
+    writer.flush();
+    return bson.get("$");
+  }
+
+  @Override
+  public BsonString visit(Path<?> path, @Nullable Void context) {
+    return new BsonString(path.path());
+  }
+}

--- a/criteria/mongo/src/org/immutables/criteria/mongo/Mongos.java
+++ b/criteria/mongo/src/org/immutables/criteria/mongo/Mongos.java
@@ -1,0 +1,22 @@
+package org.immutables.criteria.mongo;
+
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+import org.immutables.criteria.constraints.Expression;
+
+/**
+ * Util methods for mongo adapter.
+ */
+final class Mongos {
+
+  private Mongos() {}
+
+  /**
+   * Convert existing expression to Bson
+   */
+  static <T> Bson toBson(CodecRegistry registry, Expression<T> expression) {
+    MongoVisitor visitor = new MongoVisitor(registry);
+    return expression.accept(visitor, null).asDocument();
+  }
+
+}

--- a/criteria/mongo/test/org/immutables/criteria/mongo/MongoRepositoryTest.java
+++ b/criteria/mongo/test/org/immutables/criteria/mongo/MongoRepositoryTest.java
@@ -1,0 +1,64 @@
+package org.immutables.criteria.mongo;
+
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import de.bwaldvogel.mongo.MongoServer;
+import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
+import io.reactivex.Flowable;
+import org.immutables.criteria.Person;
+import org.immutables.criteria.PersonCriteria;
+import org.immutables.criteria.constraints.Expressional;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Basic tests of mongo adapter
+ */
+public class MongoRepositoryTest {
+
+
+  private final MongoServer server = new MongoServer(new MemoryBackend());
+  private final MongoClient client = MongoClients.create(String.format("mongodb://localhost:%d", server.bind().getPort()));
+
+  private MongoCollection<Person> collection;
+
+  private MongoRepository<Person> repository;
+
+  @Before
+  public void setUp() throws Exception {
+
+    Flowable.fromPublisher(client.getDatabase("test").createCollection("test"))
+            .test()
+            .awaitTerminalEvent();
+
+    this.collection = client.getDatabase("test").getCollection("test").withDocumentClass(Person.class);
+    this.repository = new MongoRepository<>(this.collection);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    client.close();
+    server.shutdownNow();
+  }
+
+  @Test
+  public void basic() {
+    execute(PersonCriteria.create().firstName.isEqualTo("aaa"));
+    execute(PersonCriteria.create().firstName.isEqualTo("aaa")
+            .age.isNotEqualTo(22));
+
+  }
+
+  private void execute(Expressional<Person> expr) {
+
+    Flowable.fromPublisher(repository.query(expr))
+            .test()
+            .awaitDone(1, TimeUnit.SECONDS)
+            .assertValueCount(0);
+
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
     <!-- Shared versions -->
     <retro.version>2.5.1</retro.version>
     <mongo-java-driver.version>3.10.1</mongo-java-driver.version>
+    <mongodb-driver-reactivestreams.version>1.11.0</mongodb-driver-reactivestreams.version>
     <mongo-java-server.version>1.14.0</mongo-java-server.version>
     <jackson.version>2.8.11</jackson.version>
     <jackson-databind.version>2.8.11.3</jackson-databind.version>
@@ -112,6 +113,7 @@
     <gson.version>2.8.5</gson.version>
     <slf4j.version>1.7.25</slf4j.version>
     <jsr305.version>1.3.9</jsr305.version>
+    <rxjava2.version>2.2.8</rxjava2.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Add Mongo Adapter to see how criteria works with external data-sources. 

This implementation uses [reactive streams](https://github.com/mongodb/mongo-java-driver-reactivestreams) driver.

Add rxjava2 as test dependency for easier validation of results (which are async by default).