### PR TITLE
Use openjdk8 (previously oraclejdk8) for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ cache:
   directories:
   - $HOME/.m2
 jdk:
-  - oraclejdk8
-
+  - openjdk8


### PR DESCRIPTION
Travis build with oraclejdk8 fails due to LTS ?