### PR TITLE
Add support for Modifiable to extend an inner class/interface

### DIFF
--- a/value-annotations/src/org/immutables/value/Value.java
+++ b/value-annotations/src/org/immutables/value/Value.java
@@ -664,6 +664,12 @@ public @interface Value {
     String typeModifiable() default "Modifiable*";
 
     /**
+     * Inner builder class name which will be matched to be extend/super for generated Modifiable class.
+     * @return naming template
+     */
+    String typeInnerModifiable() default "Modifiable";
+
+    /**
      * Generated "with" interface name. Used to detect a demand and generate "with" interface.
      * @return naming template
      */

--- a/value-processor/src/org/immutables/value/processor/Modifiables.generator
+++ b/value-processor/src/org/immutables/value/processor/Modifiables.generator
@@ -65,9 +65,17 @@ Use @Value.Modifiable cannot be used with @Value.Immutable which implements Ordi
      LongPositions positions = longsFor mandatories,
      LongPositions nondefaultsPositions = longsFor nondefaults]
 [type.typeImmutable.access][if not topLevel]static [/if][if type.names.create ne 'new']final [/if][output.linesShortable]class [type.names.typeModifiable][type.generics]
+  [if type.innerModifiable.isSuper]
+    [if type.innerModifiable.isInterface]
+    extends [type.typeAbstract] implements [type.typeAbstract.relativeRaw].[type.innerModifiable.simpleName][type.innerModifiable.generics.args][if type.serial.shouldImplement], java.io.Serializable[/if] {
+    [else]
+    extends [type.typeAbstract.relativeRaw].[type.innerModifiable.simpleName][type.innerModifiable.generics.args][if type.serial.shouldImplement] implements java.io.Serializable[/if] {
+    [/if]
+  [else]
     [if type.implementing]implements[else]extends[/if] [type.typeAbstract][if type.serial.shouldImplement][if type.implementing],
         [else]
-    implements [/if]java.io.Serializable[/if] {[/output.linesShortable]
+    implements [/if]java.io.Serializable[/if] {
+  [/if][/output.linesShortable]
 [if type.serial.enabled]
   [for serialVersion = type.serialVersionUID]
     [if serialVersion]

--- a/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
+++ b/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
@@ -156,6 +156,10 @@ public abstract class StyleInfo implements ValueMirrors.Style {
 
   @Value.Parameter
   @Override
+  public abstract String typeInnerModifiable();
+
+  @Value.Parameter
+  @Override
   public abstract String typeWith();
 
   @Value.Parameter
@@ -419,6 +423,7 @@ public abstract class StyleInfo implements ValueMirrors.Style {
         input.typeImmutableEnclosing(),
         input.typeImmutableNested(),
         input.typeModifiable(),
+        input.typeInnerModifiable(),
         input.typeWith(),
         input.packageGenerated(),
         ToImmutableInfo.FUNCTION.apply(input.defaults()),

--- a/value-processor/src/org/immutables/value/processor/meta/Styles.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Styles.java
@@ -108,6 +108,7 @@ public final class Styles {
     Naming create = Naming.from(style.create());
     Naming toImmutable = Naming.from(style.toImmutable());
     Naming typeModifiable = Naming.from(style.typeModifiable());
+    Naming typeInnerModifiable = Naming.from(style.typeInnerModifiable());
 
     Naming[] attributeBuilder = Naming.fromAll(style.attributeBuilder());
     Naming getBuilder = Naming.from(style.getBuilder());

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -149,6 +149,8 @@ public final class ValueMirrors {
 
     String typeModifiable() default "Modifiable*";
 
+    String typeInnerModifiable() default "Modifiable";
+
     String typeWith() default "With*";
 
     String packageGenerated() default "*";

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -64,6 +64,7 @@ import org.immutables.value.processor.meta.AnnotationInjections.AnnotationInject
 import org.immutables.value.processor.meta.AnnotationInjections.InjectAnnotation.Where;
 import org.immutables.value.processor.meta.Constitution.AppliedNameForms;
 import org.immutables.value.processor.meta.Constitution.InnerBuilderDefinition;
+import org.immutables.value.processor.meta.Constitution.InnerModifiableDefinition;
 import org.immutables.value.processor.meta.Constitution.NameForms;
 import org.immutables.value.processor.meta.Proto.DeclaringType;
 import org.immutables.value.processor.meta.Proto.Environment;
@@ -651,6 +652,10 @@ public final class ValueType extends TypeIntrospectionBase implements HasStyleIn
 
   public InnerBuilderDefinition getInnerBuilder() {
     return constitution.innerBuilder();
+  }
+
+  public InnerModifiableDefinition getInnerModifiable() {
+    return constitution.innerModifiable();
   }
 
   public String getDocumentName() {


### PR DESCRIPTION
I was hoping for this feature, and saw several other people had been requesting it, so I decided to take a stab at it.

Turns the current class for the innerBuilder which is extended by Builder and Modifiable implementations.

Supports both classes and interfaces, and will complain if it's a class that does not extend the base Abstract one.