### PR TITLE
Move Matcher creation logic from template into java class (CriteriaModel)

### DIFF
--- a/criteria/common/src/org/immutables/criteria/matcher/IterableMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/IterableMatcher.java
@@ -65,6 +65,6 @@ public interface IterableMatcher<R, S, V>  {
 
   }
 
-  interface Self<V> extends IterableMatcher<Self<V>, Self<V>, V> {}
+  interface Self<R, V> extends IterableMatcher<Self<R, V>, Self<R, V>, V> {}
 
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/OptionalMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/OptionalMatcher.java
@@ -47,4 +47,6 @@ public interface OptionalMatcher<R, S, C>  {
     return context.<R, C>factory().root().create(Matchers.extract(c).ofParent());
   }
 
+  interface Self<R, S> extends OptionalMatcher<R, S, S> {}
+
 }

--- a/value-processor/src/org/immutables/value/processor/Criteria.generator
+++ b/value-processor/src/org/immutables/value/processor/Criteria.generator
@@ -96,7 +96,7 @@ import [starImport];
    [if a.optionalType or (a.collectionType ornot a.hasCriteria)]
    public final [toUpper a.name]Field<R> [a.name];
    [else]
-   public final [criteriaType a type] [a.name];
+   public final [a.criteria.matcher.toTemplate] [a.name];
    [/if]
    [/for]
 
@@ -174,11 +174,11 @@ import [starImport];
 [/template]
 
 [template fieldDefinition Attribute a Type type]
-public interface [toUpper a.name]Field<R> extends [criteriaType a type], NotMatcher<R, [criteriaTypeSelf a type]>, WithMatcher<R, [criteriaTypeSelf a type]>  {}
+public interface [toUpper a.name]Field<R> extends [a.criteria.matcher.toTemplate], NotMatcher<R, [a.criteria.matcher.toSelf.toTemplate]>, WithMatcher<R, [a.criteria.matcher.toSelf.toTemplate]>  {}
 [/template]
 
 [template fieldImplementation Attribute a Type type]
-private static class Private[toUpper a.name]Field implements [toUpper a.name]Field<[criteriaTypeSelf a type]>, HasContext {
+private static class Private[toUpper a.name]Field implements [toUpper a.name]Field<[a.criteria.matcher.toSelf.toTemplate]>, HasContext {
   private final CriteriaContext context;
   private Private[toUpper a.name]Field(CriteriaContext context) {
     this.context = context;
@@ -190,63 +190,6 @@ private static class Private[toUpper a.name]Field implements [toUpper a.name]Fie
   }
 }
 [/template]
-
-[template criteriaType Attribute a Type type][output.trim]
-[if (a.boolean or (a.type eq 'java.lang.Boolean'))]
-BooleanMatcher<R>
-[else if a.stringType]
-StringMatcher<R>
-[else if a.optionalType]
-  [if a.hasSimpleScalarElementType or a.isMaybeComparableKey]
-    OptionalMatcher<R, [scalarElementCriteria a 'R'], [scalarElementCriteria a 'Self']>
-  [else if a.hasCriteria]
-    OptionalMatcher<R, [a.unwrappedElementType]Criteria<R>, [a.unwrappedElementType]Criteria.Self>
-  [else]
-    OptionalMatcher<R, [scalarElementCriteria a 'R'], [scalarElementCriteria a 'Self']>
-  [/if]
-[else if a.comparable]
-  ComparableMatcher<R, [a.wrappedElementType]>
-[else if a.collectionType]
-  [if a.hasCriteria]
-      IterableMatcher<R, [a.unwrappedElementType]Criteria<R>, [a.wrappedElementType]>
-  [else]
-      IterableMatcher<R, [scalarElementCriteria a 'R'], [a.wrappedElementType]>
-  [/if]
-[else if a.hasCriteria]
-  [a.unwrappedElementType]Criteria<R>
-[else]
-  ObjectMatcher<R, [a.wrappedElementType]>
-[/if]
-[/output.trim][/template]
-
-[template criteriaTypeSelf Attribute a Type type][output.trim]
-[if (a.boolean or (a.type eq 'java.lang.Boolean'))]
-BooleanMatcher.Self
-[else if a.stringType]
-StringMatcher.Self
-[else if a.optionalType]
-  [if a.hasSimpleScalarElementType or a.isMaybeComparableKey]
-    OptionalMatcher<[scalarElementCriteria a 'Self'], [scalarElementCriteria a 'Self'], [scalarElementCriteria a 'Self']>
-  [else if a.hasCriteria]
-    OptionalMatcher<[a.unwrappedElementType]Criteria.Self, [a.unwrappedElementType]Criteria.Self, [a.unwrappedElementType]Criteria.Self>
-  [else]
-    OptionalMatcher<[scalarElementCriteria a 'Self'], [scalarElementCriteria a 'Self'], [scalarElementCriteria a 'Self']>
-  [/if]
-[else if a.comparable]
-  ComparableMatcher.Self<[a.wrappedElementType]>
-[else if a.collectionType]
-  [if a.hasCriteria]
-      IterableMatcher<[a.unwrappedElementType]Criteria.Self, [a.unwrappedElementType]Criteria.Self, [a.wrappedElementType]>
-  [else]
-      IterableMatcher<[scalarElementCriteria a 'Self'], [scalarElementCriteria a 'Self'], [a.wrappedElementType]>
-  [/if]
-[else if a.hasCriteria]
-  [a.unwrappedElementType]Criteria.Self
-[else]
-  [scalarElementCriteria a 'Self']
-[/if]
-[/output.trim][/template]
-
 
 [template createMatcher Attribute a Type type][output.trim]
 [let fieldName]Private[toUpper a.name]Field[/let]
@@ -270,7 +213,7 @@ StringMatcher.Self
 [else if a.hasSimpleScalarElementType or a.isMaybeComparableKey]
   context.withPath([type.name].class, "[a.name]")
            .withCreators(ctx -> [type.name]Criteria.create(ctx),
-                           ctx -> Matchers.create([scalarMatcherType a].Self.class, ctx))
+                           ctx -> Matchers.create([a.criteria.scalarMatcher.withoutParameters.toTemplate].class, ctx))
 [else]
   context
   .withPath([type.name].class, "[a.name]")
