### PR TITLE
Add scroll support to Elasticsearch backend

### DIFF
--- a/criteria/elasticsearch/pom.xml
+++ b/criteria/elasticsearch/pom.xml
@@ -84,6 +84,13 @@
             <version>${rxjava2.version}</version>
         </dependency>
         <dependency>
+            <!-- This is currently used for ES async scrolling.
+            See FlowableTransformers.expand() operator -->
+            <groupId>com.github.akarnokd</groupId>
+            <artifactId>rxjava2-extensions</artifactId>
+            <version>${rxjava2-extensions.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams</artifactId>
             <version>${reactive-streams.version}</version>

--- a/criteria/elasticsearch/src/org/immutables/criteria/elasticsearch/Scrolling.java
+++ b/criteria/elasticsearch/src/org/immutables/criteria/elasticsearch/Scrolling.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.criteria.elasticsearch;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Preconditions;
+import hu.akarnokd.rxjava2.operators.FlowableTransformers;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.FlowableTransformer;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Uses <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html">Scroll API</a>
+ * to fetch results recursively and asynchronously.
+ */
+class Scrolling<T> {
+
+  private final ElasticsearchOps ops;
+
+  private final Class<T> type;
+
+  private final int scrollSize;
+
+  /**
+   * Duration to keep scroll context alive.
+   */
+  private final Duration keepAlive = Duration.ofMinutes(1);
+
+  Scrolling(ElasticsearchOps ops, Class<T> type) {
+    this.ops = ops;
+    this.type = type;
+    this.scrollSize = ops.scrollSize;
+  }
+
+  Flowable<T> scroll(ObjectNode query) {
+    final Map<String, String> params = Collections.singletonMap("scroll", keepAlive.getSeconds() + "s");
+    final boolean hasLimit = query.has("size");
+    final long limit = hasLimit ? query.get("size").asLong() : Long.MAX_VALUE;
+
+    if (scrollSize > limit) {
+      // don't use scrolling when batch size is greater than limit
+      return ops.search(query, type);
+    }
+
+    // override size during scrolling
+    query.put("size", scrollSize);
+
+    return ops.searchRaw(query, params)
+            .toFlowable()
+            .scan(AccumulatedResult.empty(limit), AccumulatedResult::next)
+            .skip(1)// skip first empty accumulator
+            .compose(transformer())
+            .map(AccumulatedResult::result)
+            .flatMapIterable(r -> r.searchHits().hits())
+            .compose(f -> hasLimit ? f.limit(limit) : f) // limit number of elements
+            .map(hit -> ops.jsonConverter(type).apply(hit.source()));
+  }
+
+  private FlowableTransformer<AccumulatedResult, AccumulatedResult> transformer() {
+    return FlowableTransformers.expand(r -> r.isLast() ?
+            maybeClearScroll(r.result).toFlowable() :
+            ops.nextScroll(r.result.scrollId().get()).toFlowable().map(r::next));
+  }
+
+  /**
+   * If scrollId is available will close scroll context
+   */
+  private Completable maybeClearScroll(Json.Result result) {
+    Objects.requireNonNull(result, "result");
+    return result.scrollId().map(scrollId -> ops.closeScroll(Collections.singleton(scrollId)))
+            .orElse(Completable.complete());
+  }
+
+  /**
+   * Used to track number of SearchHits seen so far (to know when to finish fetching)
+   */
+  private static class AccumulatedResult {
+
+    /**
+     * Number of documents fetched so far
+     */
+    private final long count;
+
+    /**
+     * Max number of documents to fetch
+     */
+    private final long limit;
+
+    private final Json.Result result;
+
+    private AccumulatedResult(long count, long limit, Json.Result result) {
+      this.count = count;
+      this.limit = limit;
+      this.result = result;
+    }
+
+    boolean isLast() {
+      Preconditions.checkState(result != null, "result not supposed to be null");
+      return result.isEmpty() || count >= limit;
+    }
+
+    Json.Result result() {
+      return result;
+    }
+
+    static AccumulatedResult empty(long limit) {
+      return new AccumulatedResult(0, limit, null);
+    }
+
+    AccumulatedResult next(Json.Result next) {
+      Objects.requireNonNull(next, "next");
+      return new AccumulatedResult(count + next.searchHits().hits().size(), limit, next);
+    }
+
+  }
+
+}

--- a/criteria/elasticsearch/test/org/immutables/criteria/elasticsearch/ScrollingTest.java
+++ b/criteria/elasticsearch/test/org/immutables/criteria/elasticsearch/ScrollingTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.criteria.elasticsearch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+import org.immutables.criteria.personmodel.CriteriaChecker;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Test for <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html">scrolling functionality</a> of ES
+ * @see Scrolling
+ */
+public class ScrollingTest {
+
+  @ClassRule
+  public static final EmbeddedElasticsearchResource RESOURCE = EmbeddedElasticsearchResource.create();
+
+  private static final ObjectMapper MAPPER = ElasticPersonTest.MAPPER;
+
+  /**
+   * Should be greater than default elastic {@code size} which is 10.
+   * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html">from-size</a>
+   */
+  private static final int SIZE = 20;
+
+  @BeforeClass
+  public static void elasticseachInit() throws Exception {
+    final ElasticsearchOps ops = ops();
+
+    Map<String, String> model = ImmutableMap.<String, String>builder()
+            .put("string", "keyword")
+            .put("optionalString", "keyword")
+            .put("bool", "boolean")
+            .put("intNumber", "integer")
+            .build();
+
+    ops.createIndex(model);
+    for (int i = 0; i < SIZE; i++) {
+      ObjectNode doc = MAPPER.createObjectNode()
+              .put("string", "s" + i)
+              .put("bool", true)
+              .put("intNumber", i);
+
+      ops.insertDocument(doc);
+    }
+  }
+
+  private static ElasticsearchOps ops() {
+    return ops(1024);
+  }
+
+  private static ElasticsearchOps ops(int scrollSize) {
+    return new ElasticsearchOps(RESOURCE.restClient(), "test", MAPPER, scrollSize);
+  }
+
+  @Test
+  public void noLimit() {
+    ElasticModelRepository repository = new ElasticModelRepository(new ElasticsearchBackend(ops(1)));
+
+    CriteriaChecker.of(repository.findAll())
+            .toList(ElasticModel::string)
+            .hasSize(SIZE);
+
+    CriteriaChecker.of(repository.findAll().orderBy(ElasticModelCriteria.elasticModel.string.asc()))
+            .toList(ElasticModel::string)
+            .hasSize(SIZE);
+  }
+
+  /**
+   * Set scroll sizes like {@code 1, 2, 3 ...} and validates number of returned records
+   */
+  @Test
+  public void withLimit() {
+    // set of scroll sizes / limits to tests
+    final int[] samples = {1, 2, 3, SIZE - 1, SIZE, SIZE + 1, 2 * SIZE, SIZE * SIZE};
+    for (int scrollSize: samples) {
+      for (int limit: samples) {
+        ElasticModelRepository repository = new ElasticModelRepository(new ElasticsearchBackend(ops(scrollSize)));
+        final int expected = Math.min(SIZE, limit);
+
+        // with limit
+        CriteriaChecker.of(repository.findAll().limit(limit))
+                .toList(ElasticModel::string)
+                .hasSize(expected);
+
+        // sort expected results manually
+        final List<String> expectedStrings = IntStream.range(0, SIZE)
+                .mapToObj(i -> "s" + i)
+                .sorted()
+                .limit(expected)
+                .collect(Collectors.toList());
+        // add order by
+        CriteriaChecker.of(repository.findAll().limit(limit)
+                .orderBy(ElasticModelCriteria.elasticModel.string.asc()))
+                .toList(ElasticModel::string)
+                .isOf(expectedStrings);
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
     <slf4j.version>1.7.25</slf4j.version>
     <jsr305.version>1.3.9</jsr305.version>
     <rxjava2.version>2.2.10</rxjava2.version>
+    <rxjava2-extensions.version>0.20.10</rxjava2-extensions.version>
     <geode.version>1.9.0</geode.version>
   </properties>
 


### PR DESCRIPTION
Have some tests which validate scrolling with small sizes (1, 2, 3 etc.)