### PR TITLE
Isuues with Gson Jackson Bridge

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -71,7 +71,7 @@
       <!-- Optional. Jackson binding have utility used when using polymorhic marshaling with jackson-core implementation -->
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
+      <version>${jackson-databind.version}</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -28,6 +28,10 @@
     streaming parsing of Gson, while using all of gson binding infrastructure.
   </description>
 
+  <properties>
+    <latest.jackson.databind.version>2.10.0</latest.jackson.databind.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <!-- Required Gson dependency -->
@@ -71,7 +75,7 @@
       <!-- Optional. Jackson binding have utility used when using polymorhic marshaling with jackson-core implementation -->
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson-databind.version}</version>
+      <version>${jackson.version}</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
@@ -115,6 +119,43 @@
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-grizzly2-http</artifactId>
       <version>2.11</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Test dependencies to test other jackson serialization formats -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>${jackson.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+      <version>${jackson.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.woodstox</groupId>
+      <artifactId>woodstox-core</artifactId>
+      <version>5.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-smile</artifactId>
+      <version>${jackson.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-properties</artifactId>
+      <version>${jackson.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-cbor</artifactId>
+      <version>${jackson.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -162,6 +203,14 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -200,14 +200,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>8</source>
-          <target>8</target>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -28,10 +28,6 @@
     streaming parsing of Gson, while using all of gson binding infrastructure.
   </description>
 
-  <properties>
-    <latest.jackson.databind.version>2.10.0</latest.jackson.databind.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <!-- Required Gson dependency -->

--- a/gson/src/org/immutables/gson/stream/JsonGeneratorWriter.java
+++ b/gson/src/org/immutables/gson/stream/JsonGeneratorWriter.java
@@ -142,11 +142,6 @@ public class JsonGeneratorWriter extends JsonWriter implements Callable<JsonGene
     if (value == null) {
       return nullValue();
     }
-    if (!isLenient()) {
-      if (Double.isNaN(value.doubleValue()) || Double.isInfinite(value.doubleValue())) {
-        throw new IllegalArgumentException("JSON forbids NaN and infinities: " + value);
-      }
-    }
     if (value instanceof Integer) {
       generator.writeNumber(value.intValue());
     } else if (value instanceof Short) {
@@ -154,17 +149,33 @@ public class JsonGeneratorWriter extends JsonWriter implements Callable<JsonGene
     } else if (value instanceof Long) {
       generator.writeNumber(value.longValue());
     } else if (value instanceof Float) {
-      generator.writeNumber(value.floatValue());
-    } else if (value instanceof Double) {
-      generator.writeNumber(value.doubleValue());
+      float f = value.floatValue();
+      checkStrictNumber(f);
+      generator.writeNumber(f);
     } else if (value instanceof BigInteger) {
       generator.writeNumber((BigInteger) value);
     } else if (value instanceof BigDecimal) {
-      generator.writeNumber((BigDecimal) value);
+      BigDecimal bd = (BigDecimal) value;
+      checkStrictNumber(bd);
+      generator.writeNumber(bd);
     } else {
-      generator.writeNumber(value.doubleValue());
+      double d = value.doubleValue();
+      checkStrictNumber(d);
+      generator.writeNumber(d);
     }
     return this;
+  }
+
+  private void checkStrictNumber(Number number) {
+    if (!isLenient()) {
+      checkStrictNumber(number.doubleValue());
+    }
+  }
+
+  private void checkStrictNumber(double number) {
+    if (!isLenient() && (Double.isInfinite(number) || Double.isNaN(number))) {
+      throw new IllegalArgumentException("JSON forbids NaN and infinities: " + number);
+    }
   }
 
   @Override

--- a/gson/src/org/immutables/gson/stream/JsonGeneratorWriter.java
+++ b/gson/src/org/immutables/gson/stream/JsonGeneratorWriter.java
@@ -25,8 +25,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.concurrent.Callable;
 
-import static java.lang.Math.floor;
-
 /**
  * {@link JsonWriter} implementation backed by Jackson's {@link JsonGenerator}.
  * Provides measurable JSON writing improvements over Gson's native implementation.
@@ -151,21 +149,19 @@ public class JsonGeneratorWriter extends JsonWriter implements Callable<JsonGene
       }
     }
     if (value instanceof Integer) {
-      generator.writeNumber((Integer) value);
+      generator.writeNumber(value.intValue());
     } else if (value instanceof Short) {
-      generator.writeNumber((Short) value);
+      generator.writeNumber(value.shortValue());
     } else if (value instanceof Long) {
-      generator.writeNumber((Long) value);
+      generator.writeNumber(value.longValue());
     } else if (value instanceof Float) {
-      generator.writeNumber((Float) value);
+      generator.writeNumber(value.floatValue());
     } else if (value instanceof Double) {
-      generator.writeNumber((Double) value);
+      generator.writeNumber(value.doubleValue());
     } else if (value instanceof BigInteger) {
       generator.writeNumber((BigInteger) value);
     } else if (value instanceof BigDecimal) {
       generator.writeNumber((BigDecimal) value);
-    } else if (floor(d) == d) {
-      generator.writeNumber(value.intValue());
     } else {
       generator.writeNumber(d);
     }

--- a/gson/src/org/immutables/gson/stream/JsonGeneratorWriter.java
+++ b/gson/src/org/immutables/gson/stream/JsonGeneratorWriter.java
@@ -17,15 +17,18 @@ package org.immutables.gson.stream;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.google.gson.stream.JsonWriter;
+
+import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.io.Writer;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.concurrent.Callable;
-import javax.annotation.concurrent.NotThreadSafe;
 
 import static java.lang.Math.floor;
 
 /**
- * {@link JsonWriter} impementation backed by Jackson's {@link JsonGenerator}.
+ * {@link JsonWriter} implementation backed by Jackson's {@link JsonGenerator}.
  * Provides measurable JSON writing improvements over Gson's native implementation.
  * Error reporting is might differ, however.
  */
@@ -147,9 +150,22 @@ public class JsonGeneratorWriter extends JsonWriter implements Callable<JsonGene
         throw new IllegalArgumentException("JSON forbids NaN and infinities: " + value);
       }
     }
-    if (floor(d) == d) {
-      int a = value.intValue();
-      generator.writeNumber(a);
+    if (value instanceof Integer) {
+      generator.writeNumber((Integer) value);
+    } else if (value instanceof Short) {
+      generator.writeNumber((Short) value);
+    } else if (value instanceof Long) {
+      generator.writeNumber((Long) value);
+    } else if (value instanceof Float) {
+      generator.writeNumber((Float) value);
+    } else if (value instanceof Double) {
+      generator.writeNumber((Double) value);
+    } else if (value instanceof BigInteger) {
+      generator.writeNumber((BigInteger) value);
+    } else if (value instanceof BigDecimal) {
+      generator.writeNumber((BigDecimal) value);
+    } else if (floor(d) == d) {
+      generator.writeNumber(value.intValue());
     } else {
       generator.writeNumber(d);
     }

--- a/gson/src/org/immutables/gson/stream/JsonGeneratorWriter.java
+++ b/gson/src/org/immutables/gson/stream/JsonGeneratorWriter.java
@@ -142,9 +142,8 @@ public class JsonGeneratorWriter extends JsonWriter implements Callable<JsonGene
     if (value == null) {
       return nullValue();
     }
-    double d = value.doubleValue();
     if (!isLenient()) {
-      if (Double.isNaN(d) || Double.isInfinite(d)) {
+      if (Double.isNaN(value.doubleValue()) || Double.isInfinite(value.doubleValue())) {
         throw new IllegalArgumentException("JSON forbids NaN and infinities: " + value);
       }
     }
@@ -163,7 +162,7 @@ public class JsonGeneratorWriter extends JsonWriter implements Callable<JsonGene
     } else if (value instanceof BigDecimal) {
       generator.writeNumber((BigDecimal) value);
     } else {
-      generator.writeNumber(d);
+      generator.writeNumber(value.doubleValue());
     }
     return this;
   }

--- a/gson/src/org/immutables/gson/stream/JsonGeneratorWriter.java
+++ b/gson/src/org/immutables/gson/stream/JsonGeneratorWriter.java
@@ -22,6 +22,8 @@ import java.io.Writer;
 import java.util.concurrent.Callable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import static java.lang.Math.floor;
+
 /**
  * {@link JsonWriter} impementation backed by Jackson's {@link JsonGenerator}.
  * Provides measurable JSON writing improvements over Gson's native implementation.
@@ -145,7 +147,12 @@ public class JsonGeneratorWriter extends JsonWriter implements Callable<JsonGene
         throw new IllegalArgumentException("JSON forbids NaN and infinities: " + value);
       }
     }
-    generator.writeNumber(d);
+    if (floor(d) == d) {
+      int a = value.intValue();
+      generator.writeNumber(a);
+    } else {
+      generator.writeNumber(d);
+    }
     return this;
   }
 

--- a/gson/src/org/immutables/gson/stream/JsonParserReader.java
+++ b/gson/src/org/immutables/gson/stream/JsonParserReader.java
@@ -16,6 +16,7 @@
 package org.immutables.gson.stream;
 
 import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonStreamContext;
 import com.fasterxml.jackson.databind.util.TokenBuffer;
@@ -143,7 +144,12 @@ public class JsonParserReader extends JsonReader implements Callable<JsonParser>
   @Override
   public boolean nextBoolean() throws IOException {
     requirePeek();
-    boolean value = parser.getBooleanValue();
+    boolean value;
+    try {
+      value = parser.getBooleanValue();
+    } catch (JsonParseException e) {
+      value = Boolean.parseBoolean(parser.getValueAsString());
+    }
     clearPeek();
     return value;
   }

--- a/gson/src/org/immutables/gson/stream/JsonParserReader.java
+++ b/gson/src/org/immutables/gson/stream/JsonParserReader.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import static com.fasterxml.jackson.core.JsonToken.*;
 
 /**
- * {@link JsonReader} impementation backed by Jackson's {@link JsonParser}.
+ * {@link JsonReader} implementation backed by Jackson's {@link JsonParser}.
  * Provides measurable JSON parsing improvements over Gson's native implementation.
  * Error reporting might differ, however.
  */

--- a/gson/src/org/immutables/gson/stream/JsonParserReader.java
+++ b/gson/src/org/immutables/gson/stream/JsonParserReader.java
@@ -144,12 +144,7 @@ public class JsonParserReader extends JsonReader implements Callable<JsonParser>
   @Override
   public boolean nextBoolean() throws IOException {
     requirePeek();
-    boolean value;
-    try {
-      value = parser.getBooleanValue();
-    } catch (JsonParseException e) {
-      value = Boolean.parseBoolean(parser.getValueAsString());
-    }
+    boolean value = parser.getBooleanValue();
     clearPeek();
     return value;
   }

--- a/gson/src/org/immutables/gson/stream/XmlParserReader.java
+++ b/gson/src/org/immutables/gson/stream/XmlParserReader.java
@@ -1,0 +1,39 @@
+package org.immutables.gson.stream;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.google.gson.stream.JsonReader;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.IOException;
+
+/**
+ *  {@link JsonReader} implementation backed by Jackson's {@link JsonParser}.
+ *  This version assumes the token producer only supports strings, therefore will
+ *  work with the XML and properties formats.
+ */
+@NotThreadSafe
+public class XmlParserReader extends JsonParserReader {
+  public XmlParserReader(JsonParser parser) {
+    super(parser);
+  }
+
+  @Override
+  public boolean nextBoolean() throws IOException {
+    return Boolean.parseBoolean(nextString());
+  }
+
+  @Override
+  public double nextDouble() throws IOException {
+    return Double.parseDouble(nextString());
+  }
+
+  @Override
+  public long nextLong() throws IOException {
+    return Long.parseLong(nextString());
+  }
+
+  @Override
+  public int nextInt() throws IOException {
+    return Integer.parseInt(nextString());
+  }
+}

--- a/gson/test/org/immutables/gson/bridge/GsonJacksonBridgeSerializationTest.java
+++ b/gson/test/org/immutables/gson/bridge/GsonJacksonBridgeSerializationTest.java
@@ -1,0 +1,247 @@
+package org.immutables.gson.bridge;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
+import com.fasterxml.jackson.dataformat.javaprop.JavaPropsFactory;
+import com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import com.fasterxml.jackson.dataformat.xml.XmlFactory;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.immutables.gson.stream.JsonGeneratorWriter;
+import org.immutables.gson.stream.JsonParserReader;
+import org.immutables.gson.stream.XmlParserReader;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.xml.namespace.QName;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Test the various Jackson serialization formats against the Gson/Jackson bridge.
+ */
+public class GsonJacksonBridgeSerializationTest {
+
+  private final Gson gson = new GsonBuilder()
+          .registerTypeAdapterFactory(new GsonAdaptersTestObject())
+          .registerTypeAdapterFactory(new GsonAdaptersTestSubObject())
+          .create();
+
+  private TestObject createTestObject() {
+    return ImmutableTestObject.builder()
+            .intVal(123)
+            .integerVal(123)
+            .addListOfInteger(1, 2, 3, 4, 5, 6)
+            .longVal(2349823948398472394L)
+            .longObjVal(2349823948398472394L)
+            .addListOfLong(2349823948398472394L, 2349822348398472394L, 2349823948123332394L)
+            .floatVal(123123.0980F)
+            .floatObjVal(123123.0980F)
+            .addListOfFloat(123123.0980F, 124234.0980F, 1233455.0980F)
+            .doubleVal(123123123.1231231)
+            .doubleObjVal(123123123.1231231)
+            .addListOfDouble(123123.1231, 123123123.123213, 234234234.23423)
+            .bigDecimalVal(new BigDecimal(4234234.1312313123))
+            .addListOfBigDecimal(new BigDecimal(123123.123123), new BigDecimal(3534345.345345), new BigDecimal(35252.2411))
+            .booleanVal(true)
+            .booleanObjVal(false)
+            .addListOfBoolean(true, false, true)
+            .stringVal("This is a test")
+            .addListOfString("a", "b", "c")
+            .addSetOfString("a", "b", "c")
+            .putMapOfStringToString("a", "1")
+            .putMapOfStringToString("b", "2")
+            .testEnumVal(TestEnum.VALUE1)
+            .putMapOfTestEnumToString(TestEnum.VALUE2, "test2")
+            .putMapOfTestEnumToString(TestEnum.VALUE3, "test3")
+            .addListOfSubObject(ImmutableTestSubObject.builder()
+                    .a("Test")
+                    .b(1231)
+                    .build())
+            .build();
+  }
+
+  @Test
+  public void jsonFactoryTest() throws IOException {
+    TestObject testObject = createTestObject();
+    JsonFactory factory = new JsonFactory();
+    runTestOnFactory(
+            testObject
+            , TestObject.class
+            , out -> {
+              try {
+                return factory.createGenerator(out);
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            }
+            , os -> {
+              try {
+                return factory.createParser(os.toByteArray());
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            }
+            , JsonParserReader::new);
+  }
+
+  @Test
+  public void xmlFactoryTest() throws IOException {
+    TestObject testObject = createTestObject();
+    XmlFactory factory = new XmlFactory();
+    Class<TestObject> clazz = TestObject.class;
+    runTestOnFactory(
+            testObject
+            , clazz
+            , out -> {
+              try {
+                ToXmlGenerator generator = factory.createGenerator(out);
+                QName rootName = Optional.ofNullable(clazz.getAnnotation(JacksonXmlRootElement.class))
+                        .map(a -> QName.valueOf(a.localName()))
+                        .orElse(QName.valueOf(clazz.getName()));
+                generator.setNextName(rootName);
+                return generator;
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            }
+            , os -> {
+              try {
+                return factory.createParser(os.toByteArray());
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            }
+            , XmlParserReader::new);
+  }
+
+  @Test
+  public void yamlFactoryTest() throws IOException {
+    TestObject testObject = createTestObject();
+    YAMLFactory factory = new YAMLFactory();
+    runTestOnFactory(
+            testObject
+            , TestObject.class
+            , out -> {
+              try {
+                return factory.createGenerator(out);
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            }
+            , os -> {
+              try {
+                return factory.createParser(os.toByteArray());
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            }
+            , JsonParserReader::new);
+  }
+
+  @Test
+  public void smileFactoryTest() throws IOException {
+    TestObject testObject = createTestObject();
+    SmileFactory factory = new SmileFactory();
+    runTestOnFactory(
+            testObject
+            , TestObject.class
+            , out -> {
+              try {
+                return factory.createGenerator(out);
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            }
+            , os -> {
+              try {
+                return factory.createParser(os.toByteArray());
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            }
+            , JsonParserReader::new);
+  }
+
+  @Test
+  public void propertiesFactoryTest() throws IOException {
+    TestObject testObject = ImmutableTestObject.copyOf(createTestObject())
+            // excluding map here because when it is de-serialized, the order is changed and the unit test fails
+            .withMapOfStringToString(new HashMap<>());
+    JavaPropsFactory factory = new JavaPropsFactory();
+    runTestOnFactory(
+            testObject
+            , TestObject.class
+            , out -> {
+              try {
+                return factory.createGenerator(out);
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            }
+            , os -> {
+              try {
+                return factory.createParser(os.toByteArray());
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            }
+            , XmlParserReader::new);
+  }
+
+  @Test
+  public void cborFactoryTest() throws IOException {
+    TestObject testObject = createTestObject();
+    CBORFactory factory = new CBORFactory();
+    runTestOnFactory(
+            testObject
+            , TestObject.class
+            , out -> {
+              try {
+                return factory.createGenerator(out);
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            }
+            , os -> {
+              try {
+                return factory.createParser(os.toByteArray());
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            }
+            , JsonParserReader::new);
+  }
+
+  private <VALUE
+          , WRITER extends JsonGenerator
+          , READER extends JsonParser
+          > void runTestOnFactory(
+          VALUE value
+          , Class<VALUE> clazz
+          , Function<ByteArrayOutputStream, WRITER> writerProducer
+          , Function<ByteArrayOutputStream, READER> readerProducer
+          , Function<READER, JsonParserReader> bridgeReaderProducer
+  ) throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    WRITER g = writerProducer.apply(outputStream);
+    JsonGeneratorWriter generatorWriter = new JsonGeneratorWriter(g);
+    gson.toJson(value, clazz, generatorWriter);
+    generatorWriter.flush();
+
+    READER r = readerProducer.apply(outputStream);
+    JsonParserReader parserReader = bridgeReaderProducer.apply(r);
+    VALUE value2 = gson.fromJson(parserReader, clazz);
+
+    Assert.assertEquals(value2.toString(), value.toString());
+  }
+}

--- a/gson/test/org/immutables/gson/bridge/GsonJacksonBridgeSerializationTest.java
+++ b/gson/test/org/immutables/gson/bridge/GsonJacksonBridgeSerializationTest.java
@@ -23,8 +23,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.HashMap;
-import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * Test the various Jackson serialization formats against the Gson/Jackson bridge.
@@ -72,176 +70,89 @@ public class GsonJacksonBridgeSerializationTest {
 
   @Test
   public void jsonFactoryTest() throws IOException {
-    TestObject testObject = createTestObject();
+    TestObject value = createTestObject();
     JsonFactory factory = new JsonFactory();
-    runTestOnFactory(
-            testObject
-            , TestObject.class
-            , out -> {
-              try {
-                return factory.createGenerator(out);
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            }
-            , os -> {
-              try {
-                return factory.createParser(os.toByteArray());
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            }
-            , JsonParserReader::new);
+    Class<TestObject> clazz = TestObject.class;
+    ByteArrayOutputStream outputStream = testWriting(value, factory, clazz);
+    TestObject value2 = testReading(factory, clazz, outputStream);
+    Assert.assertEquals(value2.toString(), value.toString());
   }
 
   @Test
   public void xmlFactoryTest() throws IOException {
-    TestObject testObject = createTestObject();
+    TestObject value = createTestObject();
     XmlFactory factory = new XmlFactory();
     Class<TestObject> clazz = TestObject.class;
-    runTestOnFactory(
-            testObject
-            , clazz
-            , out -> {
-              try {
-                ToXmlGenerator generator = factory.createGenerator(out);
-                QName rootName = Optional.ofNullable(clazz.getAnnotation(JacksonXmlRootElement.class))
-                        .map(a -> QName.valueOf(a.localName()))
-                        .orElse(QName.valueOf(clazz.getName()));
-                generator.setNextName(rootName);
-                return generator;
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            }
-            , os -> {
-              try {
-                return factory.createParser(os.toByteArray());
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            }
-            , XmlParserReader::new);
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    ToXmlGenerator g = factory.createGenerator(outputStream);
+    g.setNextName(QName.valueOf(clazz.getAnnotation(JacksonXmlRootElement.class).localName()));
+    JsonGeneratorWriter generatorWriter = new JsonGeneratorWriter(g);
+    gson.toJson(value, clazz, generatorWriter);
+    generatorWriter.flush();
+    TestObject value2 = testXmlReading(factory, clazz, outputStream);
+    Assert.assertEquals(value2.toString(), value.toString());
   }
 
   @Test
   public void yamlFactoryTest() throws IOException {
-    TestObject testObject = createTestObject();
+    TestObject value = createTestObject();
     YAMLFactory factory = new YAMLFactory();
-    runTestOnFactory(
-            testObject
-            , TestObject.class
-            , out -> {
-              try {
-                return factory.createGenerator(out);
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            }
-            , os -> {
-              try {
-                return factory.createParser(os.toByteArray());
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            }
-            , JsonParserReader::new);
+    Class<TestObject> clazz = TestObject.class;
+    ByteArrayOutputStream outputStream = testWriting(value, factory, clazz);
+    TestObject value2 = testReading(factory, clazz, outputStream);
+    Assert.assertEquals(value2.toString(), value.toString());
   }
 
   @Test
   public void smileFactoryTest() throws IOException {
-    TestObject testObject = createTestObject();
+    TestObject value = createTestObject();
     SmileFactory factory = new SmileFactory();
-    runTestOnFactory(
-            testObject
-            , TestObject.class
-            , out -> {
-              try {
-                return factory.createGenerator(out);
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            }
-            , os -> {
-              try {
-                return factory.createParser(os.toByteArray());
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            }
-            , JsonParserReader::new);
+    Class<TestObject> clazz = TestObject.class;
+    ByteArrayOutputStream outputStream = testWriting(value, factory, clazz);
+    TestObject value2 = testReading(factory, clazz, outputStream);
+    Assert.assertEquals(value2.toString(), value.toString());
   }
 
   @Test
   public void propertiesFactoryTest() throws IOException {
-    TestObject testObject = ImmutableTestObject.copyOf(createTestObject())
+    TestObject value = ImmutableTestObject.copyOf(createTestObject())
             // excluding map here because when it is de-serialized, the order is changed and the unit test fails
-            .withMapOfStringToString(new HashMap<>());
+            .withMapOfStringToString(new HashMap<String, String>());
     JavaPropsFactory factory = new JavaPropsFactory();
-    runTestOnFactory(
-            testObject
-            , TestObject.class
-            , out -> {
-              try {
-                return factory.createGenerator(out);
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            }
-            , os -> {
-              try {
-                return factory.createParser(os.toByteArray());
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            }
-            , XmlParserReader::new);
+    Class<TestObject> clazz = TestObject.class;
+    ByteArrayOutputStream outputStream = testWriting(value, factory, clazz);
+    TestObject value2 = testXmlReading(factory, clazz, outputStream);
+    Assert.assertEquals(value2.toString(), value.toString());
   }
 
   @Test
   public void cborFactoryTest() throws IOException {
-    TestObject testObject = createTestObject();
+    TestObject value = createTestObject();
     CBORFactory factory = new CBORFactory();
-    runTestOnFactory(
-            testObject
-            , TestObject.class
-            , out -> {
-              try {
-                return factory.createGenerator(out);
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            }
-            , os -> {
-              try {
-                return factory.createParser(os.toByteArray());
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            }
-            , JsonParserReader::new);
+    Class<TestObject> clazz = TestObject.class;
+    ByteArrayOutputStream outputStream = testWriting(value, factory, clazz);
+    TestObject value2 = testReading(factory, clazz, outputStream);
+    Assert.assertEquals(value2.toString(), value.toString());
   }
 
-  private <VALUE
-          , WRITER extends JsonGenerator
-          , READER extends JsonParser
-          > void runTestOnFactory(
-          VALUE value
-          , Class<VALUE> clazz
-          , Function<ByteArrayOutputStream, WRITER> writerProducer
-          , Function<ByteArrayOutputStream, READER> readerProducer
-          , Function<READER, JsonParserReader> bridgeReaderProducer
-  ) throws IOException {
+  private ByteArrayOutputStream testWriting(TestObject value, JsonFactory factory, Class<TestObject> clazz) throws IOException {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    WRITER g = writerProducer.apply(outputStream);
+    JsonGenerator g = factory.createGenerator(outputStream);
     JsonGeneratorWriter generatorWriter = new JsonGeneratorWriter(g);
     gson.toJson(value, clazz, generatorWriter);
     generatorWriter.flush();
+    return outputStream;
+  }
 
-    READER r = readerProducer.apply(outputStream);
-    JsonParserReader parserReader = bridgeReaderProducer.apply(r);
-    VALUE value2 = gson.fromJson(parserReader, clazz);
+  private TestObject testReading(JsonFactory factory, Class<TestObject> clazz, ByteArrayOutputStream outputStream) throws IOException {
+    JsonParser r = factory.createParser(outputStream.toByteArray());
+    JsonParserReader parserReader = new JsonParserReader(r);
+    return gson.fromJson(parserReader, clazz);
+  }
 
-    Assert.assertEquals(value2.toString(), value.toString());
+  private TestObject testXmlReading(JsonFactory factory, Class<TestObject> clazz, ByteArrayOutputStream outputStream) throws IOException {
+    JsonParser r = factory.createParser(outputStream.toByteArray());
+    JsonParserReader parserReader = new XmlParserReader(r);
+    return gson.fromJson(parserReader, clazz);
   }
 }

--- a/gson/test/org/immutables/gson/bridge/TestEnum.java
+++ b/gson/test/org/immutables/gson/bridge/TestEnum.java
@@ -1,0 +1,5 @@
+package org.immutables.gson.bridge;
+
+public enum TestEnum {
+  VALUE1, VALUE2, VALUE3
+}

--- a/gson/test/org/immutables/gson/bridge/TestObject.java
+++ b/gson/test/org/immutables/gson/bridge/TestObject.java
@@ -1,0 +1,65 @@
+package org.immutables.gson.bridge;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import org.immutables.gson.Gson;
+import org.immutables.value.Value;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Gson.TypeAdapters
+@Value.Immutable
+@JacksonXmlRootElement(localName = "test-object")
+public interface TestObject {
+  int intVal();
+
+  Integer integerVal();
+
+  List<Integer> listOfInteger();
+
+  long longVal();
+
+  Long longObjVal();
+
+  List<Long> listOfLong();
+
+  float floatVal();
+
+  Float floatObjVal();
+
+  List<Float> listOfFloat();
+
+  double doubleVal();
+
+  Double doubleObjVal();
+
+  List<Double> listOfDouble();
+
+  BigDecimal bigDecimalVal();
+
+  List<BigDecimal> listOfBigDecimal();
+
+  boolean booleanVal();
+
+  Boolean booleanObjVal();
+
+  List<Boolean> listOfBoolean();
+
+  String stringVal();
+
+  List<String> listOfString();
+
+  Set<String> setOfString();
+
+  Map<String, String> mapOfStringToString();
+
+  TestEnum testEnumVal();
+
+  List<TestEnum> listOfTestEnum();
+
+  Map<TestEnum, String> mapOfTestEnumToString();
+
+  List<TestSubObject> listOfSubObject();
+}

--- a/gson/test/org/immutables/gson/bridge/TestSubObject.java
+++ b/gson/test/org/immutables/gson/bridge/TestSubObject.java
@@ -1,0 +1,12 @@
+package org.immutables.gson.bridge;
+
+import org.immutables.gson.Gson;
+import org.immutables.value.Value;
+
+@Gson.TypeAdapters
+@Value.Immutable
+public interface TestSubObject {
+  String a();
+
+  Number b();
+}


### PR DESCRIPTION
- Fixed issue where integers are always printed as doubles
- Fixed issue using the jackson XML streaming parser where boolean tokens are always strings