### PR TITLE
Generate X_Fields.java that simply lists all marshaled fields of X, for every class X marked with @Immutable

### DIFF
--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -20,6 +20,7 @@
 [output.java type.package type.typeImmutable.simple type.element]
 [generateImmutable type true]
 [/output.java]
+[generateFieldsFile type]
       [if type.generateWithInterface]
 [output.java type.package type.typeWith.simple type.element]
 [generateWithInterface type true]
@@ -37,8 +38,32 @@
 [output.java type.package type.typeEnclosing.simple type.element]
 [generateEnclosing type]
 [/output.java]
+[generateFieldsFile type]
     [/if]
   [/for]
+[/template]
+
+[template generateFieldsFile Type type]
+[output.java type.package (type.name '_Fields') type.element]
+[type.sourceHeader]
+[generateFields type]
+[/output.java]
+[/template]
+
+[template generateFields Type type]
+[if type.package]
+package [type.package];
+[/if]
+
+[for starImport in type.requiredSourceStarImports]
+import [starImport];
+[/for]
+
+final class [type.name]_Fields[type.generics] {
+  [for a in type.allMarshalingAttributes]
+    public [a.type] [a.name];
+  [/for]
+}
 [/template]
 
 [template annotationsWhenTopLevel Type type Boolean is]


### PR DESCRIPTION
The main driver for this change is to be able to determine the schema of objects (X in our example) that are persisted in a database like mongoDB. Since there is no way to inspect private fields of the Immutable class using reflection, the closest alternative is to inspect the mutator methods on the Immutable Builder class. But that approach is hacky, because the builder class has additional methods (equals, from, wait and collection utility methods like addAll, remove, set, etc.). Also the builder sometimes has overloaded methods, e.g. if a field is of type Optional<T>. Also fields annotated with @Gson.Ignore can't be excluded from the schema, when enumerating mutators on the Builder. Thus generating a new _Fields class seems to be the best available option to be able to determine a database schema.