@@ -278,30 +221,6 @@ StringMatcher.Self
 [/if]
 [/output.trim][/template]
 
-[-- Used to create criteria for T (eg. List<T>) when T is a scalar / comparable--]
-[template scalarElementCriteria Attribute a String elementName][output.trim]
-[if a.unwrappedElementType eq 'boolean']
-  [if elementName eq 'Self']BooleanMatcher.Self[else]BooleanMatcher<[elementName]>[/if]
-[else if a.unwrappedElementType eq 'java.lang.String']
-  [if elementName eq 'Self']StringMatcher.Self[else]StringMatcher<[elementName]>[/if]
-[else if a.isMaybeComparableKey]
-  [if elementName eq 'Self']ComparableMatcher.Self<[a.wrappedElementType]>[else]ComparableMatcher<[elementName], [a.wrappedElementType]>[/if]
-[else]
-  [if elementName eq 'Self']ObjectMatcher.Self<[a.wrappedElementType]>[else]ObjectMatcher<[elementName], [a.wrappedElementType]>[/if]
-[/if]
-[/output.trim][/template]
-
-[template scalarMatcherType Attribute a][output.trim]
-[if a.unwrappedElementType eq 'boolean']
-  BooleanMatcher
-[else if a.unwrappedElementType eq 'java.lang.String']
-  StringMatcher
-[else if a.isMaybeComparableKey]
-  ComparableMatcher
-[else]
-  ObjectMatcher
-[/if]
-[/output.trim][/template]
 
 [template atGenerated Type type]
 [if type allowsClasspathAnnotation 'org.immutables.value.Generated']

