### PR TITLE
Remove Operations.KeyedInsert and extract object ID (in backend)  using reflection

### DIFF
--- a/criteria/common/src/org/immutables/criteria/Criteria.java
+++ b/criteria/common/src/org/immutables/criteria/Criteria.java
@@ -41,7 +41,7 @@ public @interface Criteria {
    * Marks attribute as id (primary key) for a particular class.
    */
   @Documented
-  @Target(ElementType.METHOD)
+  @Target({ElementType.METHOD, ElementType.FIELD})
   @Retention(RetentionPolicy.RUNTIME)
   @interface Id {}
 

--- a/criteria/common/src/org/immutables/criteria/adapter/Backends.java
+++ b/criteria/common/src/org/immutables/criteria/adapter/Backends.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.criteria.adapter;
+
+import com.google.common.base.Preconditions;
+import org.immutables.criteria.Criteria;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Utils for backend implementations
+ */
+public final class Backends {
+
+  private Backends() {}
+
+  /**
+   * Return function which extracts identifier (key) from existing instance.
+   * Identifier is defined on POJOs with {@link Criteria.Id} annotation.
+   * @throws IllegalArgumentException if {@link Criteria.Id} annotation is not declared in any methods
+   * or fields.
+   */
+  public static <T, K> Function<T, K> idExtractor(final Class<T> type) {
+    Objects.requireNonNull(type, "type");
+    final Class<? extends Annotation> annotationClass = Criteria.Id.class;
+    final Set<Class<?>> visited = new HashSet<>();
+    visited.add(Object.class); // don't visit Object
+    final Deque<Class<?>> toVisit = new ArrayDeque<>();
+    toVisit.push(type);
+    while (!toVisit.isEmpty()) {
+      final Class<?> current = toVisit.pop();
+      if (!visited.add(current)) {
+        continue;
+      }
+
+      // look for fields
+      for (Field field: current.getFields()) {
+        if (field.getAnnotation(annotationClass) != null) {
+          if (!field.isAccessible()) {
+            field.setAccessible(true);
+          }
+          return new FieldExtractor<>(field);
+        }
+      }
+
+      // look for methods
+      for (Method method: current.getMethods()) {
+        if (method.getParameterCount() == 0 &&
+                Modifier.isPublic(method.getModifiers()) &&
+                method.getAnnotation(annotationClass) != null) {
+          if (!method.isAccessible()) {
+            method.setAccessible(true);
+          }
+          return new MethodExtractor<>(method);
+        }
+      }
+
+      toVisit.push(current.getSuperclass());
+      toVisit.addAll(Arrays.asList(current.getInterfaces()));
+    }
+
+    throw new IllegalArgumentException(String.format("Annotation %s not found in methods or fields of %s", annotationClass, type));
+  }
+
+  /**
+   * Extracts value by calling a method using reflection
+   */
+  private static class MethodExtractor<T, K> implements Function<T, K> {
+    private final Method method;
+
+    private MethodExtractor(Method method) {
+      this.method = Objects.requireNonNull(method, "method");
+      Preconditions.checkArgument(method.getParameterCount() == 0, "expected not parameters for %s", method);
+    }
+
+    @Override
+    public K apply(T instance) {
+      Objects.requireNonNull(instance, "instance");
+      try {
+        @SuppressWarnings("unchecked")
+        K result = (K) method.invoke(instance);
+        return result;
+      } catch (IllegalAccessException|InvocationTargetException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  /**
+   * Used to extract value from a field
+   */
+  private static class FieldExtractor<T, K> implements Function<T, K> {
+    private final Field field;
+
+    private FieldExtractor(Field field) {
+      this.field = Objects.requireNonNull(field, "field");
+    }
+
+    @Override
+    public K apply(T instance) {
+      Objects.requireNonNull(instance, "instance");
+      try {
+        @SuppressWarnings("unchecked")
+        final K result = (K) field.get(instance);
+        return result;
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+}

--- a/criteria/common/src/org/immutables/criteria/adapter/Operations.java
+++ b/criteria/common/src/org/immutables/criteria/adapter/Operations.java
@@ -22,12 +22,7 @@ import org.immutables.criteria.Criterion;
 import org.immutables.criteria.expression.Query;
 import org.immutables.value.Value;
 
-import java.util.AbstractMap;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 /**
  * List of default operations which can be executed on the backend
@@ -65,49 +60,6 @@ public final class Operations {
       return ImmutableInsert.<V>builder().values(ImmutableList.copyOf(values)).build();
     }
 
-    /**
-     * Create an insert where objects have ID.
-     */
-    static <K, V> KeyedInsert<K, V> ofEntries(Iterable<Map.Entry<K, V>> entries) {
-      return ImmutableKeyedInsert.<K, V>builder().entries(entries).build();
-    }
-
-    /**
-     * Extract IDs using provided functions and create Insert with {@link #ofEntries(Iterable)} ()}.
-     */
-    static <K, V> KeyedInsert<K, V> ofKeyed(Iterable<V> iterable, Function<? super V, K> keyExtractor) {
-      final List<Map.Entry<K, V>> entries = StreamSupport.stream(iterable.spliterator(), false)
-              .map(d -> new AbstractMap.SimpleImmutableEntry<>(keyExtractor.apply(d), d))
-              .collect(Collectors.toList());
-
-      return ofEntries(entries);
-    }
-  }
-
-  /**
-   * Insert operation for a set of objects which have keys (aka {@code ID}). This is usually used
-   * for key-value stores (like Geode / {@link java.util.concurrent.ConcurrentMap}) where one needs
-   * to provide key explicitly (like {@link Map#put(Object, Object)} in API.
-   *
-   * @param <K> key type of the key
-   * @param <V> value type of the value
-   */
-  @Value.Immutable
-  public interface KeyedInsert<K, V> extends Insert<V> {
-
-    List<Map.Entry<K, V>> entries();
-
-    /**
-     * Convert events to a map (assumes no duplicate keys)
-     */
-    default Map<K, V> toMap() {
-      return entries().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
-
-    @Override
-    default List<V> values() {
-      return entries().stream().map(Map.Entry::getValue).collect(Collectors.toList());
-    }
   }
 
   /**

--- a/criteria/common/src/org/immutables/criteria/repository/reactive/ReactiveWritable.java
+++ b/criteria/common/src/org/immutables/criteria/repository/reactive/ReactiveWritable.java
@@ -23,11 +23,10 @@ import org.immutables.criteria.repository.WriteResult;
 import org.reactivestreams.Publisher;
 
 import java.util.Objects;
-import java.util.function.Function;
 
 public class ReactiveWritable<T> implements ReactiveRepository.Writable<T> {
 
-  final Backend backend;
+  private final Backend backend;
 
   public ReactiveWritable(Backend backend) {
     this.backend = Objects.requireNonNull(backend, "backend");
@@ -43,25 +42,4 @@ public class ReactiveWritable<T> implements ReactiveRepository.Writable<T> {
     return backend.execute(Operations.Delete.of(criteria));
   }
 
-  public <K> ReactiveWritable<T> keyedWith(Function<? super T, K> keyExtractor) {
-    return new KeyedWriter<K, T>(backend, keyExtractor);
-  }
-
-  /**
-   * Writes entries having a key
-   */
-  private static class KeyedWriter<K, T> extends ReactiveWritable<T> {
-
-    private final Function<? super T, K> keyExtractor;
-
-    private KeyedWriter(Backend backend, Function<? super T, K> keyExtractor) {
-      super(backend);
-      this.keyExtractor = Objects.requireNonNull(keyExtractor, "keyExtractor");
-    }
-
-    @Override
-    public Publisher<WriteResult> insert(Iterable<? extends T> docs) {
-      return backend.execute(Operations.Insert.ofKeyed(docs, keyExtractor));
-    }
-  }
 }

--- a/value-processor/src/org/immutables/value/processor/CriteriaRepository.generator
+++ b/value-processor/src/org/immutables/value/processor/CriteriaRepository.generator
@@ -117,13 +117,7 @@ import java.util.function.Function;
 [if not type.criteriaRepository.readonly]
   @Override
   public Publisher<WriteResult> insert(Iterable<? extends [type.name]> docs) {
-  [for a = type.idAttribute]
-  [if a]
-    return backend.execute(Operations.Insert.ofKeyed(docs, ID_EXTRACTOR));
-  [else]
     return writable.insert(docs);
-  [/if]
-  [/for]
   }
 
   @Override


### PR DESCRIPTION
Simplify repository logic and allow single operation insert().

Support for `put(key, value)` is on hold since ID (key) can be extracted from `value`.