### PR TITLE
Lazy computation of hashCode #857

### DIFF
--- a/value-annotations/src/org/immutables/value/Value.java
+++ b/value-annotations/src/org/immutables/value/Value.java
@@ -93,9 +93,18 @@ public @interface Value {
      * In general, use this when {@code hashCode} computation is expensive and will be used a lot.
      * Note that if {@link Style#privateNoargConstructor()} == <code>true</code> this option will be
      * ignored.
+     * For lazy (deferred) {@code hashCode} computation use {@link #lazyhash()}
      * @return if generate hash code precomputing
      */
     boolean prehash() default false;
+
+    /**
+     * If {@code lazyhash=true} then internal {@code hashCode} will be computed (and cached) on first {@code hashCode()}
+     * method call.
+     * For eager {@code hashCode} computation (in constructor) use {@link #prehash()}.
+     * @return to lazily compute the {@code hashCode}
+     */
+    boolean lazyhash() default false;
 
     /**
      * If {@code builder=false}, disables generation of {@code builder()}. Default is

--- a/value-fixture/src/org/immutables/fixture/LazyHash.java
+++ b/value-fixture/src/org/immutables/fixture/LazyHash.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.fixture;
+
+import org.immutables.value.Value;
+
+@Value.Immutable(lazyhash = true)
+public interface LazyHash {
+  String s();
+  boolean b();
+  int i();
+}

--- a/value-fixture/src/org/immutables/fixture/annotation/LazyhashAnnotation.java
+++ b/value-fixture/src/org/immutables/fixture/annotation/LazyhashAnnotation.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.immutables.fixture.annotation;
+
+import org.immutables.value.Value;
+
+// Compilation should not fail when equals use hashCode
+// field to short circuit attribute comparison
+@Value.Immutable(lazyhash = true)
+public @interface LazyhashAnnotation {}
+
+// No attibutes, no prehashing, just zero
+@Value.Immutable(lazyhash = true)
+@interface LazyhashAnnotationEmpty {}
+
+//No attibutes, no prehashing
+@Value.Immutable(lazyhash = true)
+interface LazyhashRegularEmpty {}

--- a/value-fixture/test/org/immutables/fixture/LazyHashTest.java
+++ b/value-fixture/test/org/immutables/fixture/LazyHashTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.fixture;
+
+import org.immutables.check.Checkers;
+import org.junit.jupiter.api.Test;
+
+class LazyHashTest {
+
+  @Test
+  void lazyHash() {
+    ImmutableLazyHash h1 = ImmutableLazyHash.builder().s("a").i(1).b(true).build();
+    ImmutableLazyHash h2 = ImmutableLazyHash.builder().s("b").i(2).b(false).build();
+
+    Checkers.check(h1.hashCode()).not().is(0); // ensure hashcode is computed
+    Checkers.check(h1.hashCode()).not().is(h2.hashCode());
+    Checkers.check(h1.equals(ImmutableLazyHash.builder().s("a").i(1).b(true).build()));
+    Checkers.check(!h1.equals(h2));
+  }
+}

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -2475,12 +2475,12 @@ this.[n] = [valueFromValue v][invokeSuper v].[v.names.get]()[/valueFromValue];
   private [if v.generateTransientDerived]transient [/if]final [v.atNullability][immutableImplementationType v] [v.name];
   [/if]
 [/for]
-[if type.usePrehashed]
+[if type.cacheHash]
   [for anj in type.syntheticFieldsInjectedAnnotations]
   [anj]
   [/for]
   [jsonIgnore type]
-  private [if not type.serial.simple]transient [/if]final int hashCode;
+  private[if not type.serial.simple] transient[/if][if type.usePrehashed] final[/if] int hashCode;[if type.useLazyhash] // hashCode lazily computed[/if]
 [/if]
 [if type.generateOrdinalValue]
   [jsonIgnore type]
@@ -3049,7 +3049,7 @@ public boolean equals([atNullable type]Object another) {
 [/if]
 [if type.useEqualTo]
 
-[if type.equalToDefined or (type.usePrehashed or getters)]
+[if type.equalToDefined or (type.cacheHash or getters)]
 [-- nothing, it's just simpler if condition is inverse --]
 [else]
 @SuppressWarnings("MethodCanBeStatic")
@@ -3058,14 +3058,14 @@ private boolean equalTo([equalToType] another) {
   [if type.equalToDefined]
   return super.equals(another);
   [else]
-    [if type.usePrehashed]
+    [if type.cacheHash]
       [if type.annotationType]
-  if (another instanceof [type.typeImmutable.relativeRaw]
-      && (([type.typeImmutable.relativeRaw]) another).hashCode != hashCode) {
-    return false;
+  if (another instanceof [type.typeImmutable.relativeRaw]) {
+    final int anotherHashCode = (([type.typeImmutable.relativeRaw]) another).hashCode;
+    if ([if type.useLazyhash]hashCode != 0 && anotherHashCode != 0 && [/if]hashCode != anotherHashCode) return false;
   }
       [else]
-  if (hashCode != another.hashCode) return false;
+  if ([if type.useLazyhash]hashCode != 0 && another.hashCode != 0 && [/if]hashCode != another.hashCode) return false;
       [/if]
     [/if]
   return [if not getters]true[/if][for v in getters][if not for.first]
@@ -3126,8 +3126,8 @@ public int hashCode() {
 /**
 [if not getters]
  * Returns a constant hash code value.
-[else if type.usePrehashed]
- * Returns a precomputed-on-construction hash code from attributes: [for a in getters][if not for.first], [/if]{@code [a.name]}[/for].
+[else if type.cacheHash]
+ * Returns a [if type.usePrehashed]precomputed-on-construction[else]lazily computed[/if] hash code from attributes: [for a in getters][if not for.first], [/if]{@code [a.name]}[/for].
 [else]
  * Computes a hash code from attributes: [for a in getters][if not for.first], [/if]{@code [a.name]}[/for].
 [/if]
@@ -3137,11 +3137,21 @@ public int hashCode() {
 public int hashCode() {
   [if type.usePrehashed]
   return hashCode;
+  [else if not getters]
+  return 0;
+  [else if type.useLazyhash]
+  int h = this.hashCode;
+  if (h == 0) {
+    h = [disambiguateAccessor type 'computeHashCode']();
+    this.hashCode = h;
+  }
+  return h;
   [else]
 [computeHashCodeBody]
   [/if]
 }
-  [if type.usePrehashed]
+
+  [if type.cacheHash and getters]
 
 private int [disambiguateAccessor type 'computeHashCode']() {
 [computeHashCodeBody]

--- a/value-processor/src/org/immutables/value/processor/meta/ValueImmutableInfo.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueImmutableInfo.java
@@ -50,6 +50,10 @@ public abstract class ValueImmutableInfo implements ValueMirrors.Immutable {
 
   @Value.Parameter
   @Override
+  public abstract boolean lazyhash();
+
+  @Value.Parameter
+  @Override
   public abstract boolean singleton();
 
   static ImmutableValueImmutableInfo infoFrom(ImmutableMirror input) {
@@ -58,6 +62,7 @@ public abstract class ValueImmutableInfo implements ValueMirrors.Immutable {
         input.copy(),
         input.intern(),
         input.prehash(),
+        input.lazyhash(),
         input.singleton())
         .withIsDefault(input.getAnnotationMirror().getElementValues().isEmpty());
   }

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -35,6 +35,8 @@ public final class ValueMirrors {
 
     boolean prehash() default false;
 
+    boolean lazyhash() default false;
+
     boolean builder() default true;
   }
 

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -612,6 +612,21 @@ public final class ValueType extends TypeIntrospectionBase implements HasStyleIn
         && !isUseSingletonOnly();
   }
 
+  /**
+   * Means object hashcode is cached at some point. Either lazily (on first access)
+   * or eagerly (during construction).
+   * @see #isUseLazyhash()
+   * @see #isUsePrehashed()
+   */
+  public boolean isCacheHash() {
+    return isUseLazyhash() || isUsePrehashed();
+  }
+
+  public boolean isUseLazyhash() {
+    // lazyhash and prehash are mutually exclusive
+    return immutableFeatures.lazyhash() && !isUsePrehashed();
+  }
+
   public boolean isUsePrehashed() {
     return immutableFeatures.prehash()
         && !isGeneratePrivateNoargConstructor()


### PR DESCRIPTION
Add `lazyhash` attribute to `@Value` annotation which generates additional private class field `hashCode`.

```java
// pseudo-code for lazy evaluation of hashcode
public int hashCode() {
  int h = this.hashCode;
  if (h == 0) {
    // 0 is considered unset int
    h = computeHashCode();
    this.hashCode = h;
  }
  return h;
}
```

This pattern is called [racy-single-check](http://javaagile.blogspot.com/2013/05/the-racy-single-check-idiom.html). From Effective Java : 
> If you don't care whether every thread recalculates the value of a field, and the type of the field is a primitive other than long or double, then you may choose to remove the volatile modifier from the field declaration in the single-check idiom [calculating the value of a volatile field if it's null]. This variant is known as the racy single-check idiom. It speeds up field access on some architectures, at the expense of additional initializations (up to one per thread that accesses the field). This is definitely an exotic technique, not for everyday use. It is, however, used by String instances to cache their hash codes.

Also read Jeremy's Mason post [Date-Race-Ful Lazy Initialization for Performance](http://jeremymanson.blogspot.com/2008/12/benign-data-races-in-java.html)