--- a/value-processor/src/org/immutables/value/processor/meta/CriteriaModel.java
+++ b/value-processor/src/org/immutables/value/processor/meta/CriteriaModel.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.value.processor.meta;
+
+import com.google.common.base.Preconditions;
+import org.immutables.value.processor.encode.Type;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Creates several matchers programmatically based on {@link ValueAttribute}.
+ * {@code StringMatcher}, {@code WithMatcher}, {@code NotMatcher} etc.
+ */
+public class CriteriaModel {
+
+  private static final Iterable<Type.Defined> NO_BOUNDS = Collections.emptyList();
+
+  private final ValueAttribute attribute;
+  private final Type.Factory factory;
+  private final Type.Parameters parameters;
+
+  CriteriaModel(ValueAttribute attribute) {
+    this.attribute = Preconditions.checkNotNull(attribute, "attribute");
+    this.factory = new Type.Producer();
+    this.parameters = factory.parameters()
+            .introduce("R", NO_BOUNDS)
+            .introduce("S", NO_BOUNDS)
+            .introduce("C", NO_BOUNDS)
+            .introduce("V", NO_BOUNDS);
+  }
+
+  public MatcherDefinition matcher() {
+    final Type type;
+
+    // TODO probably need to use Transformer
+    if (attribute.isStringType()) {
+      // StringMatcher<R>
+      type = parameterized("org.immutables.criteria.matcher.StringMatcher", "R");
+    } else if (Boolean.class.getName().equals(attribute.getWrapperType())) {
+      type = parameterized("org.immutables.criteria.matcher.BooleanMatcher", "R");
+    } else if (attribute.isOptionalType()) {
+      Type.Parameterized param = (Type.Parameterized) parameterized("org.immutables.criteria.matcher.OptionalMatcher", "R", "S", "C");
+      final Type.Defined def;
+      if (attribute.hasCriteria()) {
+        def = parameterized(attribute.getUnwrappedElementType() + "Criteria", "R");
+      } else  {
+        def = scalar();
+      }
+
+      final Type.VariableResolver resolver = Type.VariableResolver.empty()
+              .bind(variable("S"), def)
+              .bind(variable("C"), toSelf(def));
+
+      type = param.accept(resolver);
+    } else if (attribute.isComparable()) {
+      Type.Defined def = parameterized("org.immutables.criteria.matcher.ComparableMatcher", "R", "V");
+      final Type.VariableResolver resolver = Type.VariableResolver.empty()
+              .bind(variable("V"), factory.reference(attribute.getWrappedElementType()));
+      type = def.accept(resolver);
+    } else if (attribute.isCollectionType()) {
+      final Type.Defined param = parameterized("org.immutables.criteria.matcher.IterableMatcher", "R", "S", "V");
+      final Type.Defined other;
+      if (attribute.hasCriteria()) {
+        other = parameterized(attribute.getUnwrappedElementType() + "Criteria", "R");
+      } else {
+        other = scalar();
+      }
+
+      final Type.VariableResolver resolver = Type.VariableResolver.empty()
+              .bind(variable("S"), other)
+              .bind(variable("V"), factory.reference(attribute.getWrappedElementType()));
+
+      type = param.accept(resolver);
+    } else if (attribute.hasCriteria()) {
+      type = parameterized(attribute.getUnwrappedElementType() + "Criteria", "R");
+    } else {
+      final Type.VariableResolver resolver = Type.VariableResolver.empty()
+              .bind(variable("V"), factory.reference(attribute.getWrappedElementType()));
+
+      type = parameterized("org.immutables.criteria.matcher.ObjectMatcher", "R", "V").accept(resolver);
+    }
+
+    return new MatcherDefinition(type);
+  }
+
+  public MatcherDefinition scalarMatcher() {
+    return new MatcherDefinition(scalar());
+  }
+
+  private Type.Variable variable(String name) {
+    return parameters.variable(name);
+  }
+
+  private Type.Defined scalar() {
+    final Type.Defined type;
+    if (Boolean.class.getName().equals(attribute.getWrappedElementType())) {
+      type = parameterized("org.immutables.criteria.matcher.BooleanMatcher", "R");
+    } else if (String.class.getName().equals(attribute.getWrappedElementType())) {
+      type = parameterized("org.immutables.criteria.matcher.StringMatcher", "R");
+    } else if (attribute.isMaybeComparableKey()) {
+      type = parameterized("org.immutables.criteria.matcher.ComparableMatcher", "R", "V");
+    } else {
+      type = parameterized("org.immutables.criteria.matcher.ObjectMatcher", "R", "V");
+    }
+
+    final Type.VariableResolver resolver = Type.VariableResolver.empty()
+            .bind(variable("V"), factory.reference(attribute.getWrappedElementType()));
+
+
+    return (Type.Defined) type.accept(resolver);
+  }
+
+  public class MatcherDefinition {
+    private final Type type;
+
+    private MatcherDefinition(Type type) {
+      this.type = type;
+    }
+
+    public MatcherDefinition toSelf() {
+      return new MatcherDefinition(CriteriaModel.this.toSelf(type));
+    }
+
+    public MatcherDefinition withoutParameters() {
+      final Type.Transformer transformer = new Type.Transformer() {
+        @Override
+        public Type parameterized(Type.Parameterized parameterized) {
+          return parameterized.reference;
+        }
+      };
+      return new MatcherDefinition(type.accept(transformer));
+    }
+
+    public String toTemplate() {
+      return type.toString();
+    }
+
+    @Override
+    public String toString() {
+      return toTemplate();
+    }
+  }
+
+  private Type.Defined parameterized(String name, String ... params) {
+    final Type.Reference reference = factory.reference(name);
+    final List<Type.Variable> variables = new ArrayList<>();
+    for (String param: params) {
+      variables.add(parameters.variable(param));
+    }
+
+    return variables.isEmpty() ? reference : factory.parameterized(reference, variables);
+  }
+
+  private Type.Defined toSelf(Type type) {
+    final Type.Transformer transformer = new Type.Transformer() {
+      @Override
+      public Type reference(Type.Reference reference) {
+        // check if it is immutables matcher or attribute has criteria defined
+        if (!(attribute.hasCriteria() || reference.name.startsWith("org.immutables.criteria.matcher."))) {
+          return defaults(reference);
+        }
+
+        // is already transformed ?
+        if (reference.name.contains(".Self")) {
+          return defaults(reference);
+        }
+
+        // PetCriteria vs Pet vs IterableMatcher
+        return factory.reference(reference.name + ".Self");
+      }
+
+      @Override
+      public Type parameterized(Type.Parameterized parameterized) {
+        if (parameterized.reference.name.contains(".Self")) {
+          return defaults(parameterized);
+        }
+
+        Type.Reference reference = (Type.Reference) parameterized.reference.accept(this);
+        if (parameterized.arguments.size() <= 1) {
+          return defaults(reference);
+        }
+
+        final List<Type.Nonprimitive> args = new ArrayList<>();
+        for (Type.Nonprimitive arg: parameterized.arguments.subList(1, parameterized.arguments.size())) {
+          if (arg instanceof Type.Parameterized) {
+            args.add((Type.Nonprimitive) arg.accept(this));
+          } else {
+            args.add(arg);
+          }
+        }
+
+        return factory.parameterized(reference, args);
+      }
+    };
+
+
+    return (Type.Defined) type.accept(transformer);
+  }
+
+}

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -119,8 +119,24 @@ public final class ValueAttribute extends TypeIntrospectionBase implements HasSt
   @Nullable
   private String rawTypeName;
 
