### PR TITLE
Move limit / offset attributes from Operations.Query to Query class

### DIFF
--- a/criteria/common/src/org/immutables/criteria/adapter/InternalReader.java
+++ b/criteria/common/src/org/immutables/criteria/adapter/InternalReader.java
@@ -16,8 +16,10 @@
 
 package org.immutables.criteria.adapter;
 
+import org.immutables.criteria.Criterias;
 import org.immutables.criteria.DocumentCriteria;
 import org.immutables.criteria.Repository;
+import org.immutables.criteria.expression.Query;
 import org.reactivestreams.Publisher;
 
 import java.util.Objects;
@@ -27,14 +29,14 @@ import java.util.Objects;
  */
 public final class InternalReader<T> implements Repository.Reader<T> {
 
-  private final ImmutableSelect<T> query;
+  private final Query query;
   private final Backend backend;
 
-  public InternalReader(DocumentCriteria<T> criteria, Class<T> returnType, Backend backend) {
-    this(ImmutableSelect.of(criteria, returnType), backend);
+  public InternalReader(DocumentCriteria<T> criteria, Backend backend) {
+    this(Criterias.toQuery(criteria), backend);
   }
 
-  private InternalReader(ImmutableSelect<T> query, Backend backend) {
+  private InternalReader(Query query, Backend backend) {
     this.query = Objects.requireNonNull(query, "query");
     this.backend = Objects.requireNonNull(backend, "backend");
   }
@@ -51,7 +53,7 @@ public final class InternalReader<T> implements Repository.Reader<T> {
 
   @Override
   public Publisher<T> fetch() {
-    return backend.execute(query);
+    return backend.execute(Operations.Select.of(query));
   }
 
 }

--- a/criteria/common/src/org/immutables/criteria/adapter/InternalWatcher.java
+++ b/criteria/common/src/org/immutables/criteria/adapter/InternalWatcher.java
@@ -16,8 +16,10 @@
 
 package org.immutables.criteria.adapter;
 
+import org.immutables.criteria.Criterias;
 import org.immutables.criteria.DocumentCriteria;
 import org.immutables.criteria.Repository;
+import org.immutables.criteria.expression.Query;
 import org.reactivestreams.Publisher;
 
 import java.util.Objects;
@@ -25,16 +27,16 @@ import java.util.Objects;
 public final class InternalWatcher<T> implements Repository.Watcher<T> {
 
   private final Backend backend;
-  private final DocumentCriteria<?> criteria;
+  private final Query query;
 
   public InternalWatcher(DocumentCriteria<?> criteria, Backend backend) {
     this.backend = Objects.requireNonNull(backend, "backend");
-    this.criteria = Objects.requireNonNull(criteria, "criteria");
+    this.query = Criterias.toQuery(Objects.requireNonNull(criteria, "criteria"));
   }
 
   @Override
   public Publisher<T> watch() {
-    return backend.execute(ImmutableWatch.of(criteria));
+    return backend.execute(ImmutableWatch.of(query));
   }
 
 }

--- a/criteria/common/src/org/immutables/criteria/adapter/Operations.java
+++ b/criteria/common/src/org/immutables/criteria/adapter/Operations.java
@@ -17,14 +17,15 @@
 package org.immutables.criteria.adapter;
 
 import com.google.common.collect.ImmutableList;
+import org.immutables.criteria.Criterias;
 import org.immutables.criteria.DocumentCriteria;
 import org.immutables.criteria.Repository;
+import org.immutables.criteria.expression.Query;
 import org.immutables.value.Value;
 
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -37,20 +38,17 @@ public final class Operations {
   private Operations() {}
 
   /**
-   * Query sent to a backend
+   * Query sent to a backend similar to SQL {@code SELECT} clause.
    */
   @Value.Immutable
   public interface Select<T> extends Backend.Operation<T> {
 
     @Value.Parameter
-    DocumentCriteria<?> criteria();
+    Query query();
 
-    @Value.Parameter
-    Class<T> returnType();
-
-    OptionalLong limit();
-
-    OptionalLong offset();
+    static <T> ImmutableSelect<T> of(Query query) {
+      return ImmutableSelect.of(query);
+    }
   }
 
   /**
@@ -119,18 +117,17 @@ public final class Operations {
   @Value.Immutable
   public interface Delete extends Backend.Operation<Repository.Success> {
     @Value.Parameter
-    DocumentCriteria<?> criteria();
-
+    Query query();
 
     static Delete of(DocumentCriteria<?> criteria) {
-      return ImmutableDelete.of(criteria);
+      return ImmutableDelete.of(Criterias.toQuery(criteria));
     }
   }
 
   @Value.Immutable
   public interface Watch<T> extends Backend.Operation<T> {
     @Value.Parameter
-    DocumentCriteria<?> criteria();
+    Query query();
 
   }
 

--- a/criteria/common/src/org/immutables/criteria/expression/Query.java
+++ b/criteria/common/src/org/immutables/criteria/expression/Query.java
@@ -18,19 +18,23 @@ package org.immutables.criteria.expression;
 
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.UnaryOperator;
+import java.util.OptionalLong;
 
 /**
- * Query which is composed of predicates, projections, group by and order by expressions.
+ * Query which is composed of predicates, projections, limit, offset, group by and order by expressions.
  */
 public final class Query  {
 
   private final EntityPath entityPath;
   private final Expression filter;
+  private final Long limit;
+  private final Long offset;
 
-  private Query(EntityPath entityPath, Expression filter) {
+  private Query(EntityPath entityPath, Expression filter, Long limit, Long offset) {
     this.entityPath = Objects.requireNonNull(entityPath, "entityPath");
     this.filter = filter;
+    this.limit = limit;
+    this.offset = offset;
   }
 
   public EntityPath entityPath() {
@@ -41,17 +45,29 @@ public final class Query  {
     return Optional.ofNullable(filter);
   }
 
+  public OptionalLong limit() {
+    return limit == null ? OptionalLong.empty() : OptionalLong.of(limit);
+  }
+
+  public Query withLimit(long limit) {
+    return new Query(entityPath, filter, limit, offset);
+  }
+
+  public OptionalLong offset() {
+    return offset == null ? OptionalLong.empty() : OptionalLong.of(offset);
+  }
+
+  public Query withOffset(long offset) {
+    return new Query(entityPath, filter, limit, offset);
+  }
+
   static Query of(Class<?> entityClass) {
-    return new Query(EntityPath.of(entityClass), null);
+    return new Query(EntityPath.of(entityClass), null, null, null);
   }
 
   Query withFilter(Expression filter) {
     Objects.requireNonNull(filter, "filter");
-    return new Query(entityPath, filter);
+    return new Query(entityPath, filter, limit, offset);
   }
-
-  public Query transform(UnaryOperator<Expression> operator) {
-    return filter().map(e -> withFilter(operator.apply(e))).orElse(this);
-  }
-
+  
 }

--- a/criteria/elasticsearch/test/org/immutables/criteria/elasticsearch/ElasticsearchIntegrationTest.java
+++ b/criteria/elasticsearch/test/org/immutables/criteria/elasticsearch/ElasticsearchIntegrationTest.java
@@ -78,7 +78,7 @@ public class ElasticsearchIntegrationTest {
 
   @Before
   public void setupRepository() throws Exception {
-    this.backend = new ElasticsearchBackend(RESOURCE.restClient(),  MAPPER, ElasticModel.class, INDEX_NAME);
+    this.backend = new ElasticsearchBackend(RESOURCE.restClient(), MAPPER, INDEX_NAME);
     this.repository = new ElasticModelRepository(backend);
   }
 

--- a/criteria/geode/src/org/immutables/criteria/geode/Geodes.java
+++ b/criteria/geode/src/org/immutables/criteria/geode/Geodes.java
@@ -69,8 +69,7 @@ class Geodes {
    *
    *
    */
-  static Optional<List<?>> canDeleteByKey(DocumentCriteria<?> criteria) {
-    final Query query = Criterias.toQuery(criteria);
+  static Optional<List<?>> canDeleteByKey(Query query) {
     if (!query.filter().isPresent()) {
       return Optional.of(Collections.emptyList());
     }

--- a/value-processor/src/org/immutables/value/processor/CriteriaRepository.generator
+++ b/value-processor/src/org/immutables/value/processor/CriteriaRepository.generator
@@ -64,8 +64,6 @@ import java.util.function.Function;
 , Repository.Readable<[type.name]>[if not type.criteriaRepository.readonly], Repository.Writable<[type.name]>[/if][if type.criteriaRepository.watch], Repository.Watchable<[type.name]>[/if]
  {[/output.trim]
 
-  private static final Class<[type.name]> ENTITY_CLASS = [type.name].class;
-
 [for a = type.idAttribute]
 [if a]
   /** Function to extract {@code [a.name]} attribute from {@link [type.name]} */
@@ -99,7 +97,7 @@ import java.util.function.Function;
 
   @Override
   public Repository.Reader<[type.name]> find(DocumentCriteria<[type.name]> criteria) {
-    return new InternalReader<>(criteria, ENTITY_CLASS, backend);
+    return new InternalReader<>(criteria, backend);
   }
 
   @Override


### PR DESCRIPTION
Rename Operations.Query to Operations.Select to avoid confusion with Query

In backend most of method are using Query instead of DocumentCriteria (which is
reserved for front-end)

Remove unused transform() method.

Remove entity class dependency in ElasticsearchBackend constructor