### PR TITLE
Make CriteriaContext private field inside generated Criteria class

### DIFF
--- a/value-processor/src/org/immutables/value/processor/Criteria.generator
+++ b/value-processor/src/org/immutables/value/processor/Criteria.generator
@@ -81,7 +81,7 @@ import [starImport];
 [atGenerated type]
 [type.typeDocument.access] class [type.name]Criteria<R> implements Criterion<[type.name]>, NotMatcher<R, [type.name]Criteria.Self> {
 
-   final CriteriaContext context;
+   private final CriteriaContext context;
 
    [for a in type.allMarshalingAttributes]
    public final [criteriaType a type] [a.name];
@@ -91,8 +91,11 @@ import [starImport];
    /** TODO this should be top-level class */
    public static class Self extends [type.name]Criteria<Self> implements Disjunction<[type.name]Criteria<Self>> {
 
+    private final CriteriaContext context;
+
     private Self(CriteriaContext context) {
       super(context);
+      this.context = context;
     }
 
     @Override
@@ -104,12 +107,15 @@ import [starImport];
 
    /** Similar to {@link Self} but exposes {@link Expressional} interface */
    private final static class ExpressionalSelf extends Self implements Queryable {
+      private final CriteriaContext context;
+
       private ExpressionalSelf() {
          this(new CriteriaContext([type.name].class, creator()).withCreators(creator(), creator(), creator()));
       }
 
       private ExpressionalSelf(CriteriaContext context) {
        super(context);
+       this.context = context;
       }
 
       private static CriteriaCreator<Self> creator() {


### PR DESCRIPTION
Hide unnecessary information from IDE