### PR TITLE
Better support for NOT operator in different backends

### DIFF
--- a/criteria/common/src/org/immutables/criteria/expression/Expressions.java
+++ b/criteria/common/src/org/immutables/criteria/expression/Expressions.java
@@ -41,11 +41,11 @@ public final class Expressions {
     return reduce(Operators.AND, expressions);
   }
 
-  public static  Expression or(Expression first, Expression second) {
+  public static Expression or(Expression first, Expression second) {
     return or(Arrays.asList(first ,second));
   }
 
-  public static  Expression or(Iterable<? extends Expression> expressions) {
+  public static Expression or(Iterable<? extends Expression> expressions) {
     return reduce(Operators.OR, expressions);
   }
 

--- a/criteria/common/test/org/immutables/criteria/personmodel/AbstractPersonTest.java
+++ b/criteria/common/test/org/immutables/criteria/personmodel/AbstractPersonTest.java
@@ -186,6 +186,42 @@ public abstract class AbstractPersonTest {
 
   }
 
+  /**
+   * some variations of boolean logic with {@code NOT} operator
+   */
+  @Test
+  public void notLogic() {
+    Person john = new PersonGenerator().next().withId("john").withFullName("John").withAge(30);
+    insert(john);
+
+    check(criteria().not(p -> p.id.isEqualTo("john"))).empty();
+    check(criteria().not(p -> p.id.isEqualTo("john").age.isEqualTo(30))).empty();
+    check(criteria().not(p -> p.id.isEqualTo("john").age.isEqualTo(31))).hasSize(1);
+    check(criteria().not(p -> p.id.isIn("john", "john").age.isIn(30, 30))).empty();
+    check(criteria().not(p -> p.id.isIn("john", "john").or().age.isIn(30, 30))).empty();
+    check(criteria().not(p -> p.id.isIn("d", "d").age.isIn(99, 99))).hasSize(1);
+    check(criteria().not(p -> p.id.isIn("d", "d").or().age.isIn(99, 99))).hasSize(1);
+
+    check(criteria().not(p -> p.id.isEqualTo("john1").or().id.isEqualTo("john"))).empty();
+    check(criteria().not(p -> p.id.isEqualTo("john1").or().id.isEqualTo("john2"))).hasSize(1);
+    check(criteria().not(p -> p.id.isNotEqualTo("john"))).hasSize(1);
+    check(criteria().not(p -> p.age.isAtLeast(29).age.isAtMost(31))).empty();
+
+    check(criteria().not(p -> p.age.isEqualTo(30)).not(p2 -> p2.id.isEqualTo("john"))).empty();
+    check(criteria().not(p -> p.age.isEqualTo(31)).not(p2 -> p2.id.isEqualTo("DUMMY"))).hasSize(1);
+
+    // double not
+    check(criteria().not(p -> p.not(p2 -> p2.id.isEqualTo("john")))).hasSize(1);
+
+    // triple not
+    check(criteria().not(p1 -> p1.not(p2 -> p2.not(p3 -> p3.id.isEqualTo("john"))))).empty();
+    check(criteria().not(p1 -> p1.not(p2 -> p2.not(p3 -> p3.id.isNotEqualTo("john"))))).hasSize(1);
+
+    check(criteria().not(p -> p.age.isGreaterThan(29))).empty();
+    check(criteria().not(p -> p.age.isGreaterThan(31))).hasSize(1);
+
+  }
+
   @Test
   public void basic() {
     Assume.assumeTrue(features().contains(Feature.QUERY));
@@ -214,6 +250,10 @@ public abstract class AbstractPersonTest {
     // isPresent / isAbsent
     check(criteria().address.isAbsent()).empty();
     check(criteria().address.isPresent()).notEmpty();
+
+    // simple OR
+    check(criteria().address.isAbsent().or().address.isPresent()).notEmpty();
+    check(criteria().isActive.isFalse().or().isActive.isTrue()).notEmpty();
   }
 
   @Test

--- a/criteria/inmemory/src/org.immutables.criteria.inmemory/InMemoryExpressionEvaluator.java
+++ b/criteria/inmemory/src/org.immutables.criteria.inmemory/InMemoryExpressionEvaluator.java
@@ -116,6 +116,21 @@ public class InMemoryExpressionEvaluator<T> implements Predicate<T> {
         return op == Operators.IN ? stream.anyMatch(r -> Objects.equals(left, r)) : stream.noneMatch(r -> Objects.equals(left, r));
       }
 
+      if (op == Operators.NOT) {
+        Preconditions.checkArgument(args.size() == 1, "Size should be 1 for %s but was %s", op, args.size());
+        final Object value = args.get(0).accept(this);
+
+        if (value == UNKNOWN || value == null) {
+          return UNKNOWN;
+        }
+
+        if (value instanceof Boolean) {
+          return !(Boolean) value;
+        }
+
+        throw new UnsupportedOperationException(String.format("Expected boolean for op %s but got %s", op, value.getClass().getName()));
+      }
+
       if (op == Operators.IS_ABSENT || op == Operators.IS_PRESENT) {
         Preconditions.checkArgument(args.size() == 1, "Size should be 1 for %s but was %s", op, args.size());
         final Object left = args.get(0).accept(this);


### PR DESCRIPTION
InMemoryOperator had missing handling of NOT.

For Mongo, things were more intricate. $not has specific logic and can't be applied on all levels
(like in boolean algebra). Sometimes ot has to be replaced with $nor. or $eq -> $ne etc.