### PR TITLE
Add Optional-like intersection types for String, Comparable and boolean

### DIFF
--- a/criteria/common/src/org/immutables/criteria/matcher/OptionalBooleanMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/OptionalBooleanMatcher.java
@@ -13,25 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.immutables.criteria.matcher;
 
+
 /**
- * Matcher for optional attributes
+ * Intersection type between {@link OptionalMatcher} and {@link BooleanMatcher}
+ *
+ * @param <R> root criteria type
  */
-public interface OptionalMatcher<R, S> extends PresentAbsentMatcher<R>, Matcher {
+public interface OptionalBooleanMatcher<R> extends BooleanMatcher<R>, PresentAbsentMatcher<R> {
 
-  /**
-   * Apply context-specific matcher if value is present
-   */
-  default S value() {
-    return Matchers.extract(this).<R, S>factory().createNested();
-  }
+  interface Self extends Template<Self> {}
 
-  /**
-   * Self-type for this matcher
-   */
-  interface Self<S> extends OptionalMatcher<Self<S>, S>, Disjunction<Self<S>> {}
+  interface Template<R> extends OptionalBooleanMatcher<R>, WithMatcher<R, Self>, NotMatcher<R, Self>  {}
 
   @SuppressWarnings("unchecked")
   static <R> CriteriaCreator<R> creator() {
@@ -43,6 +37,5 @@ public interface OptionalMatcher<R, S> extends PresentAbsentMatcher<R>, Matcher 
 
     return ctx -> (R) new Local(ctx);
   }
-
 
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/OptionalComparableMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/OptionalComparableMatcher.java
@@ -17,21 +17,21 @@
 package org.immutables.criteria.matcher;
 
 /**
- * Matcher for optional attributes
+ * Intersection type between {@link OptionalMatcher} and {@link ComparableMatcher}.
+ *
+ * <p>Syntax sugar to avoid chaining {@code value()} method from {@link OptionalMatcher}
+ * on long expressions with many optional elements.
+ *
+ * @param <R> root criteria type
  */
-public interface OptionalMatcher<R, S> extends PresentAbsentMatcher<R>, Matcher {
-
-  /**
-   * Apply context-specific matcher if value is present
-   */
-  default S value() {
-    return Matchers.extract(this).<R, S>factory().createNested();
-  }
+public interface OptionalComparableMatcher<R, V extends Comparable<? super V>> extends ComparableMatcher<R, V>, PresentAbsentMatcher<R> {
 
   /**
    * Self-type for this matcher
    */
-  interface Self<S> extends OptionalMatcher<Self<S>, S>, Disjunction<Self<S>> {}
+  interface Self<V extends Comparable<? super V>> extends Template<Self<V>, V>, Disjunction<Template<Self<V>, V>> {}
+
+  interface Template<R, V extends Comparable<? super V>> extends OptionalComparableMatcher<R, V>, WithMatcher<R, Self<V>>, NotMatcher<R, Self<V>> {}
 
   @SuppressWarnings("unchecked")
   static <R> CriteriaCreator<R> creator() {
@@ -43,6 +43,5 @@ public interface OptionalMatcher<R, S> extends PresentAbsentMatcher<R>, Matcher 
 
     return ctx -> (R) new Local(ctx);
   }
-
 
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/OptionalStringMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/OptionalStringMatcher.java
@@ -17,21 +17,14 @@
 package org.immutables.criteria.matcher;
 
 /**
- * Matcher for optional attributes
+ * Intersection type between {@link OptionalMatcher} and {@link StringMatcher}
+ * @param <R> root criteria type
  */
-public interface OptionalMatcher<R, S> extends PresentAbsentMatcher<R>, Matcher {
+public interface OptionalStringMatcher<R> extends StringMatcher<R>, PresentAbsentMatcher<R> {
 
-  /**
-   * Apply context-specific matcher if value is present
-   */
-  default S value() {
-    return Matchers.extract(this).<R, S>factory().createNested();
-  }
+  interface Self extends Template<Self>, Disjunction<OptionalStringMatcher<Self>> {}
 
-  /**
-   * Self-type for this matcher
-   */
-  interface Self<S> extends OptionalMatcher<Self<S>, S>, Disjunction<Self<S>> {}
+  interface Template<R> extends OptionalStringMatcher<R>, WithMatcher<R, Self>, NotMatcher<R, Self>{}
 
   @SuppressWarnings("unchecked")
   static <R> CriteriaCreator<R> creator() {
@@ -43,6 +36,4 @@ public interface OptionalMatcher<R, S> extends PresentAbsentMatcher<R>, Matcher 
 
     return ctx -> (R) new Local(ctx);
   }
-
-
 }

--- a/criteria/common/src/org/immutables/criteria/matcher/PresentAbsentMatcher.java
+++ b/criteria/common/src/org/immutables/criteria/matcher/PresentAbsentMatcher.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.criteria.matcher;
+
+import org.immutables.criteria.expression.Expression;
+import org.immutables.criteria.expression.Expressions;
+import org.immutables.criteria.expression.Operators;
+
+import java.util.function.UnaryOperator;
+
+/**
+ * Base interface for optional and optional-derived matchers having just two methods:
+ * {@code isPresent()} and {@code isAbsent()}
+ */
+public interface PresentAbsentMatcher<R> extends Matcher {
+
+  default R isPresent() {
+    final UnaryOperator<Expression> expr = e -> Expressions.call(Operators.IS_PRESENT, e);
+    return Matchers.extract(this).<R, Object>factory().createRoot(expr);
+  }
+
+  default R isAbsent() {
+    final UnaryOperator<Expression> expr = e -> Expressions.call(Operators.IS_ABSENT, e);
+    return Matchers.extract(this).<R, Object>factory().createRoot(expr);
+  }
+}

--- a/criteria/common/test/org/immutables/criteria/TypeHolderTest.java
+++ b/criteria/common/test/org/immutables/criteria/TypeHolderTest.java
@@ -53,20 +53,20 @@ public class TypeHolderTest {
 
     // == Optionals
     TypeHolderCriteria.typeHolder
-            .optBoolean.value().isFalse()
-            .optBoolean.value().isTrue()
+            .optBoolean.isFalse()
+            .optBoolean.isTrue()
             .optBoolean.isAbsent()
             .optInt.isAbsent()
             .optLong.isAbsent()
-            .optLong.value().lessThan(11L)
+            .optLong.lessThan(11L)
             .optLong2.isAbsent()
-            .optLong2.value().lessThan(22L)
+            .optLong2.lessThan(22L)
             .optShort.isPresent()
             .optDouble.isPresent()
-            .optDouble.value().greaterThan(22D)
-            .optDouble2.value().lessThan(11D)
+            .optDouble.greaterThan(22D)
+            .optDouble2.lessThan(11D)
             .optFloat.isAbsent()
-            .optShort.value().lessThan((short) 22)
+            .optShort.lessThan((short) 22)
             .optShort.isAbsent();
 
     // == Boxed
@@ -119,7 +119,7 @@ public class TypeHolderTest {
   public void dates() {
     TypeHolderCriteria.typeHolder
             .localDate.atMost(LocalDate.MIN)
-            .optLocalDate.value().atMost(LocalDate.MAX)
+            .optLocalDate.atMost(LocalDate.MAX)
             .localDates.contains(LocalDate.MAX);
   }
 
@@ -130,7 +130,7 @@ public class TypeHolderTest {
 
     TypeHolderCriteria.typeHolder
             .utilDate.atMost(date)
-            .optUtilDate.value().atMost(date)
+            .optUtilDate.atMost(date)
             .utilDates.all().atLeast(date);
   }
 
@@ -141,14 +141,14 @@ public class TypeHolderTest {
   public void bigIntegerAndDecimal() {
     TypeHolderCriteria.typeHolder
             .bigDecimal.atLeast(BigDecimal.ONE)
-            .optBigDecimal.value().atLeast(BigDecimal.ONE)
+            .optBigDecimal.atLeast(BigDecimal.ONE)
             .bigDecimals.contains(BigDecimal.TEN)
             .bigDecimals.notEmpty()
             .bigDecimals.any().atLeast(BigDecimal.ONE);
 
     TypeHolderCriteria.typeHolder
             .bigInteger.atLeast(BigInteger.ONE)
-            .optBigInteger.value().atLeast(BigInteger.ONE)
+            .optBigInteger.atLeast(BigInteger.ONE)
             .bigIntegers.contains(BigInteger.TEN)
             .bigIntegers.notEmpty()
             .bigIntegers.any().atLeast(BigInteger.ONE);
@@ -160,7 +160,7 @@ public class TypeHolderTest {
               .foos.none().is(TypeHolder.Foo.TWO)
               .foo.is(TypeHolder.Foo.ONE)
               .optFoo.isPresent()
-              .optFoo.value().is(TypeHolder.Foo.ONE);
+              .optFoo.is(TypeHolder.Foo.ONE);
   }
 
   @Test

--- a/criteria/common/test/org/immutables/criteria/nested/NestedTest.java
+++ b/criteria/common/test/org/immutables/criteria/nested/NestedTest.java
@@ -44,10 +44,10 @@ public class NestedTest {
     assertExpressional(RootCriteria.root.a.value().b.value().c.value().value.is("gem")
             , "call op=EQUAL path=a.b.c.value constant=gem");
 
-    assertExpressional(RootCriteria.root.a.value().b.value().c.value().hidden.value().is("gem")
+    assertExpressional(RootCriteria.root.a.value().b.value().c.value().hidden.is("gem")
             , "call op=EQUAL path=a.b.c.hidden constant=gem");
 
-    assertExpressional(RootCriteria.root.a.value().b.value().c.value().hidden.value().with(s -> s.is("gem"))
+    assertExpressional(RootCriteria.root.a.value().b.value().c.value().hidden.with(s -> s.is("gem"))
             , "call op=EQUAL path=a.b.c.hidden constant=gem");
 
     assertExpressional(RootCriteria.root.a.value().with(a -> a.b.isPresent()),
@@ -66,7 +66,7 @@ public class NestedTest {
             "call op=EQUAL path=a.b.c.value constant=gem"
     );
 
-    assertExpressional(RootCriteria.root.a.value().with(a -> a.b.value().with(b -> b.c.value().with(c -> c.hidden.value().with(h -> h.is("gem"))))),
+    assertExpressional(RootCriteria.root.a.value().with(a -> a.b.value().with(b -> b.c.value().with(c -> c.hidden.with(h -> h.is("gem"))))),
             "call op=EQUAL path=a.b.c.hidden constant=gem"
     );
 

--- a/criteria/common/test/org/immutables/criteria/processor/CriteriaModelProcessorTest.java
+++ b/criteria/common/test/org/immutables/criteria/processor/CriteriaModelProcessorTest.java
@@ -63,10 +63,16 @@ public class CriteriaModelProcessorTest {
   }
 
   @Test
+  public void debug() {
+    assertAttribute("optionalBoolean",
+            "org.immutables.criteria.matcher.OptionalBooleanMatcher.Template<R>");
+  }
+
+  @Test
   public void basic() {
     assertAttribute("string", "org.immutables.criteria.matcher.StringMatcher.Template<R>");
-    assertAttribute("nullableString", "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.StringMatcher.Template<R>>");
-    assertAttribute("optionalString", "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.StringMatcher.Template<R>>");
+    assertAttribute("nullableString", "org.immutables.criteria.matcher.OptionalStringMatcher.Template<R>");
+    assertAttribute("optionalString", "org.immutables.criteria.matcher.OptionalStringMatcher.Template<R>");
     assertAttribute("stringList", "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.matcher.StringMatcher.Template<R>,java.lang.String>");
 
 
@@ -77,28 +83,28 @@ public class CriteriaModelProcessorTest {
     assertAttribute("arrayArrayInteger",
             "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.matcher.ComparableMatcher.Template<R,java.lang.Integer>,java.lang.Integer>,java.lang.Integer[]>");
     assertAttribute("optionalInteger",
-            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.ComparableMatcher.Template<R,java.lang.Integer>>");
+            "org.immutables.criteria.matcher.OptionalComparableMatcher.Template<R,java.lang.Integer>");
     assertAttribute("optionalInteger2",
-            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.ComparableMatcher.Template<R,java.lang.Integer>>");
+            "org.immutables.criteria.matcher.OptionalComparableMatcher.Template<R,java.lang.Integer>");
 
     assertAttribute("longValue",
             "org.immutables.criteria.matcher.ComparableMatcher.Template<R,java.lang.Long>");
     assertAttribute("optionalLong",
-            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.ComparableMatcher.Template<R,java.lang.Long>>");
+            "org.immutables.criteria.matcher.OptionalComparableMatcher.Template<R,java.lang.Long>");
     assertAttribute("optionalLong2",
-            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.ComparableMatcher.Template<R,java.lang.Long>>");
+            "org.immutables.criteria.matcher.OptionalComparableMatcher.Template<R,java.lang.Long>");
 
     assertAttribute("doubleValue",
             "org.immutables.criteria.matcher.ComparableMatcher.Template<R,java.lang.Double>");
     assertAttribute("optionalDouble",
-            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.ComparableMatcher.Template<R,java.lang.Double>>");
+            "org.immutables.criteria.matcher.OptionalComparableMatcher.Template<R,java.lang.Double>");
     assertAttribute("optionalDouble2",
-            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.ComparableMatcher.Template<R,java.lang.Double>>");
+            "org.immutables.criteria.matcher.OptionalComparableMatcher.Template<R,java.lang.Double>");
 
     assertAttribute("booleanValue",
             "org.immutables.criteria.matcher.BooleanMatcher.Template<R>");
     assertAttribute("optionalBoolean",
-            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.BooleanMatcher.Template<R>>");
+            "org.immutables.criteria.matcher.OptionalBooleanMatcher.Template<R>");
 
     assertAttribute("timeZone",
             "org.immutables.criteria.matcher.ObjectMatcher.Template<R,java.util.TimeZone>");
@@ -116,13 +122,13 @@ public class CriteriaModelProcessorTest {
   @Test
   public void wierd() {
     assertAttribute("weird1",
-            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.StringMatcher.Template<R>>>");
+            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.OptionalStringMatcher.Template<R>>");
     assertAttribute("weird2",
             "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.matcher.StringMatcher.Template<R>,java.lang.String>>");
     assertAttribute("weird3",
-            "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.StringMatcher.Template<R>>,java.util.Optional<java.lang.String>>");
+            "org.immutables.criteria.matcher.IterableMatcher<R,org.immutables.criteria.matcher.OptionalStringMatcher.Template<R>,java.util.Optional<java.lang.String>>");
     assertAttribute("weird4",
-            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.ComparableMatcher.Template<R,java.lang.Integer>>>");
+            "org.immutables.criteria.matcher.OptionalMatcher<R,org.immutables.criteria.matcher.OptionalComparableMatcher.Template<R,java.lang.Integer>>");
   }
 
   @Test

--- a/criteria/elasticsearch/test/org/immutables/criteria/elasticsearch/ElasticModelTest.java
+++ b/criteria/elasticsearch/test/org/immutables/criteria/elasticsearch/ElasticModelTest.java
@@ -90,8 +90,8 @@ public class ElasticModelTest {
     assertCount(crit.string.in("not", "not"), 0);
     assertCount(crit.string.is("bar"), 1);
     assertCount(crit.string.is("hello"), 0);
-    assertCount(crit.optionalString.value().is("optFoo"), 1);
-    assertCount(crit.optionalString.value().is("missing"), 0);
+    assertCount(crit.optionalString.is("optFoo"), 1);
+    assertCount(crit.optionalString.is("missing"), 0);
     assertCount(crit.intNumber.atMost(42).string.is("foo"), 1);
     assertCount(crit.intNumber.atMost(11), 0);
 

--- a/criteria/inmemory/test/org/immutables/criteria/inmemory/InMemoryExpressionEvaluatorTest.java
+++ b/criteria/inmemory/test/org/immutables/criteria/inmemory/InMemoryExpressionEvaluatorTest.java
@@ -78,17 +78,17 @@ public class InMemoryExpressionEvaluatorTest {
     check(evaluate(crit.nickName.isAbsent(), person.withNickName(Optional.empty())));
 
     // == value().$expr
-    check(!evaluate(crit.nickName.value().isNot("Smith"), person.withNickName("Smith")));
-    check(evaluate(crit.nickName.value().in("Smith", "Nobody"), person.withNickName("Smith")));
-    check(!evaluate(crit.nickName.value().in("Nobody", "Sky"), person.withNickName("Smith")));
-    check(evaluate(crit.nickName.value().notIn("Nobody", "Sky"), person.withNickName("Smith")));
+    check(!evaluate(crit.nickName.isNot("Smith"), person.withNickName("Smith")));
+    check(evaluate(crit.nickName.in("Smith", "Nobody"), person.withNickName("Smith")));
+    check(!evaluate(crit.nickName.in("Nobody", "Sky"), person.withNickName("Smith")));
+    check(evaluate(crit.nickName.notIn("Nobody", "Sky"), person.withNickName("Smith")));
 
     // == value($expr)
-    check(evaluate(crit.nickName.value().with(v -> v.is("Smith")), person.withNickName("Smith")));
-    check(!evaluate(crit.nickName.value().with(v -> v.isNot("Smith")), person.withNickName("Smith")));
-    check(evaluate(crit.nickName.value().with(v -> v.in("Smith", "Nobody")), person.withNickName("Smith")));
-    check(!evaluate(crit.nickName.value().with(v -> v.in("Nobody", "Sky")), person.withNickName("Smith")));
-    check(evaluate(crit.nickName.value().with(v -> v.notIn("Nobody", "Sky")), person.withNickName("Smith")));
+    check(evaluate(crit.nickName.with(v -> v.is("Smith")), person.withNickName("Smith")));
+    check(!evaluate(crit.nickName.with(v -> v.isNot("Smith")), person.withNickName("Smith")));
+    check(evaluate(crit.nickName.with(v -> v.in("Smith", "Nobody")), person.withNickName("Smith")));
+    check(!evaluate(crit.nickName.with(v -> v.in("Nobody", "Sky")), person.withNickName("Smith")));
+    check(evaluate(crit.nickName.with(v -> v.notIn("Nobody", "Sky")), person.withNickName("Smith")));
   }
 
   @Test


### PR DESCRIPTION
Introduce three interfaces which combine functionality of Optional and target type matchers:
1. OptionalStringMatcher
2. OptionalBooleanMatcher
3. OptionalComparableMatcher

It is now possible to write `optionalBool.isTrue()` instead of `optionalBool.value().isTrue()`