### PR TITLE
Diagnostics for NPE in SourceOrdering

### DIFF
--- a/generator/src/org/immutables/generator/SourceOrdering.java
+++ b/generator/src/org/immutables/generator/SourceOrdering.java
@@ -17,6 +17,7 @@ package org.immutables.generator;
 
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ArrayListMultimap;
@@ -256,6 +257,8 @@ public final class SourceOrdering {
         String rightKey = ToSimpleName.FUNCTION.apply(right);
         Intratype leftIntratype = accessorOrderings.get(leftKey);
         Intratype rightIntratype = accessorOrderings.get(rightKey);
+        Preconditions.checkNotNull(leftIntratype, "intratype not found by key: %s", leftKey);
+        Preconditions.checkNotNull(rightIntratype, "intratype not found by key: %s", rightKey);
         return leftIntratype == rightIntratype
             ? leftIntratype.ordering.compare(leftKey, rightKey)
             : Integer.compare(leftIntratype.rank, rightIntratype.rank);


### PR DESCRIPTION
When upgrading immutables (2.7.3 -> 2.7.5), it fails with NPE in
SourceOrdering (line 260).

Unfortunately, I cannot reproduce the NPE with small example, but
at least I can add some diagnostics, so next time I will try to
upgrade, I will have some clue where to start looking.

Generally, when obtaining an item from a map by key, one should not
assume the value is not null.