### PR TITLE
Criteria. Migrate matchers to interfaces

### DIFF
--- a/criteria/common/src/org/immutables/criteria/expression/Operators.java
+++ b/criteria/common/src/org/immutables/criteria/expression/Operators.java
@@ -13,6 +13,7 @@ public enum Operators implements Operator {
   ANY, // some elements match (at least one)
   EMPTY, // means collection is empty
   SIZE, // size of the collection
+  CONTAINS,
 
   // boolean ops
   AND,

--- a/criteria/common/src/org/immutables/criteria/matcher/BooleanMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/BooleanMatcher.java
@@ -22,24 +22,18 @@ import org.immutables.criteria.expression.Operators;
 /**
  * Very simple matcher for booleans just has {@code true} / {@code false} checks.
  */
-public class BooleanMatcher<R> extends ObjectMatcher<R, Boolean> {
+public interface BooleanMatcher<R>  {
 
-  public BooleanMatcher(CriteriaContext<R> context) {
-    super(context);
+  default R isTrue() {
+    return Matchers.extract(this).<R>factory1()
+            .create1(e -> Expressions.call(Operators.EQUAL, e, Expressions.constant(Boolean.TRUE)));
   }
 
-  public R isTrue() {
-    return create(e -> Expressions.call(Operators.EQUAL, e, Expressions.constant(Boolean.TRUE)));
+  default R isFalse() {
+    return Matchers.extract(this).<R>factory1()
+            .create1(e -> Expressions.call(Operators.EQUAL, e, Expressions.constant(Boolean.FALSE)));
   }
 
-  public R isFalse() {
-    return create(e -> Expressions.call(Operators.EQUAL, e, Expressions.constant(Boolean.FALSE)));
-  }
-
-  public static class Self extends BooleanMatcher<Self> {
-    public Self(CriteriaContext<BooleanMatcher.Self> context) {
-      super(context);
-    }
-  }
+  interface Self extends BooleanMatcher<Self> {}
 
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/CollectionMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/CollectionMatcher.java
@@ -7,76 +7,67 @@ import org.immutables.criteria.expression.Operators;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
 
-public class CollectionMatcher<R, S, C>  {
+public interface CollectionMatcher<R, S, C, V> {
 
-  private final CriteriaContext<R> context;
-  private final CriteriaCreator<S> inner;
-  private final CriteriaCreator<C> outer;
-
-  public CollectionMatcher(CriteriaContext<R> context, CriteriaCreator<S> inner, CriteriaCreator<C> outer) {
-    this.context = Objects.requireNonNull(context, "context");
-    this.inner = Objects.requireNonNull(inner, "inner");
-    this.outer = Objects.requireNonNull(outer, "outer");
-  }
-
-  public S all() {
+  default S all() {
     final UnaryOperator<Expression> expr = e -> Expressions.call(Operators.ALL, e);
-    return inner.create((CriteriaContext<S>) context.create(expr));
+    return Matchers.extract(this).<R, S, C>factory3().create2(expr);
   }
 
-  public R all(UnaryOperator<C> consumer) {
-    final UnaryOperator<Expression> expr = e -> Expressions.call(Operators.ALL, toExpressionOperator(consumer).apply(e));
-    return context.create(expr);
+  default R all(UnaryOperator<C> consumer) {
+    final CriteriaCreator.TriFactory<R, S, C> factory3 = Matchers.extract(this).<R, S, C>factory3();
+    final UnaryOperator<Expression> expr = e -> Expressions.call(Operators.ALL,
+            Matchers.toExpressionOperator(factory3::create3, consumer).apply(e));
+    return factory3.create1(expr);
   }
 
-  public S none() {
+  default S none() {
     final UnaryOperator<Expression> expr = e -> Expressions.call(Operators.NONE, e);
-    return inner.create((CriteriaContext<S>) context.create(expr));
+    return Matchers.extract(this).<R, S, C>factory3().create2(expr);
   }
 
-  public R none(UnaryOperator<C> consumer) {
-    final UnaryOperator<Expression> expr = e -> Expressions.call(Operators.NONE, toExpressionOperator(consumer).apply(e));
-    return context.create(expr);
+  default R none(UnaryOperator<C> consumer) {
+    final CriteriaCreator.TriFactory<R, S, C> factory3 = Matchers.extract(this).<R, S, C>factory3();
+    final UnaryOperator<Expression> expr = e -> Expressions.call(Operators.NONE,
+            Matchers.toExpressionOperator(factory3::create3, consumer).apply(e));
+    return factory3.create1(expr);
   }
 
-  public S any() {
+  default S any() {
     final UnaryOperator<Expression> expr = e -> Expressions.call(Operators.ANY, e);
-    return inner.create((CriteriaContext<S>) context.create(expr));
+    return Matchers.extract(this).<R, S, C>factory3().create2(expr);
   }
 
-  public R any(UnaryOperator<C> consumer) {
-    final UnaryOperator<Expression> expr = e -> Expressions.call(Operators.ANY, toExpressionOperator(consumer).apply(e));
-    return context.create(expr);
+  default R any(UnaryOperator<C> consumer) {
+    final CriteriaCreator.TriFactory<R, S, C> factory3 = Matchers.extract(this).<R, S, C>factory3();
+    final UnaryOperator<Expression> expr = e -> Expressions.call(Operators.ANY,
+            Matchers.toExpressionOperator(factory3::create3, consumer).apply(e));
+    return factory3.create1(expr);
   }
 
-  public S at(int index) {
+  default S at(int index) {
     throw new UnsupportedOperationException();
   }
 
-  public R isEmpty() {
-    return context.create(e -> Expressions.call(Operators.EMPTY, e));
+  default R contains(V value) {
+    return Matchers.extract(this).<R, S, C>factory3().create1(e -> Expressions.call(Operators.CONTAINS, e));
   }
 
-  public R isNotEmpty() {
-    return context.create(e -> Expressions.not(Expressions.call(Operators.EMPTY, e)));
+  default R isEmpty() {
+    return Matchers.extract(this).<R, S, C>factory3().create1(e -> Expressions.call(Operators.EMPTY, e));
   }
 
-  public R hasSize(int size) {
-    return context.create(e -> Expressions.call(Operators.SIZE, e, Expressions.constant(size)));
+  default R isNotEmpty() {
+    return Matchers.extract(this).<R, S, C>factory3().create1(e -> Expressions.not(Expressions.call(Operators.EMPTY, e)));
   }
 
-  private UnaryOperator<Expression> toExpressionOperator(UnaryOperator<C> operator) {
-    return expression -> {
-      final C initial = context.withCreator(outer).create();
-      final C changed = operator.apply(initial);
-      return Matchers.extract(changed);
-    };
+  default R hasSize(int size) {
+    UnaryOperator<Expression> expr = e -> Expressions.call(Operators.SIZE, e, Expressions.constant(size));
+    return Matchers.extract(this).<R, S, C>factory3().create1(expr);
+
   }
 
-  public static class Self extends CollectionMatcher<Self, Self, Self> {
-    public Self(CriteriaContext<Self> context) {
-      super(context, Self::new, Self::new);
-    }
-  }
+
+  interface Self<V> extends CollectionMatcher<Self, Self, Self, V> {}
 
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/ComparableMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/ComparableMatcher.java
@@ -22,47 +22,38 @@ import org.immutables.criteria.expression.Operators;
 /**
  * Criteria for comparables (like {@code >, <=, >} and ranges).
  */
-public class ComparableMatcher<R, V extends Comparable<V>>
-        extends ObjectMatcher<R, V> {
+public interface ComparableMatcher<R, V extends Comparable<V>> extends ObjectMatcher<R, V> {
 
-  public ComparableMatcher(CriteriaContext<R> context) {
-    super(context);
-  }
-
-  /**]
+  /**
    * Checks that attribute is less than (but not equal to) {@code upper}.
    * <p>Use {@link #isAtMost(Comparable)} for less <i>or equal</i> comparison</p>
    */
-  public R isLessThan(V upper) {
-    return create(e -> Expressions.call(Operators.LESS_THAN, e, Expressions.constant(upper)));
+  default R isLessThan(V upper) {
+    return Matchers.extract(this).<R>factory1().create1(e -> Expressions.call(Operators.LESS_THAN, e, Expressions.constant(upper)));
   }
 
   /**
    * Checks that attribute is greater than (but not equal to)  {@code lower}.
    * <p>Use {@link #isAtLeast(Comparable)} for greater <i>or equal</i> comparison</p>
    */
-  public R isGreaterThan(V lower) {
-    return create(e -> Expressions.call(Operators.GREATER_THAN, e, Expressions.constant(lower)));
+  default R isGreaterThan(V lower) {
+    return Matchers.extract(this).<R>factory1().create1(e -> Expressions.call(Operators.GREATER_THAN, e, Expressions.constant(lower)));
   }
 
   /**
    * Checks that attribute is less than or equal to {@code upperInclusive}.
    */
-  public R isAtMost(V upperInclusive) {
-    return create(e -> Expressions.call(Operators.LESS_THAN_OR_EQUAL, e, Expressions.constant(upperInclusive)));
+  default R isAtMost(V upperInclusive) {
+    return Matchers.extract(this).<R>factory1().create1(e -> Expressions.call(Operators.LESS_THAN_OR_EQUAL, e, Expressions.constant(upperInclusive)));
   }
 
   /**
    * Checks that attribute is greater or equal to {@code lowerInclusive}.
    */
-  public R isAtLeast(V lowerInclusive) {
-    return create(e -> Expressions.call(Operators.GREATER_THAN_OR_EQUAL, e, Expressions.constant(lowerInclusive)));
+  default R isAtLeast(V lowerInclusive) {
+    return Matchers.extract(this).<R>factory1().create1(e -> Expressions.call(Operators.GREATER_THAN_OR_EQUAL, e, Expressions.constant(lowerInclusive)));
   }
 
-  public static class Self<V extends Comparable<V>> extends ComparableMatcher<Self<V>, V> {
-    public Self(CriteriaContext<ComparableMatcher.Self<V>> context) {
-      super(context);
-    }
-  }
+  interface Self<V extends Comparable<V>> extends ComparableMatcher<Self<V>, V> {}
 
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/CriteriaContext.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/CriteriaContext.java
@@ -1,12 +1,16 @@
 package org.immutables.criteria.matcher;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import org.immutables.criteria.expression.DnfExpression;
 import org.immutables.criteria.expression.Expression;
 import org.immutables.criteria.expression.Expressional;
+import org.immutables.criteria.expression.Expressions;
 import org.immutables.criteria.expression.Operator;
 import org.immutables.criteria.expression.Operators;
 import org.immutables.criteria.expression.Path;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
 
@@ -14,47 +18,124 @@ import java.util.function.UnaryOperator;
  * Link between front-end (Criteria DSL) and <a href="https://cs.lmu.edu/~ray/notes/ir/">Intermediate Representation</a>
  * (internally known as {@link Expression}).
  */
-public final class CriteriaContext<R> implements Expressional {
+public final class CriteriaContext implements Expressional {
 
-  private final CriteriaCreator<R> creator;
+  private final List<CriteriaCreator<?>> creators;
   private final DnfExpression expression;
   private final Path path;
   private final Operator operator;
 
-  public CriteriaContext(CriteriaCreator<R> creator) {
-    this(Operators.AND, DnfExpression.create(), null, creator);
+  public CriteriaContext(CriteriaCreator<?> creator) {
+    this(Operators.AND, DnfExpression.create(), null, ImmutableList.of(creator));
   }
 
-  private CriteriaContext(Operator operator, DnfExpression expression, Path path, CriteriaCreator<R> creator) {
-    this.creator = creator;
+  private CriteriaContext(Operator operator, DnfExpression expression, Path path, List<CriteriaCreator<?>> creators) {
+    this.creators = ImmutableList.copyOf(creators);
     this.expression = expression;
     this.path = path;
     this.operator = operator;
   }
 
-  public <S> CriteriaContext<S> withCreator(CriteriaCreator<S> creator) {
+  public <S> CriteriaContext withCreators(CriteriaCreator<S> creator) {
     Objects.requireNonNull(creator, "creator");
-    return new CriteriaContext<S>(operator, expression, path, creator);
+    return new CriteriaContext(operator, expression, path, ImmutableList.of(creator));
   }
 
-  public R create() {
-    return creator.create(this);
+
+  public <T1, T2> CriteriaContext withCreators(CriteriaCreator<T1> c1, CriteriaCreator<T2> c2) {
+    Objects.requireNonNull(c1, "c1");
+    Objects.requireNonNull(c2, "c2");
+
+    return new CriteriaContext(operator, expression, path, ImmutableList.of(c1, c2));
+  }
+
+  public <T1, T2, T3> CriteriaContext withCreators(CriteriaCreator<T1> c1, CriteriaCreator<T2> c2, CriteriaCreator<T3> c3) {
+    Objects.requireNonNull(c1, "c1");
+    Objects.requireNonNull(c2, "c2");
+    Objects.requireNonNull(c3, "c3");
+
+    return new CriteriaContext(operator, expression, path, ImmutableList.of(c1, c2, c3));
+  }
+
+
+  public <T1> CriteriaCreator.SingleFactory<T1> factory1() {
+    Preconditions.checkState(creators.size() > 0, "Expected size > 0 got %s", creators.size());
+
+    return new CriteriaCreator.SingleFactory<T1>() {
+      @Override
+      public CriteriaCreator<T1> creator1() {
+        return (CriteriaCreator<T1>) creators.get(0);
+      }
+
+      @Override
+      public CriteriaContext context() {
+        return CriteriaContext.this;
+      }
+    };
+  }
+
+  public <T1, T2> CriteriaCreator.BiFactory<T1, T2> factory2() {
+    Preconditions.checkState(creators.size() > 1, "Expected size > 1 got %s", creators.size());
+
+    return new CriteriaCreator.BiFactory<T1, T2>() {
+      @Override
+      public CriteriaCreator<T2> creator2() {
+        return (CriteriaCreator<T2>) creators.get(1);
+      }
+
+      @Override
+      public CriteriaCreator<T1> creator1() {
+        return (CriteriaCreator<T1>) creators.get(0);
+      }
+
+      @Override
+      public CriteriaContext context() {
+        return CriteriaContext.this;
+      }
+    };
+  }
+
+  public <T1, T2, T3> CriteriaCreator.TriFactory<T1, T2, T3>  factory3() {
+    Preconditions.checkState(creators.size() > 2, "Expected size > 2 got %s", creators.size());
+
+    return new CriteriaCreator.TriFactory<T1, T2, T3>() {
+      @Override
+      public CriteriaCreator<T3> creator3() {
+        return (CriteriaCreator<T3>) creators.get(2);
+      }
+
+      @Override
+      public CriteriaCreator<T2> creator2() {
+        return (CriteriaCreator<T2>) creators.get(1);
+      }
+
+      @Override
+      public CriteriaCreator<T1> creator1() {
+        return (CriteriaCreator<T1>) creators.get(0);
+      }
+
+      @Override
+      public CriteriaContext context() {
+        return CriteriaContext.this;
+      }
+    };
   }
 
   /**
-   *  adds an intermediate step (list of paths usually)
+   *  adds an intermediate path
    */
-  public CriteriaContext<R> add(Path path) {
+  public CriteriaContext withPath(String pathAsString) {
+    final Path path = Expressions.path(pathAsString);
     final Path newPath = this.path != null ? this.path.concat(path) : path;
-    return new CriteriaContext<>(operator, expression, newPath, creator);
+    return new CriteriaContext(operator, expression, newPath, creators);
   }
 
-  public CriteriaContext<R> or() {
+  public CriteriaContext or() {
     if (operator == Operators.OR) {
       return this;
     }
 
-    return new CriteriaContext<>(Operators.OR, expression, path, creator);
+    return new CriteriaContext(Operators.OR, expression, path, creators);
   }
 
   @Override
@@ -62,12 +143,12 @@ public final class CriteriaContext<R> implements Expressional {
     return this.expression.expression();
   }
 
-  @SuppressWarnings("unchecked")
-  public R create(UnaryOperator<Expression> operator) {
+  public CriteriaContext withOperator(UnaryOperator<Expression> operator) {
+    Objects.requireNonNull(operator, "operator");
     final Expression apply = operator.apply(path);
     final DnfExpression existing = expression;
     final DnfExpression newExpression = this.operator == Operators.AND ? existing.and(apply) : existing.or(apply);
-    return new CriteriaContext<R>(Operators.AND, newExpression, null, creator).create();
+    return new CriteriaContext(Operators.AND, newExpression, null, creators);
   }
 
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/CriteriaCreator.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/CriteriaCreator.java
@@ -15,11 +15,81 @@
  */
 package org.immutables.criteria.matcher;
 
+import org.immutables.criteria.expression.Expression;
+
+import java.util.function.UnaryOperator;
+
 /**
  * Creates document criteria from existing expression.
  */
 public interface CriteriaCreator<R> {
 
-  R create(CriteriaContext<R> context);
+  R create(CriteriaContext context);
+
+  interface Factory {
+    CriteriaContext context();
+  }
+
+  interface SingleFactory<T1> extends Factory {
+    CriteriaCreator<T1> creator1();
+
+    default T1 create1(UnaryOperator<Expression> operator) {
+      return creator1().create(context().withOperator(operator));
+    }
+
+    default T1 create1() {
+      return creator1().create(context());
+    }
+  }
+
+  interface BiFactory<T1, T2> extends SingleFactory<T1> {
+
+    CriteriaCreator<T2> creator2();
+
+    default T2 create2(UnaryOperator<Expression> operator) {
+      return creator2().create(context().withOperator(operator));
+    }
+
+    default T2 create2() {
+      return creator2().create(context());
+    }
+
+  }
+
+  interface TriFactory<T1, T2, T3>  extends BiFactory<T1, T2> {
+    CriteriaCreator<T3> creator3();
+
+    default T3 create3(UnaryOperator<Expression> operator) {
+      return creator3().create(context().withOperator(operator));
+    }
+
+    default T3 create3() {
+      return creator3().create(context());
+    }
+
+  }
+
+  interface QuadFactory<T1, T2, T3, T4>  extends TriFactory<T1, T2, T3> {
+    CriteriaCreator<T4> creator4();
+
+    default T4 create4(UnaryOperator<Expression> operator) {
+      return creator4().create(context().withOperator(operator));
+    }
+
+    default T4 create4() {
+      return creator4().create(context());
+    }
+
+  }
+
+
+  /**
+   * Used to create a no-op creator
+   */
+  static <R> CriteriaCreator<R> unsupported() {
+    return context -> {
+      throw new UnsupportedOperationException("Not supposed to be called");
+    };
+  }
 
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/Matchers.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/Matchers.java
@@ -2,34 +2,177 @@ package org.immutables.criteria.matcher;
 
 import org.immutables.criteria.expression.Expression;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 public class Matchers {
+
+
+  interface HasContext {
+    CriteriaContext context();
+  }
+
+  public static <R> BooleanMatcher<R> booleanMatcher(CriteriaContext context) {
+    Objects.requireNonNull(context, "context");
+    class Local implements BooleanMatcher.Self, HasContext {
+      @Override
+      public CriteriaContext context() {
+        return context;
+      }
+    }
+
+    return (BooleanMatcher<R>) new Local();
+  }
+
+  public static <R> StringMatcher<R> stringMatcher(CriteriaContext context) {
+    Objects.requireNonNull(context, "context");
+    class Local implements StringMatcher.Self, HasContext {
+      @Override
+      public CriteriaContext context() {
+        return context;
+      }
+    }
+
+    return (StringMatcher<R>) new Local();
+  }
+
+  public static <R, V extends Comparable<V>> ComparableMatcher<R, V> comparableMatcher(CriteriaContext context) {
+    Objects.requireNonNull(context, "context");
+    class Local implements ComparableMatcher.Self, HasContext {
+      @Override
+      public CriteriaContext context() {
+        return context;
+      }
+    }
+    return (ComparableMatcher<R, V>) new Local();
+  }
+
+  public static <R, V> ObjectMatcher<R, V> objectMatcher(CriteriaContext context) {
+    Objects.requireNonNull(context, "context");
+    class Local implements ObjectMatcher.Self<V>, HasContext {
+      @Override
+      public CriteriaContext context() {
+        return context;
+      }
+    }
+    return (ObjectMatcher<R, V>) new Local();
+  }
+
+  public static <R, S, C> OptionalMatcher<R, S, C> optionalMatcher(CriteriaContext context) {
+    Objects.requireNonNull(context, "context");
+    class Local implements OptionalMatcher, HasContext {
+      @Override
+      public CriteriaContext context() {
+        return context;
+      }
+    }
+    return new Local();
+  }
+
+  public static <R, S, C, V> CollectionMatcher<R, S, C, V> collectionMatcher(CriteriaContext context) {
+    Objects.requireNonNull(context, "context");
+
+    class Local implements CollectionMatcher.Self, HasContext {
+      @Override
+      public CriteriaContext context() {
+        return context;
+      }
+    }
+
+    return (CollectionMatcher<R, S, C, V>) new Local();
+  }
+
+  public static <T> T create(Class<T> type, CriteriaContext context) {
+    Objects.requireNonNull(type, "type");
+
+//    if (type.getSimpleName().equals("Self") && !type.isInterface()) {
+//      return createWithReflection(type, context);
+//    }
+
+    if (type == BooleanMatcher.class || type == BooleanMatcher.Self.class) {
+      return (T) booleanMatcher(context);
+    } else if (type == StringMatcher.class || type == StringMatcher.Self.class) {
+      return (T) stringMatcher(context);
+    } else if (type == ComparableMatcher.class) {
+      return (T) comparableMatcher(context);
+    } else if (type == ObjectMatcher.class) {
+      return (T) objectMatcher(context);
+    } else if (type == OptionalMatcher.class) {
+      return (T) optionalMatcher(context);
+    } else if (type == CollectionMatcher.class) {
+      return (T) collectionMatcher(context);
+    }
+
+    throw new UnsupportedOperationException("Don't know how to create matcher " + type.getName());
+  }
+
+  private static <T> T createWithReflection(Class<T> type, CriteriaContext context) {
+    try {
+      Constructor<T> ctor = type.getConstructor(CriteriaContext.class);
+      return  ctor.newInstance(context);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
 
 
   /**
    * Hacky (and temporary) reflection until we define proper sub-classes for criterias
    * (to hide Expressional implementation).
    */
-  static Expression extract(Object object) {
+  static CriteriaContext extract(Object object) {
     Objects.requireNonNull(object, "object");
+
+    if (object instanceof HasContext) {
+      return ((HasContext) object).context();
+    }
+
+    // TODO should be removed later
+    return extractWithReflection(object);
+  }
+
+  static <C> UnaryOperator<Expression> toExpressionOperator(Supplier<C> supplier, UnaryOperator<C> expr) {
+    return expression -> {
+      final C initial = supplier.get();
+      final C changed = expr.apply(initial);
+      return Matchers.extract(changed).expression();
+    };
+  }
+
+  static <C> UnaryOperator<Expression> toExpressionOperator3(CriteriaContext context, UnaryOperator<C> expr) {
+    return expression -> {
+      // creator1 changes ObjectCriteria.creator1() == Person
+      // need to override creator1 otherwise ClassCastException
+      // final C initial = factory.creator3().create(); // does not work
+      final CriteriaCreator.TriFactory<?, ?, C> factory = context.factory3();
+      final C initial = (C) context.withCreators(factory.creator3(), factory.creator2(), factory.creator3()).factory3().create3();
+      final C changed = expr.apply(initial);
+      return Matchers.extract(changed).expression();
+    };
+  }
+
+
+  private static CriteriaContext extractWithReflection(Object object) {
     try {
       Class<?> current = object.getClass();
-      while(current.getSuperclass() != null){
+      while (current.getSuperclass() != null) {
         if (Arrays.stream(current.getDeclaredFields()).anyMatch(f -> f.getName().equals("context"))) {
           Field field = current.getDeclaredField("context");
           field.setAccessible(true);
-          CriteriaContext<?> context = (CriteriaContext<?>) field.get(object);
-          return context.expression();
+          CriteriaContext context = (CriteriaContext) field.get(object);
+          return context;
         }
         current = current.getSuperclass();
       }
-    } catch (NoSuchFieldException|IllegalAccessException e) {
+    } catch (NoSuchFieldException | IllegalAccessException e) {
       throw new RuntimeException("No field in " + object.getClass().getName(), e);
     }
 
     throw new UnsupportedOperationException("No field context found in " + object.getClass().getName());
   }
+
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/ObjectMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/ObjectMatcher.java
@@ -16,16 +16,14 @@
 
 package org.immutables.criteria.matcher;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import org.immutables.criteria.expression.Expression;
 import org.immutables.criteria.expression.Expressions;
 import org.immutables.criteria.expression.Operators;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.UnaryOperator;
+import java.util.Objects;
 
 /**
  * Comparing directly values of an attribute.
@@ -33,30 +31,18 @@ import java.util.function.UnaryOperator;
  * @param <V> attribute type for which criteria is applied
  * @param <R> Criteria self-type, allowing {@code this}-returning methods to avoid needing subclassing
  */
-public class ObjectMatcher<R, V> {
+public interface ObjectMatcher<R, V> {
 
-  protected final CriteriaContext<R> context;
 
-  public ObjectMatcher(CriteriaContext<R> context) {
-    this.context = Preconditions.checkNotNull(context, "context");
+  default R isEqualTo(V value) {
+    return Matchers.extract(this).<R>factory1().create1(e -> Expressions.call(Operators.EQUAL, e, Expressions.constant(value)));
   }
 
-  /**
-   * Use context to create new root criteria
-   */
-  protected R create(UnaryOperator<Expression> fn) {
-    return (R) context.create(fn);
+  default R isNotEqualTo(V value) {
+    return Matchers.extract(this).<R>factory1().create1(e -> Expressions.call(Operators.NOT_EQUAL, e, Expressions.constant(value)));
   }
 
-  public R isEqualTo(V value) {
-    return create(e -> Expressions.call(Operators.EQUAL, e, Expressions.constant(value)));
-  }
-
-  public R isNotEqualTo(V value) {
-    return create(e -> Expressions.call(Operators.NOT_EQUAL, e, Expressions.constant(value)));
-  }
-
-  public R isIn(V v1, V v2, V ... rest) {
+  default R isIn(V v1, V v2, V ... rest) {
     final List<V> values = new ArrayList<>(2 + rest.length);
     values.add(v1);
     values.add(v2);
@@ -65,7 +51,7 @@ public class ObjectMatcher<R, V> {
     return isIn(values);
   }
 
-  public R isNotIn(V v1, V v2, V ... rest) {
+  default R isNotIn(V v1, V v2, V ... rest) {
     final List<V> values = new ArrayList<>(2 + rest.length);
     values.add(v1);
     values.add(v2);
@@ -74,21 +60,16 @@ public class ObjectMatcher<R, V> {
     return isNotIn(values);
   }
 
-  public R isIn(Iterable<? super V> values) {
-    Preconditions.checkNotNull(values, "values");
-    return create(e -> Expressions.call(Operators.IN, e, Expressions.constant(ImmutableList.copyOf(values))));
+  default R isIn(Iterable<? super V> values) {
+    Objects.requireNonNull(values, "values");
+    return Matchers.extract(this).<R>factory1().create1(e -> Expressions.call(Operators.IN, e, Expressions.constant(ImmutableList.copyOf(values))));
   }
 
-  public R isNotIn(Iterable<? super V> values) {
-    Preconditions.checkNotNull(values, "values");
-    return create(e -> Expressions.call(Operators.NOT_IN, e, Expressions.constant(ImmutableList.copyOf(values))));
+  default R isNotIn(Iterable<? super V> values) {
+    Objects.requireNonNull(values, "values");
+    return Matchers.extract(this).<R>factory1().create1(e -> Expressions.call(Operators.NOT_IN, e, Expressions.constant(ImmutableList.copyOf(values))));
   }
 
-  public static class Self<V> extends ObjectMatcher<Self<V>, V> {
-    public Self(CriteriaContext<Self<V>> context) {
-      super(context);
-    }
-  }
-
+  interface Self<V> extends ObjectMatcher<Self<V>, V> {}
 
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/StringMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/StringMatcher.java
@@ -20,46 +20,39 @@ import org.immutables.criteria.expression.Expressions;
 import org.immutables.criteria.expression.Operators;
 
 /**
- * String specific criterias like {@code isAbsent}, {@code contains} etc.
+ * String specific criterias like {@code startsWith}, {@code contains} etc.
  */
-public class StringMatcher<R> extends ComparableMatcher<R, String> {
+public interface StringMatcher<R> extends ComparableMatcher<R, String> {
 
-  public StringMatcher(CriteriaContext<R> context) {
-    super(context);
+  default R isEmpty() {
+    return Matchers.extract(this).<R>factory1().create1(e -> Expressions.call(Operators.EQUAL, e, Expressions.constant("")));
   }
 
-  public R isEmpty() {
-    return create(e -> Expressions.call(Operators.EQUAL, e, Expressions.constant("")));
+  default R isNotEmpty() {
+    return Matchers.extract(this).<R>factory1().create1(e -> Expressions.call(Operators.NOT_EQUAL, e, Expressions.constant("")));
   }
 
-  public R isNotEmpty() {
-    return create(e -> Expressions.call(Operators.NOT_EQUAL, e, Expressions.constant("")));
-  }
-
-  public R contains(CharSequence other) {
+  default R contains(CharSequence other) {
     throw new UnsupportedOperationException();
   }
 
-  public R startsWith(CharSequence prefix) {
+  default R startsWith(CharSequence prefix) {
     throw new UnsupportedOperationException();
   }
 
-  public R endsWith(CharSequence suffix) {
+  default R endsWith(CharSequence suffix) {
     throw new UnsupportedOperationException();
   }
 
-  public R hasSize(int size) {
+  default R hasSize(int size) {
     throw new UnsupportedOperationException();
   }
 
-  public static class Self extends StringMatcher<Self> implements Disjunction<StringMatcher<Self>> {
-    public Self(CriteriaContext<StringMatcher.Self> context) {
-      super(context);
-    }
+  interface Self extends StringMatcher<Self>, Disjunction<StringMatcher<Self>> {
 
     @Override
-    public StringMatcher<StringMatcher.Self> or() {
-      return context.or().create();
+    default StringMatcher<StringMatcher.Self> or() {
+      return Matchers.extract(this).or().<StringMatcher.Self>factory1().create1();
     }
   }
 

--- a/criteria/common/test/org/immutables/criteria/PersonTest.java
+++ b/criteria/common/test/org/immutables/criteria/PersonTest.java
@@ -10,7 +10,7 @@ public class PersonTest {
   public void collection() {
     PersonCriteria.create()
             .friends.any().nickName.isNotEmpty()
-            .aliases.none().contains("foo")
+            .aliases.none().startsWith("foo")
             .or()//.or() should not work
             .isMarried.isTrue()
             .or()
@@ -19,6 +19,7 @@ public class PersonTest {
             .friends.none().nickName.hasSize(3)
             .friends.all(f -> f.nickName.isEmpty().or().nickName.hasSize(2))
             .friends.any(f -> f.nickName.isEmpty().or().nickName.hasSize(2))
+            .aliases.contains("test")
             .friends.none(f -> f.nickName.hasSize(3).nickName.startsWith("a"));
   }
 

--- a/criteria/common/test/org/immutables/criteria/TypeHolderTest.java
+++ b/criteria/common/test/org/immutables/criteria/TypeHolderTest.java
@@ -15,7 +15,6 @@ public class TypeHolderTest {
     // primitives
     TypeHolderCriteria.create()
             .booleanPrimitive.isTrue()
-            .booleanPrimitive.isEqualTo(false)
             .booleanPrimitive.isFalse()
             .intPrimitive.isEqualTo(0)
             .intPrimitive.isGreaterThan(22)

--- a/value-processor/src/org/immutables/value/processor/Criteria.generator
+++ b/value-processor/src/org/immutables/value/processor/Criteria.generator
@@ -39,6 +39,7 @@ import org.immutables.criteria.matcher.CriteriaContext;
 import org.immutables.criteria.matcher.CriteriaCreator;
 import org.immutables.criteria.matcher.CollectionMatcher;
 import org.immutables.criteria.matcher.Disjunction;
+import org.immutables.criteria.matcher.Matchers;
 import org.immutables.criteria.matcher.OptionalMatcher;
 import org.immutables.criteria.matcher.ObjectMatcher;
 import org.immutables.criteria.matcher.StringMatcher;
@@ -78,7 +79,7 @@ import [starImport];
 [atGenerated type]
 [type.typeDocument.access] class [type.name]Criteria<R> implements DocumentCriteria<[type.name]>, Expressional {
 
-   final CriteriaContext<R> context;
+   final CriteriaContext context;
 
    [for a in type.allMarshalingAttributes]
    public final [criteriaType a type] [a.name];
@@ -89,27 +90,27 @@ import [starImport];
    public static final class Self extends [type.name]Criteria<Self> implements Disjunction<[type.name]Criteria<Self>> {
 
     private Self() {
-      this(new CriteriaContext<Self>(creator()));
+      this(new CriteriaContext(creator()));
     }
 
-    private Self(CriteriaContext<Self> context) {
+    private Self(CriteriaContext context) {
       super(context);
     }
 
     private static CriteriaCreator<Self> creator() {
-      return (CriteriaContext<Self> ctx) ->  new Self(ctx);
+      return (CriteriaContext ctx) ->  new Self(ctx);
     }
 
     @Override
     public [type.name]Criteria<Self> or() {
-      return context.or().create();
+      return context.or().<Self>factory1().create1();
     }
    }
 
-   public [type.name]Criteria(CriteriaContext<R> context) {
-       this.context = Objects.requireNonNull(context, "context");
+   public [type.name]Criteria(CriteriaContext context) {
+     this.context = Objects.requireNonNull(context, "context");
    [for a in type.allMarshalingAttributes]
-     this.[a.name] = new [criteriaType a type]([constructorArgs a type]);
+     this.[a.name] = ([criteriaType a type]) [createMatcher a type];
    [/for]
    }
 
@@ -124,7 +125,6 @@ import [starImport];
 
 }
 [/template]
-
 
 [template criteriaType Attribute a Type type][output.trim]
 [if (a.boolean or (a.type eq 'java.lang.Boolean'))]
@@ -141,9 +141,9 @@ StringMatcher<R>
   ComparableMatcher<R, [a.wrappedElementType]>
 [else if a.collectionType]
   [if a.hasSimpleScalarElementType]
-      CollectionMatcher<R, [scalarElementCriteria a 'R'], [scalarElementCriteria a 'Self']>
+      CollectionMatcher<R, [scalarElementCriteria a 'R'], [scalarElementCriteria a 'Self'], [a.wrappedElementType]>
   [else if a.hasCriteria]
-      CollectionMatcher<R, [a.unwrappedElementType]Criteria<R>, [a.unwrappedElementType]Criteria.Self>
+      CollectionMatcher<R, [a.unwrappedElementType]Criteria<R>, [a.unwrappedElementType]Criteria.Self, [a.wrappedElementType]>
   [else]
      [output.error]Can't create criteria for collection [type.name].[a.name] [a.unwrappedElementType][/output.error]
   [/if]
@@ -154,15 +154,39 @@ StringMatcher<R>
 [/if]
 [/output.trim][/template]
 
+[template createMatcher Attribute a Type type][output.trim]
+[if (a.boolean or (a.type eq 'java.lang.Boolean'))]
+Matchers.create(BooleanMatcher.class, [constructorArgs a type])
+[else if a.stringType]
+Matchers.create(StringMatcher.class, [constructorArgs a type])
+[else if a.optionalType]
+   Matchers.create(OptionalMatcher.class, [constructorArgs a type])
+[else if a.comparable]
+   Matchers.create(ComparableMatcher.class, [constructorArgs a type])
+[else if a.collectionType]
+   Matchers.create(CollectionMatcher.class, [constructorArgs a type])
+[else if a.hasCriteria]
+  new [a.unwrappedElementType]Criteria<R>([constructorArgs a type])
+[else]
+   Matchers.create(ObjectMatcher.class, [constructorArgs a type])
+[/if]
+[/output.trim][/template]
+
 [template constructorArgs Attribute a Type type][output.trim]
 [if a.optionalType or a.collectionType]
   [if a.hasSimpleScalarElementType]
-    context.add(Expressions.path("[a.name]")), ctx -> new [scalarElementCriteria a 'R']((CriteriaContext<R>)  ctx), ctx -> new [scalarElementCriteria a 'Self'](ctx)
+    context.withPath("[a.name]")
+           .withCreators(ctx -> new [type.name]Criteria.Self(ctx),
+                           ctx -> Matchers.create([scalarMatcherType a].class, ctx),
+                          ctx -> Matchers.create([scalarMatcherType a].Self.class, ctx))
   [else if a.hasCriteria]
-    context.add(Expressions.path("[a.name]")), ctx -> new [a.unwrappedElementType]Criteria<R>((CriteriaContext<R>) ctx), ctx -> ([a.unwrappedElementType]Criteria.Self) [a.unwrappedElementType]Criteria.create()
+    context.withPath("[a.name]")
+           .withCreators(ctx -> new [type.name]Criteria.Self(ctx),
+                         ctx -> new [a.unwrappedElementType]Criteria<R>((CriteriaContext) ctx),
+                         ctx -> ([a.unwrappedElementType]Criteria.Self) [a.unwrappedElementType]Criteria.create())
   [/if]
 [else]
-context.add(Expressions.path("[a.name]"))
+context.withPath("[a.name]").withCreators(ctx -> new [type.name]Criteria.Self(ctx))
 [/if]
 [/output.trim][/template]
 
@@ -178,6 +202,19 @@ context.add(Expressions.path("[a.name]"))
   [output.error]unexpected type [a.name] [a.unwrappedElementType]<[elementName]>, not a simple one[/output.error]
 [/if]
 [/output.trim][/template]
+
+[template scalarMatcherType Attribute a][output.trim]
+[if a.unwrappedElementType eq 'boolean']
+  BooleanMatcher
+[else if a.unwrappedElementType eq 'java.lang.String']
+  StringMatcher
+[else if a.isMaybeComparableKey]
+  ComparableMatcher
+[else]
+  ObjectMatcher
+[/if]
+[/output.trim]
+[/template]
 
 [template atGenerated Type type]
 [if type allowsClasspathAnnotation 'org.immutables.value.Generated']


### PR DESCRIPTION
Matchers are not implemented as interfaces with default methods.