### PR TITLE
Introduce WithMatcher on all levels: scalar and object/model

### DIFF
--- a/criteria/common/src/org/immutables/criteria/matcher/BooleanMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/BooleanMatcher.java
@@ -34,6 +34,11 @@ public interface BooleanMatcher<R>  {
             .createRoot(e -> Expressions.call(Operators.EQUAL, e, Expressions.constant(Boolean.FALSE)));
   }
 
-  interface Self extends BooleanMatcher<Self> {}
+  interface Self extends Template<Self> {}
 
+  interface With<R> extends WithMatcher<R, Self> {}
+
+  interface Not<R> extends NotMatcher<R, Self> {}
+
+  interface Template<R> extends BooleanMatcher<R>, With<R>, Not<R> {}
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/ComparableMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/ComparableMatcher.java
@@ -54,6 +54,11 @@ public interface ComparableMatcher<R, V extends Comparable<? super V>> extends O
     return Matchers.extract(this).<R, Object>factory().createRoot(e -> Expressions.call(Operators.GREATER_THAN_OR_EQUAL, e, Expressions.constant(lowerInclusive)));
   }
 
-  interface Self<V extends Comparable<? super V>> extends ComparableMatcher<Self<V>, V> {}
+  interface Self<V extends Comparable<? super V>> extends Template<Self<V>, V> {}
 
+  interface With<R, V extends Comparable<? super V>> extends WithMatcher<R, Self<V>> {}
+
+  interface Not<R, V extends Comparable<? super V>> extends NotMatcher<R, Self<V>> { }
+
+  interface Template<R, V extends Comparable<? super V>> extends ComparableMatcher<R, V>, With<R, V>, Not<R, V> {}
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/CriteriaContext.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/CriteriaContext.java
@@ -112,7 +112,6 @@ public final class CriteriaContext implements Queryable {
     return withPath(newPath);
   }
 
-
   public CriteriaContext or() {
     return new CriteriaContext(entityClass, expression.or(), path, creators, parent);
   }

--- a/criteria/common/src/org/immutables/criteria/matcher/Matchers.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/Matchers.java
@@ -78,7 +78,7 @@ public final class Matchers {
     return (ObjectMatcher<R, V>) new Local();
   }
 
