### PR TITLE
Generate criteria from Pojo / JavaBean #1092

### DIFF
--- a/criteria/common/test/org/immutables/criteria/processor/JavaBeanModelTest.java
+++ b/criteria/common/test/org/immutables/criteria/processor/JavaBeanModelTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.criteria.processor;
+
+import org.immutables.criteria.Criteria;
+import org.immutables.value.processor.meta.ProcessorRule;
+import org.immutables.value.processor.meta.ValueAttribute;
+import org.immutables.value.processor.meta.ValueType;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.immutables.check.Checkers.check;
+
+public class JavaBeanModelTest {
+
+  @Rule // TODO migrate to JUnit5 Extension
+  public final ProcessorRule rule = new ProcessorRule();
+
+  @Test
+  public void javaBean() {
+    ValueType valueType = rule.value(Model1.class);
+    check(valueType.constitution.protoclass().criteria().isPresent());
+    check(valueType.constitution.protoclass().criteriaRepository().isPresent());
+    check(valueType.typeDocument().toString()).is(Model1.class.getCanonicalName());
+    check(valueType.attributes).notEmpty();
+
+    List<String> attributes = valueType.allMarshalingAttributes().stream().map(ValueAttribute::name).collect(Collectors.toList());
+
+    check(attributes).hasContentInAnyOrder("set", "foo", "base", "dep", "deps", "nullableDep");
+    // java.lang.Object should not be included
+    check(attributes).not().hasContentInAnyOrder("equals", "hashCode", "toString", "getClass");
+    check(attributes).not().hasContentInAnyOrder("ignore");
+  }
+
+  @Test
+  public void attributes() {
+    ValueType valueType = rule.value(Model1.class);
+    Function<String, ValueAttribute> findFn = name -> valueType.attributes.stream().filter(a -> a.name().equals(name)).findAny().get();
+
+    check(findFn.apply("foo").getType()).is("int");
+    ValueAttribute dep = findFn.apply("dep");
+    check(dep.hasCriteria());
+    check(dep.criteria().matcher().creator()).contains("DepCriteria.creator()");
+    check(dep.criteria().matcher().creator()).not().contains("DepCriteriaTemplate.creator()");
+  }
+
+  @Test
+  public void nullable() {
+    ValueType valueType = rule.value(Model1.class);
+    Function<String, ValueAttribute> findFn = name -> valueType.attributes.stream().filter(a -> a.name().equals(name)).findAny().get();
+    check(findFn.apply("nullableDep").isNullable());
+  }
+
+  @Test
+  public void criteria() {
+    Model1Criteria model1 = Model1Criteria.model1;
+    model1.base.is("aaa")
+          .foo.greaterThan(22)
+           .set.isTrue()
+           .deps.isEmpty();
+  }
+
+  @ProcessorRule.TestImmutable
+  @Criteria
+  @Criteria.Repository
+  static class Model1  extends Base {
+
+    private boolean set;
+    private int foo;
+    private List<Dep> deps;
+
+    private Dep dep;
+
+    private Dep nullableDep;
+
+    public int getFoo() {
+      return foo;
+    }
+
+    public void setFoo(int foo) {
+      this.foo = foo;
+    }
+
+    public boolean isSet() {
+      return set;
+    }
+
+    public void setSet(boolean set) {
+      this.set = set;
+    }
+
+    public Dep getDep() {
+      return dep;
+    }
+
+    public List<Dep> getDeps() {
+      return deps;
+    }
+
+    @Nullable
+    public Dep getNullableDep() {
+      return nullableDep;
+    }
+
+    /**
+     * Should not be included in attribute list. Since not a java bean getter
+     */
+    public int ignore() {
+      return 0;
+    }
+  }
+
+  /**
+   * Used for testing nested criterias
+   */
+  @ProcessorRule.TestImmutable
+  @Criteria
+  static class Dep {
+
+    private final Date date = new Date();
+
+    public Date getDate() {
+      return date;
+    }
+  }
+
+  static abstract class Base {
+    private String base;
+
+    public String getBase() {
+      return base;
+    }
+
+    public void setBase(String base) {
+      this.base = base;
+    }
+  }
+}

--- a/criteria/common/test/org/immutables/criteria/repository/AsyncModel.java
+++ b/criteria/common/test/org/immutables/criteria/repository/AsyncModel.java
@@ -24,6 +24,6 @@ import org.immutables.value.Value;
 @Value.Immutable
 @Criteria
 @Criteria.Repository(facets = {AsyncReadable.class, AsyncWritable.class})
-class AsyncModel {
+abstract class AsyncModel {
 
 }

--- a/value-processor/src/org/immutables/value/processor/Criteria.generator
+++ b/value-processor/src/org/immutables/value/processor/Criteria.generator
@@ -15,7 +15,7 @@
 --]
 [template public generate]
   [for type in values.values if type.generateCriteria]
-    [if type.kind.isValue andnot type.generics]
+    [if type.kind.isValue or type.kind.isJavaBean]
 [output.java type.package (type.name 'Criteria') type.element]
 [type.sourceHeader]
 [generateCriteria type]
