### PR TITLE
Fix suppress warnings for generated MongoDB repositories

### DIFF
--- a/value-processor/src/org/immutables/value/processor/Repositories.generator
+++ b/value-processor/src/org/immutables/value/processor/Repositories.generator
@@ -57,7 +57,9 @@ import [starImport];
  [/if]
  */
 [atGenerated type]
-[if type.generateSuppressAllWarnings]@SuppressWarnings("all")[/if]
+[if type.generatedSuppressWarnings]
+@SuppressWarnings({[for k in type.generatedSuppressWarnings][if not for.first], [/if][literal k][/for]})
+[/if]
 [if type allowsClasspathAnnotation 'javax.annotation.ParametersAreNonnullByDefault']
 @javax.annotation.ParametersAreNonnullByDefault
 [/if]


### PR DESCRIPTION
This fixes issues to copy over set custom `@SuppressWarnings` annotations.