### PR TITLE
Limited support of delete operation in Geode

### DIFF
--- a/criteria/common/src/org/immutables/criteria/expression/Root.java
+++ b/criteria/common/src/org/immutables/criteria/expression/Root.java
@@ -42,6 +42,10 @@ public final class Root implements Expression {
     return visitor.visit(this, context);
   }
 
+  public Class<?> entityClass() {
+    return this.entityClass;
+  }
+
   public Optional<Expression> expression() {
     return Optional.ofNullable(expression);
   }

--- a/criteria/geode/src/org/immutables/criteria/geode/Geodes.java
+++ b/criteria/geode/src/org/immutables/criteria/geode/Geodes.java
@@ -16,8 +16,22 @@
 
 package org.immutables.criteria.geode;
 
+import com.google.common.base.Preconditions;
+import org.immutables.criteria.Criterias;
+import org.immutables.criteria.DocumentCriteria;
+import org.immutables.criteria.expression.Call;
+import org.immutables.criteria.expression.Constant;
+import org.immutables.criteria.expression.Expression;
 import org.immutables.criteria.expression.ExpressionConverter;
 import org.immutables.criteria.expression.Expressions;
+import org.immutables.criteria.expression.Operators;
+import org.immutables.criteria.expression.Root;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Util class for Geode
@@ -31,9 +45,67 @@ class Geodes {
    * @return predicate, empty string if no predicate
    */
   static ExpressionConverter<String> converter() {
-    return expression -> {
-      return Expressions.extractPredicate(expression).map(e -> e.accept(new GeodeQueryVisitor()))
-              .orElse("");
-    };
+    return expression -> Expressions.extractPredicate(expression)
+            .map(e -> e.accept(new GeodeQueryVisitor()))
+            .orElse("");
+  }
+
+  /**
+   * Checks if current criteria has any predicate expressions defined (like {@code foo = 123}).
+   */
+  static boolean hasPredicate(DocumentCriteria<?> criteria) {
+    return Expressions.extractPredicate(Criterias.toExpression(criteria)).isPresent();
+  }
+
+  /**
+   * Geode (currently) doesn't support delete by query syntax ({@code DELETE ... WHERE ...}) and elements have to be
+   * removed explicitly by key ({@link Map#remove(Object)} API)
+   *
+   * <p>Tries to detect if current criteria is based only on keys and extract them from expression (if it is only
+   * expression based on keys).
+   *
+   * <p>Example:
+   * <pre>
+   *  {@code
+   *     key = 123
+   *     key in [1, 2, 3]
+   *     key not in [1, 2, 3] (invalid since keys are unknown)
+   *     key != 1 (invalid since keys are unknown)
+   *  }
+   * </pre>
+   *
+   *
+   */
+  static Optional<List<?>> canDeleteByKey(DocumentCriteria<?> criteria) {
+    if (!hasPredicate(criteria)) {
+      return Optional.of(Collections.emptyList());
+    }
+
+    final Expression expr = Expressions.extractPredicate(Criterias.toExpression(criteria))
+            .orElseThrow(() -> new IllegalStateException("Shouldn't get here"));
+
+    if (!(expr instanceof Call)) {
+      return Optional.empty();
+    }
+
+    final Call predicate = (Call) expr;
+    if (!(predicate.operator() == Operators.EQUAL || predicate.operator() == Operators.IN)) {
+      return Optional.empty();
+    }
+
+    final List<Expression> args = predicate.arguments();
+    Preconditions.checkArgument(args.size() == 2, "Expected size 2 but got %s for %s",
+            args.size(), predicate);
+
+
+    if (!(args.get(0) instanceof Path && args.get(1) instanceof Constant)) {
+      // second argument should be constant
+      return Optional.empty();
+    }
+
+    // field should be id
+    final Class<?> entityClass = ((Root) Criterias.toExpression(criteria)).entityClass();
+
+    return Optional.empty();
   }
 }


### PR DESCRIPTION
It is currently checking for existence of a predicate.
For empty (missing) predicate `map.clear()` is called.