@@ -66,7 +66,7 @@ import java.util.Objects;
 
 [for a in type.allMarshalingAttributes]
 [if a.hasCriteria]
-import [a.unwrappedElementType]Criteria;
+import [a.criteria.rawTypeName];
 [/if]
 [/for]
 
@@ -115,7 +115,7 @@ import org.immutables.criteria.expression.Queryable;
 
 [for a in type.allMarshalingAttributes]
 [if a.hasCriteria]
-import [a.unwrappedElementType]Criteria;
+import [a.criteria.rawTypeName];
 [/if]
 [/for]
 

--- a/value-processor/src/org/immutables/value/processor/CriteriaRepository.generator
+++ b/value-processor/src/org/immutables/value/processor/CriteriaRepository.generator
@@ -15,7 +15,7 @@
 --]
 [template public generate]
   [for type in values.values if type.generateCriteriaRepository]
-    [if type.kind.isValue andnot type.generics]
+    [if type.kind.isValue or type.kind.isJavaBean]
 [output.java type.package (type.name 'Repository') type.element]
 [type.sourceHeader]
 [generateRepository type]

--- a/value-processor/src/org/immutables/value/processor/Processor.java
+++ b/value-processor/src/org/immutables/value/processor/Processor.java
@@ -18,21 +18,13 @@ package org.immutables.value.processor;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.Set;
-import javax.annotation.processing.Filer;
-import javax.annotation.processing.ProcessingEnvironment;
-import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.lang.model.element.Element;
-import javax.tools.FileObject;
-import javax.tools.Diagnostic.Kind;
-import javax.tools.JavaFileManager.Location;
 import org.immutables.generator.AbstractGenerator;
 import org.immutables.generator.ForwardingFiler;
 import org.immutables.generator.ForwardingProcessingEnvironment;
 import org.immutables.value.processor.encode.EncodingMirror;
 import org.immutables.value.processor.encode.Generator_Encodings;
+import org.immutables.value.processor.meta.CriteriaMirror;
+import org.immutables.value.processor.meta.CriteriaRepositoryMirror;
 import org.immutables.value.processor.meta.CustomImmutableAnnotations;
 import org.immutables.value.processor.meta.EnclosingMirror;
 import org.immutables.value.processor.meta.FConstructorMirror;
