### PR TITLE
Support for Geode Watcher (CQ / Continuous Query)

### DIFF
--- a/criteria/common/test/org/immutables/criteria/personmodel/Person.java
+++ b/criteria/common/test/org/immutables/criteria/personmodel/Person.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.criteria.Criteria;
 import org.immutables.value.Value;
 
+import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -36,7 +37,8 @@ import java.util.Set;
 @Criteria.Repository(watch = true)
 @JsonSerialize(as = ImmutablePerson.class)
 @JsonDeserialize(as = ImmutablePerson.class)
-public interface Person {
+public interface Person extends Serializable // serializable needed for Geode temporarily
+{
 
   @Criteria.Id
   String id();
@@ -58,6 +60,5 @@ public interface Person {
   Optional<Friend> bestFriend();
 
   List<Pet> pets();
-
 
 }

--- a/criteria/geode/pom.xml
+++ b/criteria/geode/pom.xml
@@ -44,6 +44,11 @@
             <version>${geode.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.geode</groupId>
+            <artifactId>geode-cq</artifactId>
+            <version>${geode.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>testing</artifactId>
             <version>${project.version}</version>

--- a/criteria/geode/src/org/immutables/criteria/geode/CqDisposable.java
+++ b/criteria/geode/src/org/immutables/criteria/geode/CqDisposable.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.criteria.geode;
+
+import io.reactivex.disposables.Disposable;
+import org.apache.geode.cache.query.CqException;
+import org.apache.geode.cache.query.CqQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+/**
+ * Disposable (rxjava interface) wrapper for {@link CqQuery}
+ */
+class CqDisposable implements Disposable  {
+
+  private static final Logger logger = LoggerFactory.getLogger(CqDisposable.class);
+
+  private final CqQuery cqQuery;
+
+  CqDisposable(CqQuery cqQuery) {
+    this.cqQuery = Objects.requireNonNull(cqQuery, "cqQuery");
+  }
+
+  @Override
+  public void dispose() {
+    try {
+      cqQuery.close();
+    } catch (CqException e) {
+      logger.error("Failed to close {} [{}]", cqQuery.getName(), cqQuery.getQueryString(), e);
+    }
+  }
+
+  @Override
+  public boolean isDisposed() {
+    return cqQuery.isClosed();
+  }
+}

--- a/criteria/geode/src/org/immutables/criteria/geode/GeodeEventListener.java
+++ b/criteria/geode/src/org/immutables/criteria/geode/GeodeEventListener.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.criteria.geode;
+
+import io.reactivex.Emitter;
+import org.apache.geode.cache.query.CqEvent;
+import org.apache.geode.cache.query.CqStatusListener;
+
+import java.util.Objects;
+
+/**
+ * Passes events to existing {@link Emitter}
+ * @param <T> event type
+ */
+class GeodeEventListener<T> implements CqStatusListener {
+
+  private final Emitter<T> emitter;
+  private final String query;
+
+  GeodeEventListener(final String query, Emitter<T> emitter) {
+    this.emitter = Objects.requireNonNull(emitter, "emitter");
+    this.query = Objects.requireNonNull(query, "query");
+  }
+
+  @Override
+  public void onCqDisconnected() {
+    emitter.onError(new IllegalStateException(String.format("CQ disconnected [%s]", query)));
+  }
+
+  @Override
+  public void onCqConnected() {
+    // nop
+  }
+
+  @Override
+  public void onEvent(CqEvent event) {
+    emitter.onNext((T) event.getNewValue());
+  }
+
+  @Override
+  public void onError(CqEvent event) {
+    emitter.onError(event.getThrowable());
+  }
+
+  @Override
+  public void close() {
+    emitter.onComplete();
+  }
+}

--- a/criteria/geode/test/org/immutables/criteria/geode/GeodeCqTest.java
+++ b/criteria/geode/test/org/immutables/criteria/geode/GeodeCqTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.criteria.geode;
+
+import io.reactivex.Flowable;
+import io.reactivex.subscribers.TestSubscriber;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
+import org.immutables.criteria.personmodel.Person;
+import org.immutables.criteria.personmodel.PersonCriteria;
+import org.immutables.criteria.personmodel.PersonGenerator;
+import org.immutables.criteria.personmodel.PersonRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.immutables.check.Checkers.check;
+
+/**
+ * Unfortunately CQ can't be tested with an embedded server. For Geode, there can be only
+ * one instance of Cache in JVM: server or client. CQ is client / server topology.
+ *
+ * <p>This test requires an external Geode instance
+ *
+ * <p>Temporary test until we have a proper way to start real geode server
+ *
+ * <pre>
+ *   copy artifact jars from common/target/*.jar into $GEMFIRE_HOME/extensions/
+ *   manually start gfsh
+ *   $ start locator --name=locator1 --port=10334
+ *   $ start server --name=server1 --server-port=40411
+ *   $ create region --name=persons --type=REPLICATE
+ * </pre>
+ */
+@Ignore // ignored because requires external gemfire instance
+public class GeodeCqTest {
+
+  private ClientCache clientCache;
+
+  private Region<String, Person> region;
+
+  @Before
+  public void setUp() throws Exception {
+    this.clientCache = new ClientCacheFactory()
+            .addPoolLocator("127.0.0.1", 10334)
+            .setPdxSerializer(new ReflectionBasedAutoSerializer(Person.class.getPackage().getName()))
+            .setPoolSubscriptionEnabled(true)
+            .create();
+
+    this.region = clientCache
+            .<String, Person>createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY)
+            .create("persons");
+
+    region.clear();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (clientCache != null) {
+      clientCache.close();
+    }
+  }
+
+  @Test
+  public void pubsub() throws Exception {
+
+    PersonRepository repository = new PersonRepository(new GeodeBackend(region));
+
+    TestSubscriber<Person> events = Flowable.fromPublisher(repository.watcher(PersonCriteria.create()).watch())
+            .test();
+
+    final PersonGenerator generator = new PersonGenerator();
+    final int count = 4;
+    for (int i = 0; i < count; i++) {
+      Flowable.fromPublisher(repository.insert(generator.next().withId("id" + i)))
+              .test()
+              .awaitDone(1, TimeUnit.SECONDS)
+              .assertComplete();
+    }
+
+    check(region.keySet()).notEmpty();
+    // ensure (de)serialization is successful
+    check(region.query("true")).hasSize(count);
+
+    events.awaitCount(count);
+    events.assertNoErrors();
+    events.assertValueCount(count);
+    check(events.values().stream().map(Person::id).collect(Collectors.toList())).hasContentInAnyOrder("id0", "id1", "id2", "id3");
+  }
+}


### PR DESCRIPTION
Implement Operation.Watch for Geode adapter using native
[Continuous Query](https://geode.apache.org/docs/geode-native/18/continuous-queries.html)