### PR TITLE
Separate Criteria into 2 classes: (main) FooCriteria and FooCriteriaTemplate

### DIFF
--- a/criteria/common/test/org/immutables/criteria/ExpressionAsStringTest.java
+++ b/criteria/common/test/org/immutables/criteria/ExpressionAsStringTest.java
@@ -36,7 +36,7 @@ public class ExpressionAsStringTest {
 
   @Test
   public void string() {
-    PersonCriteria<PersonCriteria.Self> crit = PersonCriteria.person;
+    PersonCriteria crit = PersonCriteria.person;
 
     assertExpressional(crit.bestFriend.isPresent(), "call op=IS_PRESENT path=bestFriend");
     assertExpressional(crit.bestFriend.isAbsent(), "call op=IS_ABSENT path=bestFriend");
@@ -56,7 +56,7 @@ public class ExpressionAsStringTest {
 
   @Test
   public void with() {
-    PersonCriteria<PersonCriteria.Self> crit = PersonCriteria.person;
+    PersonCriteria crit = PersonCriteria.person;
 
     assertExpressional(crit.with(c -> c.fullName.is("John")),
             "call op=EQUAL path=fullName constant=John");
@@ -109,7 +109,7 @@ public class ExpressionAsStringTest {
 
   @Test
   public void not() {
-    PersonCriteria<PersonCriteria.Self> crit = PersonCriteria.person;
+    PersonCriteria crit = PersonCriteria.person;
 
     assertExpressional(crit.fullName.not(n -> n.is("John")),
             "call op=NOT",
@@ -124,9 +124,9 @@ public class ExpressionAsStringTest {
 
   @Test
   public void and() {
-    PersonCriteria<PersonCriteria.Self> crit = PersonCriteria.person;
+    PersonCriteria crit = PersonCriteria.person;
 
-    PersonCriteria<PersonCriteria.Self> other = PersonCriteria.person
+    PersonCriteria other = PersonCriteria.person
             .and(crit.age.atMost(1)).and(crit.age.atLeast(2));
 
     assertExpressional(other, "call op=AND",
@@ -148,9 +148,9 @@ public class ExpressionAsStringTest {
 
   @Test
   public void or() {
-    PersonCriteria<PersonCriteria.Self> crit = PersonCriteria.person;
+    PersonCriteria crit = PersonCriteria.person;
 
-    PersonCriteria<PersonCriteria.Self> other = PersonCriteria.person
+    PersonCriteria other = PersonCriteria.person
             .or(crit.age.atMost(1)).or(crit.age.atLeast(2));
 
     assertExpressional(other, "call op=OR",
@@ -176,7 +176,7 @@ public class ExpressionAsStringTest {
    */
   @Test
   public void andOrCombined() {
-    PersonCriteria<PersonCriteria.Self> crit = PersonCriteria.person;
+    PersonCriteria crit = PersonCriteria.person;
 
     // A or (B and C)
     assertExpressional(crit.age.is(1).or()
@@ -242,7 +242,7 @@ public class ExpressionAsStringTest {
 
   @Test
   public void next() {
-    PersonCriteria<PersonCriteria.Self> crit = PersonCriteria.person;
+    PersonCriteria crit = PersonCriteria.person;
     assertExpressional(crit.bestFriend.value().hobby.is("ski"), "call op=EQUAL path=bestFriend.hobby constant=ski");
 
     assertExpressional(crit.bestFriend.value().hobby.is("ski")

--- a/criteria/common/test/org/immutables/criteria/personmodel/AbstractPersonTest.java
+++ b/criteria/common/test/org/immutables/criteria/personmodel/AbstractPersonTest.java
@@ -19,8 +19,8 @@ package org.immutables.criteria.personmodel;
 import com.google.common.collect.Ordering;
 import io.reactivex.Flowable;
 import org.immutables.criteria.Criterion;
-import org.immutables.criteria.repository.reactive.ReactiveReader;
 import org.immutables.criteria.repository.Reader;
+import org.immutables.criteria.repository.reactive.ReactiveReader;
 import org.junit.Assume;
 import org.junit.Test;
 
@@ -65,7 +65,7 @@ public abstract class AbstractPersonTest {
   /**
    * Create person criteria
    */
-  private static PersonCriteria<PersonCriteria.Self> criteria() {
+  private static PersonCriteria criteria() {
     return PersonCriteria.person;
   }
 

--- a/criteria/common/test/org/immutables/criteria/personmodel/PersonTest.java
+++ b/criteria/common/test/org/immutables/criteria/personmodel/PersonTest.java
@@ -21,12 +21,12 @@ import org.junit.Test;
 
 import java.time.LocalDate;
 
+@Ignore("used for compile-time testing only")
 public class PersonTest {
 
   @Test
-  @Ignore("used for compile-time testing only")
   public void collection() {
-    PersonCriteria.person
+    PersonCriteria crit = PersonCriteria.person
             .pets.any().name.notEmpty()
             .age.atMost(22)
             .isActive.isFalse()
@@ -45,4 +45,15 @@ public class PersonTest {
             .interests.contains("test");
   }
 
+  /**
+   * Make sure use-friendly criteria is returned after
+   */
+  @Test
+  public void returnNiceCriteria() {
+    PersonCriteria crit = PersonCriteria.person;
+    crit = crit.age.atLeast(21);
+    crit = crit.or(crit.fullName.notEmpty());
+    crit = crit.not(f -> f.isActive.isTrue()); // TODO classcast exception here
+    crit = crit.bestFriend.value().with(f -> f.hobby.endsWith("test"));
+  }
 }

--- a/criteria/common/test/org/immutables/criteria/processor/CriteriaModelProcessorTest.java
+++ b/criteria/common/test/org/immutables/criteria/processor/CriteriaModelProcessorTest.java
@@ -128,21 +128,21 @@ public class CriteriaModelProcessorTest {
   @Test
   public void havingCriteria() {
     assertAttribute("foo",
-            "org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteria<R>");
+            "org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteriaTemplate<R>");
     assertAttribute("nullableFoo",
-            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteria<R>>");
+            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteriaTemplate<R>>");
     assertAttribute("optionalFoo",
-            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteria<R>>");
+            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteriaTemplate<R>>");
     assertAttribute("listFoo",
-            "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteria<R>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo>");
+            "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteriaTemplate<R>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo>");
     assertAttribute("listListFoo",
-            "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteria<R>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo>,java.util.List<org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo>>");
+            "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteriaTemplate<R>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo>,java.util.List<org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo>>");
     assertAttribute("arrayFoo",
-            "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteria<R>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo>");
+            "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteriaTemplate<R>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo>");
     assertAttribute("arrayArrayFoo",
-            "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteria<R>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo[]>");
+            "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteriaTemplate<R>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo[]>");
     assertAttribute("listArrayFoo",
-            "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteria<R>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo[]>");
+            "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.processor.CriteriaModelProcessorTest.FooCriteriaTemplate<R>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo>,org.immutables.criteria.processor.CriteriaModelProcessorTest.Foo[]>");
   }
 
   private void assertAttribute(String name, String expected) {

--- a/criteria/elasticsearch/test/org/immutables/criteria/elasticsearch/ElasticModelTest.java
+++ b/criteria/elasticsearch/test/org/immutables/criteria/elasticsearch/ElasticModelTest.java
@@ -79,7 +79,7 @@ public class ElasticModelTest {
 
   @Test
   public void criteria() {
-    ElasticModelCriteria<ElasticModelCriteria.Self> crit = ElasticModelCriteria.elasticModel;
+    ElasticModelCriteria crit = ElasticModelCriteria.elasticModel;
 
     assertCount(crit, 2);
     assertCount(crit.intNumber.is(1), 0);
@@ -97,7 +97,7 @@ public class ElasticModelTest {
 
   }
 
-  private void assertCount(ElasticModelCriteria<?> crit, int count) {
+  private void assertCount(ElasticModelCriteria crit, int count) {
     Observable.fromPublisher(repository.find(crit).fetch())
             .test()
             .awaitDone(1, TimeUnit.SECONDS)

--- a/criteria/inmemory/test/org/immutables/criteria/inmemory/InMemoryExpressionEvaluatorTest.java
+++ b/criteria/inmemory/test/org/immutables/criteria/inmemory/InMemoryExpressionEvaluatorTest.java
@@ -44,7 +44,7 @@ public class InMemoryExpressionEvaluatorTest {
 
   @Test
   public void reflection() {
-    final PersonCriteria<PersonCriteria.Self> crit = PersonCriteria.person;
+    final PersonCriteria crit = PersonCriteria.person;
 
     final ImmutablePerson person = example.withFullName("John");
 
@@ -93,7 +93,7 @@ public class InMemoryExpressionEvaluatorTest {
 
   @Test
   public void booleans() {
-    final PersonCriteria<PersonCriteria.Self> crit = PersonCriteria.person;
+    final PersonCriteria crit = PersonCriteria.person;
 
     final ImmutablePerson person = example.withFullName("A");
 

--- a/value-processor/src/org/immutables/value/processor/Criteria.generator
+++ b/value-processor/src/org/immutables/value/processor/Criteria.generator
@@ -20,6 +20,10 @@
 [type.sourceHeader]
 [generateCriteria type]
 [/output.java]
+[output.java type.package (type.name 'CriteriaTemplate') type.element]
+[type.sourceHeader]
+[generateTemplate type]
+[/output.java]
     [else]
 [output.error]
 Use @Criteria to annotate @Value.Immutable abstract value types with no type variables
@@ -28,17 +32,15 @@ Use @Criteria to annotate @Value.Immutable abstract value types with no type var
   [/for]
 [/template]
 
-[template generateCriteria Type type]
+[template generateTemplate Type type]
 [if type.package]
 package [type.package];
 [/if]
 
 import org.immutables.criteria.Criterion;
-import org.immutables.criteria.matcher.ContextHolder;
 import org.immutables.criteria.matcher.CriteriaContext;
 import org.immutables.criteria.matcher.CriteriaCreator;
 import org.immutables.criteria.matcher.IterableMatcher;
-import org.immutables.criteria.matcher.Disjunction;
 import org.immutables.criteria.matcher.AndMatcher;
 import org.immutables.criteria.matcher.OrMatcher;
 import org.immutables.criteria.matcher.Matchers;
@@ -50,8 +52,6 @@ import org.immutables.criteria.matcher.NotMatcher;
 import org.immutables.criteria.matcher.WithMatcher;
 import org.immutables.criteria.matcher.ComparableMatcher;
 import org.immutables.criteria.expression.Expression;
-import org.immutables.criteria.expression.Query;
-import org.immutables.criteria.expression.Queryable;
 import org.immutables.criteria.expression.ExpressionVisitor;
 import org.immutables.criteria.expression.Expressions;
 import org.immutables.criteria.expression.Constant;
@@ -82,13 +82,10 @@ import [starImport];
 [/if]
 @javax.annotation.concurrent.Immutable
 [atGenerated type]
-[type.typeDocument.access]class [type.name]Criteria<R> implements Criterion<[type.typeDocument]>,
-            AndMatcher<[type.name]Criteria<R>>, OrMatcher<[type.name]Criteria<R>>,
-            NotMatcher<R, [type.name]Criteria.Self>,
-            WithMatcher<R, [type.name]Criteria.Self> {
-
-   /** Default criteria instance */
-   public static final [type.name]Criteria<Self> [toLower type.name] = create();
+[type.typeDocument.access]class [type.name]CriteriaTemplate<R> implements Criterion<[type.typeDocument]>,
+            AndMatcher<[type.name]Criteria>, OrMatcher<[type.name]Criteria>,
+            NotMatcher<R, [type.name]Criteria>,
+            WithMatcher<R, [type.name]Criteria> {
 
    private final CriteriaContext context;
 
@@ -96,61 +93,96 @@ import [starImport];
    public final [a.criteria.matcher.matcherType] [a.name];
    [/for]
 
-   /** TODO this should be top-level class */
-   public static class Self extends [type.name]Criteria<Self> implements Disjunction<[type.name]Criteria<Self>> {
-
-    private final CriteriaContext context;
-
-    private Self(CriteriaContext context) {
-      super(context);
-      this.context = context;
-    }
-   }
-
-   /** Similar to {@link Self} but exposes {@link Expressional} interface */
-   private static final class Private extends Self implements Queryable, ContextHolder {
-      private final CriteriaContext context;
-
-      private Private() {
-         this(new CriteriaContext([type.typeDocument].class, creator()).withCreators(creator(), creator()));
-      }
-
-      private Private(CriteriaContext context) {
-       super(context);
-       this.context = context;
-      }
-
-      private static CriteriaCreator<Self> creator() {
-        return (CriteriaContext ctx) ->  new Private(ctx);
-      }
-
-      @Override
-      public Query query() {
-        return context().query();
-      }
-
-      @Override
-      public CriteriaContext context() {
-         return this.context;
-      }
-   }
-
    @SuppressWarnings("unchecked")
-   private [type.name]Criteria(CriteriaContext context) {
+   [type.name]CriteriaTemplate(CriteriaContext context) {
      this.context = Objects.requireNonNull(context, "context");
    [for a in type.allMarshalingAttributes]
      this.[a.name] = ([a.criteria.matcher.matcherType]) [a.criteria.matcher.creator];
    [/for]
    }
+}
+[/template]
 
-   /** Factory method to create an instance of [type.name]Criteria */
-   private static [type.name]Criteria<Self> create() {
-     return new Private();
-   }
+[template generateCriteria Type type]
+[if type.package]
+package [type.package];
+[/if]
 
-   public static [type.name]Criteria<Self> create(CriteriaContext context) {
+import org.immutables.criteria.Criterion;
+import org.immutables.criteria.matcher.ContextHolder;
+import org.immutables.criteria.matcher.CriteriaContext;
+import org.immutables.criteria.matcher.CriteriaCreator;
+import org.immutables.criteria.matcher.Disjunction;
+import org.immutables.criteria.expression.Query;
+import org.immutables.criteria.expression.Queryable;
+
+[for a in type.allMarshalingAttributes]
+[if a.hasCriteria]
+import [a.unwrappedElementType]Criteria;
+[/if]
+[/for]
+
+[for starImport in type.requiredSourceStarImports]
+import [starImport];
+[/for]
+/**
+ * A {@code [type.name]Criteria} provides type-safe API for retrieving documents
+ * from a generic data-source.
+ * <p>This class is immutable and thus thread-safe.</p>
+ */
+[if type allowsClasspathAnnotation 'javax.annotation.concurrent.ThreadSafe']
+@javax.annotation.concurrent.ThreadSafe
+[/if]
+@javax.annotation.concurrent.Immutable
+[atGenerated type]
+[type.typeDocument.access]class [type.name]Criteria extends [type.name]CriteriaTemplate<[type.name]Criteria>
+     implements Disjunction<[type.name]CriteriaTemplate<[type.name]Criteria>>  {
+
+  /** Default criteria instance */
+  public static final [type.name]Criteria [toLower type.name] = create();
+
+  /** Factory method to create an instance of [type.name]Criteria */
+  private static [type.name]Criteria create() {
+    return new Private();
+  }
+
+  /** Used to instantiate [type.name]Criteria by other criterias */
+  public static [type.name]Criteria create(CriteriaContext context) {
      return new Private(context);
-   }
+  }
+
+  private [type.name]Criteria(CriteriaContext context) {
+     super(context);
+  }
+
+  /** Private implementation which exposes {@link Queryable} interface. It is used to hide internal API (interfaces) */
+  private static final class Private extends [type.name]Criteria implements Queryable, ContextHolder {
+    private final CriteriaContext context;
+
+    private Private() {
+      this(new CriteriaContext([type.typeDocument].class, creator()).withCreators(creator(), creator()));
+    }
+
+    private Private(CriteriaContext context) {
+      super(context);
+      this.context = context;
+    }
+
+    private static CriteriaCreator<[type.name]Criteria> creator() {
+      return (CriteriaContext ctx) ->  new Private(ctx);
+    }
+
+    @Override
+    public Query query() {
+      return context().query();
+    }
+
+    @Override
+    public CriteriaContext context() {
+      return this.context;
+    }
+  }
+
 }
 [/template]
 
@@ -159,3 +191,4 @@ import [starImport];
 @org.immutables.value.Generated(from = "[type.typeAbstract.relativeRaw]", generator = "Criteria")
 [/if]
 [/template]
+


### PR DESCRIPTION
Allows nicer source code when dynamically building criterias.

```java
// BEFORE
PersonCriteria<PersonCriteria.Self> crit = PersonCriteria.person;

// AFTER
PersonCriteria crit = PersonCriteria.person;
```