@@ -48,6 +40,17 @@ import org.immutables.value.processor.meta.UnshadeGuava;
 import org.immutables.value.processor.meta.ValueType;
 import org.immutables.value.processor.meta.ValueUmbrellaMirror;
 
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.element.Element;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.FileObject;
+import javax.tools.JavaFileManager.Location;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Set;
+
 @SupportedAnnotationTypes({
     ImmutableMirror.QUALIFIED_NAME,
     EnclosingMirror.QUALIFIED_NAME,
@@ -58,6 +61,8 @@ import org.immutables.value.processor.meta.ValueUmbrellaMirror;
     FConstructorMirror.QUALIFIED_NAME,
     FIncludeMirror.QUALIFIED_NAME,
     EncodingMirror.QUALIFIED_NAME,
+    CriteriaMirror.QUALIFIED_NAME,
+    CriteriaRepositoryMirror.QUALIFIED_NAME
 })
 public final class Processor extends AbstractGenerator {
   @Override

--- a/value-processor/src/org/immutables/value/processor/meta/Constitution.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Constitution.java
@@ -173,6 +173,11 @@ public abstract class Constitution {
           ? typeAbstract()
           : typeImmutable();
     }
+
+    if (protoclass().kind().isJavaBean()) {
+      return typeAbstract();
+    }
+
     if (isFactory()) {
 
       if (protoclass().kind().isConstructor()) {

--- a/value-processor/src/org/immutables/value/processor/meta/CriteriaModel.java
+++ b/value-processor/src/org/immutables/value/processor/meta/CriteriaModel.java
@@ -520,6 +520,13 @@ public class CriteriaModel {
     return matcherDefinition;
   }
 
+  /**
+   * Return class name of matcher for this criteria
+   */
+  public String rawTypeName() {
+    return matcher().matcherType().reference.name;
+  }
+
   public static class MatcherDefinition {
     private final ValueAttribute attribute;
     private final Type.Parameterized matcherType;

--- a/value-processor/src/org/immutables/value/processor/meta/JavaBeanAttributesCollector.java
+++ b/value-processor/src/org/immutables/value/processor/meta/JavaBeanAttributesCollector.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.value.processor.meta;
+
+import com.google.common.base.Preconditions;
+import org.immutables.generator.Naming;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.util.ElementFilter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Collects attributes by searching for getters in a class definition.
+ *
+ * For each {@code getFoo} method (without parameters) create attribute {@code foo}.
+ * @see AccessorAttributesCollector
+ */
+final class JavaBeanAttributesCollector {
+
+  private final ValueType type;
+  private final Reporter reporter;
+  private final ProcessingEnvironment processing;
+  private final Styles styles;
+
+  JavaBeanAttributesCollector(Proto.Protoclass protoclass, ValueType type) {
+    this.type = Preconditions.checkNotNull(type, "type");
+    this.reporter = protoclass.report();
+    this.styles = new Styles(ImmutableStyleInfo.copyOf(protoclass.styles().style()).withGet("is*", "get*"));
+    this.processing = protoclass.processing();
+  }
+
+  private TypeElement getTypeElement() {
+    return (TypeElement) type.element;
+  }
+
+  void collect() {
+    TypeElement originalType = CachingElements.getDelegate(getTypeElement());
+    List<ValueAttribute> attributes = new ArrayList<>();
+    List<ExecutableElement> methods = ElementFilter.methodsIn(processing.getElementUtils().getAllMembers(originalType));
+    for (ExecutableElement method : methods) {
+      if (isGetter(method)) {
+        ValueAttribute attribute = toAttribute(method);
+        attributes.add(attribute);
+      }
+    }
+
+    type.attributes.addAll(attributes);
+  }
+
+  /**
+   * Create attribute from JavaBean getter
+   */
+  private ValueAttribute toAttribute(ExecutableElement getter) {
+    ValueAttribute attribute = new ValueAttribute();
+    attribute.reporter = reporter;
+    attribute.returnType = getter.getReturnType();
+    attribute.names = styles.forAccessor(getter.getSimpleName().toString());
+    attribute.element = getter;
+    attribute.containingType = type;
+    attribute.isGenerateAbstract = true; // to be visible as marshalling attribute
+    attribute.initAndValidate(null);
+    return attribute;
+  }
+
+  private boolean isGetter(ExecutableElement executable) {
+    if (isJavaLangObject(executable.getEnclosingElement())) {
+      return false;
+    }
+
+    String name = executable.getSimpleName().toString();
+    boolean getterName = false;
+    for (Naming naming: styles.scheme().get) {
+      if (!naming.detect(name).isEmpty()) {
+        getterName = true;
+        break;
+      }
+    }
+    boolean noArgs = executable.getParameters().isEmpty() && executable.getReturnType().getKind() != TypeKind.VOID;
+    return getterName && noArgs;
+  }
+
+  private static boolean isJavaLangObject(Element element) {
+    return element instanceof TypeElement && ((TypeElement) element).getQualifiedName().contentEquals(Object.class.getName());
+  }
+
+}

--- a/value-processor/src/org/immutables/value/processor/meta/Round.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Round.java
@@ -348,6 +348,7 @@ public abstract class Round {
       }
 
       if (declaringType.isImmutable()
+          || declaringType.isJavaBean()
           || declaringType.isEnclosing()
           || declaringType.isModifiable()) {
 
@@ -368,6 +369,9 @@ public abstract class Round {
     }
 
     private Kind kindOfDefinedBy(DeclaringType declaringType) {
+      if (declaringType.isJavaBean()) {
+        return Kind.DEFINED_JAVABEAN;
+      }
       if (declaringType.isImmutable()) {
         if (declaringType.isEnclosing()) {
           return Kind.DEFINED_AND_ENCLOSING_TYPE;

--- a/value-processor/src/org/immutables/value/processor/meta/Styles.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Styles.java
@@ -38,6 +38,10 @@ public final class Styles {
         : Depluralizer.NONE;
   }
 
+  Scheme scheme() {
+    return scheme;
+  }
+
   public ValueImmutableInfo defaults() {
     return style.defaults();
   }

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -1319,7 +1319,7 @@ public final class ValueAttribute extends TypeIntrospectionBase implements HasSt
       } else {
         Environment environment = protoclass().environment();
         for (Protoclass p : environment.protoclassesFrom(Collections.singleton(containedTypeElement))) {
-          if ((p.kind().isDefinedValue() || p.kind().isModifiable())
+          if ((p.kind().isDefinedValue() || p.kind().isModifiable() || p.kind().isJavaBean())
               && canAccessImplementation(p)
               && p.constitution().generics().isEmpty()) {
             this.attributeValueType = environment.composeValue(p);

--- a/value-processor/src/org/immutables/value/processor/meta/ValueTypeComposer.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueTypeComposer.java
@@ -51,6 +51,8 @@ public final class ValueTypeComposer {
 
     if (protoclass.kind().isFactory()) {
       new FactoryMethodAttributesCollector(protoclass, type).collect();
+    } else if (protoclass.kind().isJavaBean()) {
+      new JavaBeanAttributesCollector(protoclass, type).collect();
     } else if (protoclass.kind().isValue() || protoclass.kind().isModifiable()) {
       Collection<String> violations = Lists.newArrayList();
       // This check is legacy, most such checks should have been done on a higher level?


### PR DESCRIPTION
Generate criteria from JavaBean definition #1092

Add separate collector which scans for getters / setters is a non-abstract class (with @Criteria and @Criteria.Repository annotations).

Helpful for projects with non-immutables classes which still want to leverage criteria API.

```java
@Criteria // enable DSL generation on existing class
// generate CustomPojoCriteria
class CustomPojo {
   private String foo;
   String getFoo() {...}
   void setFoo(String foo) {...}
}
```