+  @Nullable
+  private CriteriaModel criteriaModel;
+
   public String name() {
     return names.var;
+  }
+
+  /**
+   * Expose criteria metadata like list of matchers for current attribute.
+   */
+  public CriteriaModel criteria() {
+    CriteriaModel model = criteriaModel;
+    if (model == null) {
+      model = new CriteriaModel(this);
+      criteriaModel = model;
+    }
+
+    return model;
   }
 
   public boolean isBoolean() {

--- a/value-processor/test/org/immutables/value/processor/meta/CriteriaModelTest.java
+++ b/value-processor/test/org/immutables/value/processor/meta/CriteriaModelTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.value.processor.meta;
+
+import com.google.common.base.Optional;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.immutables.check.Checkers.check;
+
+public class CriteriaModelTest {
+
+  @Rule
+  public final ProcessorRule rule = new ProcessorRule();
+
+  @Test
+  public void string() {
+    CriteriaModel.MatcherDefinition matcher = matcherFor("string");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.StringMatcher<R>");
+    check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.StringMatcher.Self");
+  }
+
+  @Test
+  public void optionalString() {
+    CriteriaModel.MatcherDefinition matcher = matcherFor("optionalString");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher<R, " +
+            "org.immutables.criteria.matcher.StringMatcher<R>, " +
+            "org.immutables.criteria.matcher.StringMatcher.Self>");
+
+    check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher.Self<" +
+            "org.immutables.criteria.matcher.StringMatcher.Self, " +
+            "org.immutables.criteria.matcher.StringMatcher.Self>");
+  }
+
+  @Test
+  public void stringList() {
+    CriteriaModel.MatcherDefinition matcher = matcherFor("stringList");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.IterableMatcher<R, org.immutables.criteria.matcher.StringMatcher<R>, java.lang.String>");
+    check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.IterableMatcher.Self<org.immutables.criteria.matcher.StringMatcher.Self, java.lang.String>");
+
+  }
+
+  @Test
+  public void integer() {
+    CriteriaModel.MatcherDefinition matcher = matcherFor("integer");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.ComparableMatcher<R, java.lang.Integer>");
+    check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.ComparableMatcher.Self<java.lang.Integer>");
+  }
+
+  @Test
+  public void optionalInteger() {
+    CriteriaModel.MatcherDefinition matcher = matcherFor("optionalInteger");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher<R, " +
+            "org.immutables.criteria.matcher.ComparableMatcher<R, java.lang.Integer>, " +
+            "org.immutables.criteria.matcher.ComparableMatcher.Self<java.lang.Integer>>");
+
+    check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher.Self<" +
+            "org.immutables.criteria.matcher.ComparableMatcher.Self<java.lang.Integer>, " +
+            "org.immutables.criteria.matcher.ComparableMatcher.Self<java.lang.Integer>>");
+  }
+
+  @Test
+  public void booleanValue() {
+    CriteriaModel.MatcherDefinition matcher = matcherFor("booleanValue");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.BooleanMatcher<R>");
+    check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.BooleanMatcher.Self");
+  }
+
+  @Test
+  public void optionalBoolean() {
+    CriteriaModel.MatcherDefinition matcher = matcherFor("optionalBoolean");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher<R, " +
+            "org.immutables.criteria.matcher.BooleanMatcher<R>, org.immutables.criteria.matcher.BooleanMatcher.Self>");
+    check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher.Self<org.immutables.criteria.matcher.BooleanMatcher.Self, " +
+            "org.immutables.criteria.matcher.BooleanMatcher.Self>");
+  }
+
+  @Test
+  public void timeZone() {
+    CriteriaModel.MatcherDefinition matcher = matcherFor("timeZone");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.ObjectMatcher<R, java.util.TimeZone>");
+    check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.ObjectMatcher.Self<java.util.TimeZone>");
+  }
+
+  @Test
+  public void optionalTimeZone() {
+    CriteriaModel.MatcherDefinition matcher = matcherFor("optionalTimeZone");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher<R, " +
+            "org.immutables.criteria.matcher.ObjectMatcher<R, java.util.TimeZone>, " +
+            "org.immutables.criteria.matcher.ObjectMatcher.Self<java.util.TimeZone>>");
+
+    check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher.Self<" +
+            "org.immutables.criteria.matcher.ObjectMatcher.Self<java.util.TimeZone>, " +
+            "org.immutables.criteria.matcher.ObjectMatcher.Self<java.util.TimeZone>>");
+  }
+
+  private CriteriaModel.MatcherDefinition matcherFor(String name) {
+    ValueType type = rule.value(Model.class);
+    ValueAttribute attr = findAttribute(type, name);
+    return attr.criteria().matcher();
+  }
+
+  private ValueAttribute findAttribute(ValueType type, String name) {
+    for (ValueAttribute attr: type.attributes) {
+      if (attr.name().equals(name)) {
+        return attr;
+      }
+    }
+
+    throw new IllegalArgumentException(String.format("%s not found in %s", name, type.name()));
+  }
+
+  @ProcessorRule.TestImmutable
+  interface Model {
+     String string();
+     Optional<String> optionalString();
+     List<String> stringList();
+     int integer();
+     Optional<Integer> optionalInteger();
+
+     boolean booleanValue();
+     Optional<Boolean> optionalBoolean();
+
+     // non-comparable
+     TimeZone timeZone();
+     Optional<TimeZone> optionalTimeZone();
+  }
+
+
+}


### PR DESCRIPTION
Allows more complex logic to be encoded in java.

Add unit tests to validate matchers (before java files are created)