-  public static <R, S, C> OptionalMatcher<R, S, C> optionalMatcher(CriteriaContext context) {
+  public static <R, S, C> OptionalMatcher<R, S> optionalMatcher(CriteriaContext context) {
     Objects.requireNonNull(context, "context");
     class Local implements OptionalMatcher, HasContext {
       @Override
@@ -105,21 +105,17 @@ public final class Matchers {
   public static <T> T create(Class<T> type, CriteriaContext context) {
     Objects.requireNonNull(type, "type");
 
-//    if (type.getSimpleName().equals("Self") && !type.isInterface()) {
-//      return createWithReflection(type, context);
-//    }
-
-    if (type == BooleanMatcher.class || type == BooleanMatcher.Self.class) {
+    if (BooleanMatcher.class.isAssignableFrom(type)) {
       return (T) booleanMatcher(context);
-    } else if (type == StringMatcher.class || type == StringMatcher.Self.class) {
+    } else if (StringMatcher.class.isAssignableFrom(type)) {
       return (T) stringMatcher(context);
-    } else if (type == ComparableMatcher.class) {
+    } else if (ComparableMatcher.class.isAssignableFrom(type)) {
       return (T) comparableMatcher(context);
-    } else if (type == ObjectMatcher.class) {
+    } else if (ObjectMatcher.class.isAssignableFrom(type)) {
       return (T) objectMatcher(context);
-    } else if (type == OptionalMatcher.class) {
+    } else if (OptionalMatcher.class.isAssignableFrom(type)) {
       return (T) optionalMatcher(context);
-    } else if (type == IterableMatcher.class) {
+    } else if (IterableMatcher.class.isAssignableFrom(type)) {
       return (T) collectionMatcher(context);
     }
 

--- a/criteria/common/src/org/immutables/criteria/matcher/ObjectMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/ObjectMatcher.java
@@ -70,6 +70,12 @@ public interface ObjectMatcher<R, V> {
     return Matchers.extract(this).<R, Object>factory().createRoot(e -> Expressions.call(Operators.NOT_IN, e, Expressions.constant(ImmutableList.copyOf(values))));
   }
 
-  interface Self<V> extends ObjectMatcher<Self<V>, V> {}
+  interface Self<V> extends Template<Self<V>, V> {}
+
+  interface With<R, V> extends WithMatcher<R, Self<V>> {}
+
+  interface Not<R, V> extends NotMatcher<R, Self<V>> {}
+
+  interface Template<R, V> extends ObjectMatcher<R, V>, With<R, V>, Not<R, V> {}
 
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/OptionalMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/OptionalMatcher.java
@@ -25,7 +25,7 @@ import java.util.function.UnaryOperator;
 /**
  * Matcher for optional attributes
  */
-public interface OptionalMatcher<R, S, C>  {
+public interface OptionalMatcher<R, S>  {
 
   default R isPresent() {
     final UnaryOperator<Expression> expr = e -> Expressions.call(Operators.IS_PRESENT, e);
@@ -41,12 +41,6 @@ public interface OptionalMatcher<R, S, C>  {
     return Matchers.extract(this).<R, S>factory().createNested();
   }
 
-  default R value(UnaryOperator<C> consumer) {
-    final CriteriaContext context = Matchers.extract(this);
-    final C c = consumer.apply((C) context.newChild().factory().createRoot());
-    return context.<R, C>factory().root().create(Matchers.extract(c).ofParent());
-  }
-
-  interface Self<R, S> extends OptionalMatcher<Self<R, S>, Self<R, S>, S> {}
+  interface Self<S> extends OptionalMatcher<Self<S>, S> {}
 
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/StringMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/StringMatcher.java
@@ -57,12 +57,18 @@ public interface StringMatcher<R> extends ComparableMatcher<R, String>  {
     throw new UnsupportedOperationException();
   }
 
-  interface Self extends StringMatcher<Self>, Disjunction<StringMatcher<Self>> {
+  interface Self extends Template<Self>, Disjunction<StringMatcher<Self>> {
 
     @Override
     default StringMatcher<StringMatcher.Self> or() {
       return Matchers.extract(this).or().<StringMatcher.Self, Object>factory().createRoot();
     }
   }
+
+  interface With<R> extends WithMatcher<R, Self> {}
+
+  interface Not<R> extends NotMatcher<R, Self> {}
+
+  interface Template<R> extends StringMatcher<R>, With<R>, Not<R> {}
 
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/WithMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/WithMatcher.java
@@ -16,6 +16,8 @@
 
 package org.immutables.criteria.matcher;
 
+import org.immutables.criteria.expression.Expression;
+
 import java.util.function.UnaryOperator;
 
 /**
@@ -35,7 +37,9 @@ import java.util.function.UnaryOperator;
 public interface WithMatcher<R, C> {
 
   default R with(UnaryOperator<C> operator) {
-    return null;
+    final CriteriaContext context = Matchers.extract(this);
+    final UnaryOperator<Expression> expr = e -> Matchers.toInnerExpression(context, operator).apply(e);
+    return context.<R, C>factory().createRoot(expr);
   }
 
 }

--- a/criteria/common/test/org/immutables/criteria/TypeHolderTest.java
+++ b/criteria/common/test/org/immutables/criteria/TypeHolderTest.java
@@ -106,7 +106,6 @@ public class TypeHolderTest {
     TypeHolderCriteria.typeHolder
             .localDate.isAtMost(LocalDate.MIN)
             .optLocalDate.value().isAtMost(LocalDate.MAX)
-            .optLocalDate.value(d -> d.isAtMost(LocalDate.MAX))
             .localDates.contains(LocalDate.MAX);
   }
 
@@ -129,7 +128,6 @@ public class TypeHolderTest {
     TypeHolderCriteria.typeHolder
             .bigDecimal.isAtLeast(BigDecimal.ONE)
             .optBigDecimal.value().isAtLeast(BigDecimal.ONE)
-            .optBigDecimal.value(b -> b.isGreaterThan(BigDecimal.TEN))
             .bigDecimals.contains(BigDecimal.TEN)
             .bigDecimals.isNotEmpty()
             .bigDecimals.any().isAtLeast(BigDecimal.ONE);
@@ -137,7 +135,6 @@ public class TypeHolderTest {
     TypeHolderCriteria.typeHolder
             .bigInteger.isAtLeast(BigInteger.ONE)
             .optBigInteger.value().isAtLeast(BigInteger.ONE)
-            .optBigInteger.value(b -> b.isGreaterThan(BigInteger.TEN))
             .bigIntegers.contains(BigInteger.TEN)
             .bigIntegers.isNotEmpty()
             .bigIntegers.any().isAtLeast(BigInteger.ONE);
@@ -149,8 +146,7 @@ public class TypeHolderTest {
               .foos.none().isEqualTo(TypeHolder.Foo.TWO)
               .foo.isEqualTo(TypeHolder.Foo.ONE)
               .optFoo.isPresent()
-              .optFoo.value().isEqualTo(TypeHolder.Foo.ONE)
-              .optFoo.value(e -> e.isIn(TypeHolder.Foo.ONE, TypeHolder.Foo.TWO));
+              .optFoo.value().isEqualTo(TypeHolder.Foo.ONE);
   }
 
   @Test

--- a/criteria/common/test/org/immutables/criteria/nested/NestedTest.java
+++ b/criteria/common/test/org/immutables/criteria/nested/NestedTest.java
@@ -47,30 +47,30 @@ public class NestedTest {
     assertExpressional(RootCriteria.root.a.value().b.value().c.value().hidden.value().isEqualTo("gem")
             , "call op=EQUAL path=a.b.c.hidden constant=gem");
 
-    assertExpressional(RootCriteria.root.a.value().b.value().c.value().hidden.value(s -> s.isEqualTo("gem"))
+    assertExpressional(RootCriteria.root.a.value().b.value().c.value().hidden.value().with(s -> s.isEqualTo("gem"))
             , "call op=EQUAL path=a.b.c.hidden constant=gem");
 
-    assertExpressional(RootCriteria.root.a.value(a -> a.b.isPresent()),
+    assertExpressional(RootCriteria.root.a.value().with(a -> a.b.isPresent()),
             "call op=IS_PRESENT path=a.b"
             );
 
-    assertExpressional(RootCriteria.root.a.value(a -> a.b.value(b -> b.c.isPresent())),
+    assertExpressional(RootCriteria.root.a.value().with(a -> a.b.value().with(b -> b.c.isPresent())),
             "call op=IS_PRESENT path=a.b.c"
     );
 
-    assertExpressional(RootCriteria.root.a.value(a -> a.b.value().c.isPresent()),
+    assertExpressional(RootCriteria.root.a.value().with(a -> a.b.value().c.isPresent()),
             "call op=IS_PRESENT path=a.b.c"
             );
 
-    assertExpressional(RootCriteria.root.a.value(a -> a.b.value(b -> b.c.value(c -> c.value.isEqualTo("gem")))),
+    assertExpressional(RootCriteria.root.a.value().with(a -> a.b.value().with(b -> b.c.value().with(c -> c.value.isEqualTo("gem")))),
             "call op=EQUAL path=a.b.c.value constant=gem"
     );
 
-    assertExpressional(RootCriteria.root.a.value(a -> a.b.value(b -> b.c.value(c -> c.hidden.value(h -> h.isEqualTo("gem"))))),
+    assertExpressional(RootCriteria.root.a.value().with(a -> a.b.value().with(b -> b.c.value().with(c -> c.hidden.value().with(h -> h.isEqualTo("gem"))))),
             "call op=EQUAL path=a.b.c.hidden constant=gem"
     );
 
-    assertExpressional(RootCriteria.root.a.value(a -> a.b.isPresent()),
+    assertExpressional(RootCriteria.root.a.value().with(a -> a.b.isPresent()),
             "call op=IS_PRESENT path=a.b"
             );
 
@@ -78,17 +78,17 @@ public class NestedTest {
 
   @Test
   public void nested2() {
-    assertExpressional(RootCriteria.root.a.isAbsent().a.value(a -> a.value.isEmpty()),
+    assertExpressional(RootCriteria.root.a.isAbsent().a.value().with(a -> a.value.isEmpty()),
             "call op=AND",
             "  call op=IS_ABSENT path=a",
             "  call op=EQUAL path=a.value constant=");
 
-    assertExpressional(RootCriteria.root.a.isAbsent().or().a.value(a -> a.value.isEmpty()),
+    assertExpressional(RootCriteria.root.a.isAbsent().or().a.value().with(a -> a.value.isEmpty()),
             "call op=OR",
             "  call op=IS_ABSENT path=a",
             "  call op=EQUAL path=a.value constant=");
 
-    assertExpressional(RootCriteria.root.a.value(a -> a.b.isAbsent().or().b.value(b -> b.c.value().value.isEmpty())),
+    assertExpressional(RootCriteria.root.a.value().with(a -> a.b.isAbsent().or().b.value().with(b -> b.c.value().value.isEmpty())),
             "call op=OR",
             "  call op=IS_ABSENT path=a.b",
             "  call op=EQUAL path=a.b.c.value constant=");
@@ -97,23 +97,26 @@ public class NestedTest {
   @Test
   public void composed() {
     assertExpressional(RootCriteria.root
-                    .a.value(a -> a.value.isEqualTo("a").value.isEqualTo("b"))
+                    .a.value().with(a -> a.value.isEqualTo("a").value.isEqualTo("b"))
                     .a.value().value.isEmpty()
             ,
             "call op=AND",
-            "  call op=EQUAL path=a.value constant=a",
-            "  call op=EQUAL path=a.value constant=b",
+            "  call op=AND",
+            "    call op=EQUAL path=a.value constant=a",
+            "    call op=EQUAL path=a.value constant=b",
             "  call op=EQUAL path=a.value constant="
     );
     assertExpressional(RootCriteria.root
-                    .a.value(a -> a.value.isEqualTo("a").value.isEqualTo("b"))
-                    .a.value(a -> a.value.isEmpty().value.isNotEmpty())
+                    .a.value().with(a -> a.value.isEqualTo("a").value.isEqualTo("b"))
+                    .a.value().with(a -> a.value.isEmpty().value.isNotEmpty())
             ,
             "call op=AND",
-            "  call op=EQUAL path=a.value constant=a",
-            "  call op=EQUAL path=a.value constant=b",
-            "  call op=EQUAL path=a.value constant=",
-            "  call op=NOT_EQUAL path=a.value constant="
+            "  call op=AND",
+            "    call op=EQUAL path=a.value constant=a",
+            "    call op=EQUAL path=a.value constant=b",
+            "  call op=AND",
+            "    call op=EQUAL path=a.value constant=",
+            "    call op=NOT_EQUAL path=a.value constant="
     );
   }
 
@@ -209,11 +212,10 @@ public class NestedTest {
   @Ignore("doesn't return optional statement")
   @Test
   public void debug() {
-    assertExpressional(RootCriteria.root
-                    .x.value.isEmpty()
-            ,
-            "call op=EQUAL path=x.value constant="
-    );
+    assertExpressional(RootCriteria.root.a.isAbsent().a.value().with(a -> a.value.isEmpty()),
+            "call op=AND",
+            "  call op=IS_ABSENT path=a",
+            "  call op=EQUAL path=a.value constant=");
   }
 
   private static void assertExpressional(Criterion<?> crit, String ... expectedLines) {

--- a/criteria/elasticsearch/test/org/immutables/criteria/elasticsearch/EmbeddedElasticsearchResource.java
+++ b/criteria/elasticsearch/test/org/immutables/criteria/elasticsearch/EmbeddedElasticsearchResource.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  *
  * <p>This rule should be used as follows:
  * <pre>
- *  public class MyTest {
+ *  public class WithTest {
  *    &#64;ClassRule
  *    public static final EmbeddedElasticsearchResource RULE = EmbeddedElasticsearchResource.create();
  *

--- a/criteria/inmemory/test/org/immutables/criteria/inmemory/InMemoryExpressionEvaluatorTest.java
+++ b/criteria/inmemory/test/org/immutables/criteria/inmemory/InMemoryExpressionEvaluatorTest.java
@@ -84,11 +84,11 @@ public class InMemoryExpressionEvaluatorTest {
     check(evaluate(crit.nickName.value().isNotIn("Nobody", "Sky"), person.withNickName("Smith")));
 
     // == value($expr)
-    check(evaluate(crit.nickName.value(v -> v.isEqualTo("Smith")), person.withNickName("Smith")));
-    check(!evaluate(crit.nickName.value(v -> v.isNotEqualTo("Smith")), person.withNickName("Smith")));
-    check(evaluate(crit.nickName.value(v -> v.isIn("Smith", "Nobody")), person.withNickName("Smith")));
-    check(!evaluate(crit.nickName.value(v -> v.isIn("Nobody", "Sky")), person.withNickName("Smith")));
-    check(evaluate(crit.nickName.value(v -> v.isNotIn("Nobody", "Sky")), person.withNickName("Smith")));
+    check(evaluate(crit.nickName.value().with(v -> v.isEqualTo("Smith")), person.withNickName("Smith")));
+    check(!evaluate(crit.nickName.value().with(v -> v.isNotEqualTo("Smith")), person.withNickName("Smith")));
+    check(evaluate(crit.nickName.value().with(v -> v.isIn("Smith", "Nobody")), person.withNickName("Smith")));
+    check(!evaluate(crit.nickName.value().with(v -> v.isIn("Nobody", "Sky")), person.withNickName("Smith")));
+    check(evaluate(crit.nickName.value().with(v -> v.isNotIn("Nobody", "Sky")), person.withNickName("Smith")));
   }
 
   @Test

--- a/value-processor/src/org/immutables/value/processor/Criteria.generator
+++ b/value-processor/src/org/immutables/value/processor/Criteria.generator
@@ -94,11 +94,7 @@ import [starImport];
    private final CriteriaContext context;
 
    [for a in type.allMarshalingAttributes]
-   [if a.optionalType or (a.collectionType ornot a.hasCriteria)]
-   public final [toUpper a.name]Field<R> [a.name];
-   [else]
    public final [a.criteria.matcher.toTemplate] [a.name];
-   [/if]
    [/for]
 
    /** TODO this should be top-level class */
@@ -119,20 +115,20 @@ import [starImport];
    }
 
    /** Similar to {@link Self} but exposes {@link Expressional} interface */
-   private final static class PrivateSelf extends Self implements Queryable, HasContext {
+   private static final class Private extends Self implements Queryable, HasContext {
       private final CriteriaContext context;
 
-      private PrivateSelf() {
+      private Private() {
          this(new CriteriaContext([type.name].class, creator()).withCreators(creator(), creator()));
       }
 
-      private PrivateSelf(CriteriaContext context) {
+      private Private(CriteriaContext context) {
        super(context);
        this.context = context;
       }
 
       private static CriteriaCreator<Self> creator() {
-        return (CriteriaContext ctx) ->  new PrivateSelf(ctx);
+        return (CriteriaContext ctx) ->  new Private(ctx);
       }
 
       @Override
@@ -150,58 +146,36 @@ import [starImport];
    private [type.name]Criteria(CriteriaContext context) {
      this.context = Objects.requireNonNull(context, "context");
    [for a in type.allMarshalingAttributes]
-     this.[a.name] = [createMatcher a type];
+     this.[a.name] = ([a.criteria.matcher.toTemplate]) [createMatcher a type];
    [/for]
    }
 
    /** Factory method to create an instance of [type.name]Criteria */
    private static [type.name]Criteria<Self> create() {
-     return new PrivateSelf();
+     return new Private();
    }
 
    public static [type.name]Criteria<Self> create(CriteriaContext context) {
-     return new PrivateSelf(context);
+     return new Private(context);
    }
-
-   [for a in type.allMarshalingAttributes]
-   [if a.optionalType or (a.collectionType ornot a.hasCriteria)]
-
-   [fieldDefinition a type]
-
-   [fieldImplementation a type]
-   [/if]
-   [/for]
-}
-[/template]
-
-[template fieldDefinition Attribute a Type type]
-public interface [toUpper a.name]Field<R> extends [a.criteria.matcher.toTemplate], NotMatcher<R, [a.criteria.matcher.toSelf.toTemplate]>, WithMatcher<R, [a.criteria.matcher.toSelf.toTemplate]>  {}
-[/template]
-
-[template fieldImplementation Attribute a Type type]
-private static class Private[toUpper a.name]Field implements [toUpper a.name]Field<[a.criteria.matcher.toSelf.toTemplate]>, HasContext {
-  private final CriteriaContext context;
-  private Private[toUpper a.name]Field(CriteriaContext context) {
-    this.context = context;
-  }
-
-  @Override
-  public CriteriaContext context() {
-    return context;
-  }
 }
 [/template]
 
 [template createMatcher Attribute a Type type][output.trim]
-[let fieldName]Private[toUpper a.name]Field[/let]
 [if (a.boolean or (a.type eq 'java.lang.Boolean'))]
-([toUpper a.name]Field<R>) new [fieldName]([constructorArgs a type])
-[else if a.stringType or (a.optionalType or (a.comparable or a.collectionType))]
-([toUpper a.name]Field<R>) new [fieldName]([constructorArgs a type])
+Matchers.create(BooleanMatcher.class, [constructorArgs a type])
+[else if a.stringType]
+Matchers.create(StringMatcher.class, [constructorArgs a type])
+[else if a.optionalType]
+   Matchers.create(OptionalMatcher.class, [constructorArgs a type])
+[else if a.comparable]
+   Matchers.create(ComparableMatcher.class, [constructorArgs a type])
+[else if a.collectionType]
+   Matchers.create(IterableMatcher.class, [constructorArgs a type])
 [else if a.hasCriteria]
-  ([a.unwrappedElementType]Criteria<R>) [a.unwrappedElementType]Criteria.create(context.withPath([type.name].class, "[a.name]"))
+  [a.unwrappedElementType]Criteria.create(context.withPath([type.name].class, "[a.name]"))
 [else]
-   ([toUpper a.name]Field<R>) new [fieldName]([constructorArgs a type])
+   Matchers.create(ObjectMatcher.class, [constructorArgs a type])
 [/if]
 [/output.trim][/template]
 

--- a/value-processor/src/org/immutables/value/processor/meta/CriteriaModel.java
+++ b/value-processor/src/org/immutables/value/processor/meta/CriteriaModel.java
@@ -51,11 +51,11 @@ public class CriteriaModel {
     // TODO probably need to use Transformer
     if (attribute.isStringType()) {
       // StringMatcher<R>
-      type = parameterized("org.immutables.criteria.matcher.StringMatcher", "R");
+      type = parameterized("org.immutables.criteria.matcher.StringMatcher.Template", "R");
     } else if (Boolean.class.getName().equals(attribute.getWrapperType())) {
-      type = parameterized("org.immutables.criteria.matcher.BooleanMatcher", "R");
+      type = parameterized("org.immutables.criteria.matcher.BooleanMatcher.Template", "R");
     } else if (attribute.isOptionalType()) {
-      Type.Parameterized param = (Type.Parameterized) parameterized("org.immutables.criteria.matcher.OptionalMatcher", "R", "S", "C");
+      Type.Parameterized param = (Type.Parameterized) parameterized("org.immutables.criteria.matcher.OptionalMatcher", "R", "S");
       final Type.Defined def;
       if (attribute.hasCriteria()) {
         def = parameterized(attribute.getUnwrappedElementType() + "Criteria", "R");
@@ -64,12 +64,11 @@ public class CriteriaModel {
       }
 
       final Type.VariableResolver resolver = Type.VariableResolver.empty()
-              .bind(variable("S"), def)
-              .bind(variable("C"), toSelf(def));
+              .bind(variable("S"), def);
 
       type = param.accept(resolver);
     } else if (attribute.isComparable()) {
-      Type.Defined def = parameterized("org.immutables.criteria.matcher.ComparableMatcher", "R", "V");
+      Type.Defined def = parameterized("org.immutables.criteria.matcher.ComparableMatcher.Template", "R", "V");
       final Type.VariableResolver resolver = Type.VariableResolver.empty()
               .bind(variable("V"), factory.reference(attribute.getWrappedElementType()));
       type = def.accept(resolver);
@@ -93,7 +92,7 @@ public class CriteriaModel {
       final Type.VariableResolver resolver = Type.VariableResolver.empty()
               .bind(variable("V"), factory.reference(attribute.getWrappedElementType()));
 
-      type = parameterized("org.immutables.criteria.matcher.ObjectMatcher", "R", "V").accept(resolver);
+      type = parameterized("org.immutables.criteria.matcher.ObjectMatcher.Template", "R", "V").accept(resolver);
     }
 
     return new MatcherDefinition(type);
@@ -110,13 +109,13 @@ public class CriteriaModel {
   private Type.Defined scalar() {
     final Type.Defined type;
     if (Boolean.class.getName().equals(attribute.getWrappedElementType())) {
-      type = parameterized("org.immutables.criteria.matcher.BooleanMatcher", "R");
+      type = parameterized("org.immutables.criteria.matcher.BooleanMatcher.Template", "R");
     } else if (String.class.getName().equals(attribute.getWrappedElementType())) {
-      type = parameterized("org.immutables.criteria.matcher.StringMatcher", "R");
+      type = parameterized("org.immutables.criteria.matcher.StringMatcher.Template", "R");
     } else if (attribute.isMaybeComparableKey()) {
-      type = parameterized("org.immutables.criteria.matcher.ComparableMatcher", "R", "V");
+      type = parameterized("org.immutables.criteria.matcher.ComparableMatcher.Template", "R", "V");
     } else {
-      type = parameterized("org.immutables.criteria.matcher.ObjectMatcher", "R", "V");
+      type = parameterized("org.immutables.criteria.matcher.ObjectMatcher.Template", "R", "V");
     }
 
     final Type.VariableResolver resolver = Type.VariableResolver.empty()
@@ -182,7 +181,11 @@ public class CriteriaModel {
         }
 
         // PetCriteria vs Pet vs IterableMatcher
-        return factory.reference(reference.name + ".Self");
+        if (reference.name.endsWith(".Template")) {
+          return factory.reference(reference.name.replace(".Template", ".Self"));
+        } else {
+          return factory.reference(reference.name + ".Self");
+        }
       }
 
       @Override

--- a/value-processor/test/org/immutables/value/processor/meta/CriteriaModelTest.java
+++ b/value-processor/test/org/immutables/value/processor/meta/CriteriaModelTest.java
@@ -33,7 +33,7 @@ public class CriteriaModelTest {
   @Test
   public void string() {
     CriteriaModel.MatcherDefinition matcher = matcherFor("string");
-    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.StringMatcher<R>");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.StringMatcher.Template<R>");
     check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.StringMatcher.Self");
   }
 
@@ -41,18 +41,16 @@ public class CriteriaModelTest {
   public void optionalString() {
     CriteriaModel.MatcherDefinition matcher = matcherFor("optionalString");
     check(matcher.toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher<R, " +
-            "org.immutables.criteria.matcher.StringMatcher<R>, " +
-            "org.immutables.criteria.matcher.StringMatcher.Self>");
+            "org.immutables.criteria.matcher.StringMatcher.Template<R>>");
 
     check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher.Self<" +
-            "org.immutables.criteria.matcher.StringMatcher.Self, " +
             "org.immutables.criteria.matcher.StringMatcher.Self>");
   }
 
   @Test
   public void stringList() {
     CriteriaModel.MatcherDefinition matcher = matcherFor("stringList");
-    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.IterableMatcher<R, org.immutables.criteria.matcher.StringMatcher<R>, java.lang.String>");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.IterableMatcher<R, org.immutables.criteria.matcher.StringMatcher.Template<R>, java.lang.String>");
     check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.IterableMatcher.Self<org.immutables.criteria.matcher.StringMatcher.Self, java.lang.String>");
 
   }
@@ -60,7 +58,7 @@ public class CriteriaModelTest {
   @Test
   public void integer() {
     CriteriaModel.MatcherDefinition matcher = matcherFor("integer");
-    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.ComparableMatcher<R, java.lang.Integer>");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.ComparableMatcher.Template<R, java.lang.Integer>");
     check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.ComparableMatcher.Self<java.lang.Integer>");
   }
 
@@ -68,18 +66,16 @@ public class CriteriaModelTest {
   public void optionalInteger() {
     CriteriaModel.MatcherDefinition matcher = matcherFor("optionalInteger");
     check(matcher.toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher<R, " +
-            "org.immutables.criteria.matcher.ComparableMatcher<R, java.lang.Integer>, " +
-            "org.immutables.criteria.matcher.ComparableMatcher.Self<java.lang.Integer>>");
+            "org.immutables.criteria.matcher.ComparableMatcher.Template<R, java.lang.Integer>>");
 
     check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher.Self<" +
-            "org.immutables.criteria.matcher.ComparableMatcher.Self<java.lang.Integer>, " +
             "org.immutables.criteria.matcher.ComparableMatcher.Self<java.lang.Integer>>");
   }
 
   @Test
   public void booleanValue() {
     CriteriaModel.MatcherDefinition matcher = matcherFor("booleanValue");
-    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.BooleanMatcher<R>");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.BooleanMatcher.Template<R>");
     check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.BooleanMatcher.Self");
   }
 
@@ -87,15 +83,14 @@ public class CriteriaModelTest {
   public void optionalBoolean() {
     CriteriaModel.MatcherDefinition matcher = matcherFor("optionalBoolean");
     check(matcher.toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher<R, " +
-            "org.immutables.criteria.matcher.BooleanMatcher<R>, org.immutables.criteria.matcher.BooleanMatcher.Self>");
-    check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher.Self<org.immutables.criteria.matcher.BooleanMatcher.Self, " +
-            "org.immutables.criteria.matcher.BooleanMatcher.Self>");
+            "org.immutables.criteria.matcher.BooleanMatcher.Template<R>>");
+    check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher.Self<org.immutables.criteria.matcher.BooleanMatcher.Self>");
   }
 
   @Test
   public void timeZone() {
     CriteriaModel.MatcherDefinition matcher = matcherFor("timeZone");
-    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.ObjectMatcher<R, java.util.TimeZone>");
+    check(matcher.toTemplate()).is("org.immutables.criteria.matcher.ObjectMatcher.Template<R, java.util.TimeZone>");
     check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.ObjectMatcher.Self<java.util.TimeZone>");
   }
 
@@ -103,11 +98,9 @@ public class CriteriaModelTest {
   public void optionalTimeZone() {
     CriteriaModel.MatcherDefinition matcher = matcherFor("optionalTimeZone");
     check(matcher.toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher<R, " +
-            "org.immutables.criteria.matcher.ObjectMatcher<R, java.util.TimeZone>, " +
-            "org.immutables.criteria.matcher.ObjectMatcher.Self<java.util.TimeZone>>");
+            "org.immutables.criteria.matcher.ObjectMatcher.Template<R, java.util.TimeZone>>");
 
     check(matcher.toSelf().toTemplate()).is("org.immutables.criteria.matcher.OptionalMatcher.Self<" +
-            "org.immutables.criteria.matcher.ObjectMatcher.Self<java.util.TimeZone>, " +
             "org.immutables.criteria.matcher.ObjectMatcher.Self<java.util.TimeZone>>");
   }
 


### PR DESCRIPTION
`with()` and `not()` can now be used on String / Comparable / Object etc.

Remove `OptionalMatcher.value(...)` which is somewhat redundant (`with()`
is more generic and applicable on all matchers)

Criteria fields are not longer generated. Using StringMatcher.Template