### PR TITLE
Support OQL String queries

### DIFF
--- a/criteria/common/test/org/immutables/criteria/personmodel/AbstractPersonTest.java
+++ b/criteria/common/test/org/immutables/criteria/personmodel/AbstractPersonTest.java
@@ -58,7 +58,8 @@ public abstract class AbstractPersonTest {
     ORDER_BY,
     REGEX, // regular expression for match() operator
     // TODO re-use Operator interface as feature flag
-    STRING_PREFIX_SUFFIX, // startsWith / endsWith operators a are supported
+    STRING_EMPTY, // supports empty/non-empty string or null values
+    STRING_PREFIX_SUFFIX, // startsWith / endsWith operators are supported
     ITERABLE_SIZE, // supports filtering on iterables sizes
     ITERABLE_CONTAINS, // can search inside inner collections
     STRING_LENGTH
@@ -526,7 +527,7 @@ public abstract class AbstractPersonTest {
    */
   @Test
   public void stringEmptyNotEmpty() {
-    assumeFeature(Feature.STRING_PREFIX_SUFFIX);
+    assumeFeature(Feature.STRING_EMPTY);
     final PersonGenerator generator = new PersonGenerator();
     insert(generator.next().withFullName("John").withNickName(Optional.empty()));
     insert(generator.next().withFullName("Adam").withNickName(""));

--- a/criteria/elasticsearch/test/org/immutables/criteria/elasticsearch/ElasticPersonTest.java
+++ b/criteria/elasticsearch/test/org/immutables/criteria/elasticsearch/ElasticPersonTest.java
@@ -86,7 +86,9 @@ public class ElasticPersonTest extends AbstractPersonTest  {
   protected Set<Feature> features() {
     return EnumSet.of(Feature.DELETE, Feature.QUERY, Feature.QUERY_WITH_LIMIT,
             Feature.QUERY_WITH_PROJECTION,
-            Feature.QUERY_WITH_OFFSET, Feature.ORDER_BY, Feature.STRING_PREFIX_SUFFIX);
+            Feature.QUERY_WITH_OFFSET, Feature.ORDER_BY,
+            Feature.STRING_EMPTY, Feature.STRING_PREFIX_SUFFIX
+    );
   }
 
   @Override

--- a/criteria/geode/test/org/immutables/criteria/geode/AutocreateRegion.java
+++ b/criteria/geode/test/org/immutables/criteria/geode/AutocreateRegion.java
@@ -28,8 +28,12 @@ class AutocreateRegion implements Consumer<Class<?>> {
   private final ContainerNaming naming;
 
   AutocreateRegion(Cache cache) {
+    this(cache, ContainerNaming.DEFAULT);
+  }
+
+  AutocreateRegion(Cache cache, ContainerNaming containerNaming) {
     this.cache = cache;
-    this.naming = ContainerNaming.DEFAULT;
+    this.naming = containerNaming;
   }
 
   @Override

--- a/criteria/geode/test/org/immutables/criteria/geode/GeodeIntegrationTest.java
+++ b/criteria/geode/test/org/immutables/criteria/geode/GeodeIntegrationTest.java
@@ -54,18 +54,6 @@ class GeodeIntegrationTest {
       super(backend);
     }
 
-    @Disabled
-    @Override
-    protected void startsWith() {}
-
-    @Disabled
-    @Override
-    protected void endsWith() {}
-
-    @Disabled
-    @Override
-    protected void contains() {}
-
     @Disabled("optionals don't work well in Geode yet (pdx serialization)")
     @Override
     protected void optional() {}

--- a/criteria/geode/test/org/immutables/criteria/geode/GeodePersonTest.java
+++ b/criteria/geode/test/org/immutables/criteria/geode/GeodePersonTest.java
@@ -43,7 +43,9 @@ public class GeodePersonTest extends AbstractPersonTest  {
   protected Set<Feature> features() {
     return EnumSet.of(
             Feature.DELETE, Feature.QUERY, Feature.QUERY_WITH_LIMIT, Feature.ORDER_BY, Feature.QUERY_WITH_PROJECTION,
-            Feature.ITERABLE_SIZE, Feature.ITERABLE_CONTAINS
+            Feature.ITERABLE_SIZE, Feature.ITERABLE_CONTAINS, Feature.STRING_PREFIX_SUFFIX
+            // todo: enable String length and Regex feautes once Pdx issue resolved
+            // Feature.STRING_LENGTH, Feature.REGEX
     );
   }
 

--- a/criteria/geode/test/org/immutables/criteria/geode/GeodePojoTest.java
+++ b/criteria/geode/test/org/immutables/criteria/geode/GeodePojoTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2019 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.criteria.geode;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.query.FunctionDomainException;
+import org.apache.geode.cache.query.NameResolutionException;
+import org.apache.geode.cache.query.QueryInvocationTargetException;
+import org.apache.geode.cache.query.SelectResults;
+import org.apache.geode.cache.query.TypeMismatchException;
+import org.immutables.criteria.backend.ContainerNaming;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(GeodeExtension.class)
+public class GeodePojoTest {
+
+  private final Cache cache;
+  private final ContainerNaming containerNaming;
+  private final AutocreateRegion autocreate;
+
+  private Region<String, GeodePojo> region;
+
+  public GeodePojoTest(Cache cache) {
+    this.cache = cache;
+    this.containerNaming = ContainerNaming.DEFAULT;
+    this.autocreate = new AutocreateRegion(cache, containerNaming);
+  }
+
+  @BeforeEach
+  void setUp() {
+    autocreate.accept(GeodePojo.class);
+
+    region = cache.getRegion(containerNaming.name(GeodePojo.class));
+
+    setUpTestData();
+  }
+
+  @Test
+  void regex() throws NameResolutionException, TypeMismatchException, QueryInvocationTargetException, FunctionDomainException {
+    final String query = "SELECT COUNT(*) FROM /geodePojo where name.matches($1)";
+    Assertions.assertEquals(1, executeCountQuery(query, "\\w+"));
+    Assertions.assertEquals(2, executeCountQuery(query, "\\w*"));
+    Assertions.assertEquals(2, executeCountQuery(query, "^\\w+\\s\\w+$"));
+  }
+
+  @Test
+  void stringNull() throws NameResolutionException, TypeMismatchException, QueryInvocationTargetException, FunctionDomainException {
+    Assertions.assertEquals(1, executeCountQuery("SELECT COUNT(*) FROM /geodePojo where name = null"));
+    Assertions.assertEquals(4, executeCountQuery("SELECT COUNT(*) FROM /geodePojo where name != null"));
+  }
+
+  @Test
+  void stringEmpty() throws NameResolutionException, TypeMismatchException, QueryInvocationTargetException, FunctionDomainException {
+    Assertions.assertEquals(1, executeCountQuery("SELECT COUNT(*) FROM /geodePojo where name = ''"));
+  }
+
+  @Test
+  void stringNotEmpty() throws NameResolutionException, TypeMismatchException, QueryInvocationTargetException, FunctionDomainException {
+    Assertions.assertEquals(4, executeCountQuery("SELECT COUNT(*) FROM /geodePojo where name != ''"));
+  }
+
+  @Test
+  void stringLength() throws NameResolutionException, TypeMismatchException, QueryInvocationTargetException, FunctionDomainException {
+    final String query = "SELECT COUNT(*) FROM /geodePojo where name.length = $1";
+    Assertions.assertEquals(1, executeCountQuery(query, 0));
+    Assertions.assertEquals(2, executeCountQuery(query, 8));
+  }
+
+  private int executeCountQuery(String query, Object... bindVariables) throws NameResolutionException, TypeMismatchException, QueryInvocationTargetException, FunctionDomainException {
+    return ((SelectResults<Integer>) execute(query, bindVariables)).stream()
+            .findAny().orElseThrow(IllegalArgumentException::new);
+  }
+
+  private Object execute(String query, Object... bindVariables) throws FunctionDomainException, TypeMismatchException, NameResolutionException, QueryInvocationTargetException {
+    return cache.getQueryService().newQuery(query).execute(bindVariables);
+  }
+
+  private void setUpTestData() {
+    Map<String, GeodePojo> pojos = createPojos();
+    region.putAll(pojos);
+  }
+
+  private static Map<String, GeodePojo> createPojos() {
+    final Function<GeodePojo, String> toName = GeodePojo::getName;
+    return createPojos("John Doe", "Jane Doe", "Joe", "", null)
+            .collect(Collectors.toMap(toName.andThen(Objects::toString), Function.identity()));
+  }
+
+  private static Stream<GeodePojo> createPojos(String... names) {
+    return Arrays.stream(names).map(name -> {
+      final GeodePojo pojo = new GeodePojo();
+      pojo.setName(name);
+      return pojo;
+    });
+  }
+
+  public static class GeodePojo {
+
+    String name;
+
+    public String getName() {
+      return name;
+    }
+
+    public GeodePojo setName(String name) {
+      this.name = name;
+      return this;
+    }
+
+  }
+}

--- a/criteria/geode/test/org/immutables/criteria/geode/GeodeQueryVisitorTest.java
+++ b/criteria/geode/test/org/immutables/criteria/geode/GeodeQueryVisitorTest.java
@@ -4,6 +4,8 @@ import static org.immutables.check.Checkers.check;
 import static org.immutables.criteria.matcher.Matchers.toExpression;
 import static org.immutables.criteria.personmodel.PersonCriteria.person;
 
+import java.util.regex.Pattern;
+
 import org.immutables.criteria.backend.PathNaming;
 import org.immutables.criteria.personmodel.ImmutablePet;
 import org.immutables.criteria.personmodel.PersonCriteria;
@@ -97,6 +99,32 @@ class GeodeQueryVisitorTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             toOql(person.pets.contains(pet));
         });
+    }
+
+    @Test
+    void filterString() {
+        check(toOql(person.fullName.isEmpty())).is("fullName = ''");
+        check(toOql(person.fullName.notEmpty())).is("fullName != ''");
+
+        check(toOql(person.fullName.hasLength(5))).is("fullName.length = 5");
+        check(toOql(person.fullName.contains("Blog"))).is("fullName LIKE '%Blog%'");
+        check(toOql(person.fullName.startsWith("Joe"))).is("fullName LIKE 'Joe%'");
+        check(toOql(person.fullName.endsWith("Bloggs"))).is("fullName LIKE '%Bloggs'");
+
+        check(toOql(person.fullName.matches(Pattern.compile("\\w+")))).is("fullName.matches('\\w+')");
+    }
+
+    @Test
+    void filterStringWithBindParams() {
+        check(toOqlWithBindParams(person.fullName.isEmpty())).is("fullName = $1");
+        check(toOqlWithBindParams(person.fullName.notEmpty())).is("fullName != $1");
+
+        check(toOqlWithBindParams(person.fullName.hasLength(5))).is("fullName.length = $1");
+        check(toOqlWithBindParams(person.fullName.contains("Blog"))).is("fullName LIKE $1");
+        check(toOqlWithBindParams(person.fullName.startsWith("Joe"))).is("fullName LIKE $1");
+        check(toOqlWithBindParams(person.fullName.endsWith("Bloggs"))).is("fullName LIKE $1");
+
+        check(toOqlWithBindParams(person.fullName.matches(Pattern.compile("\\w+")))).is("fullName.matches($1)");
     }
 
     @Test

--- a/criteria/inmemory/test/org/immutables/criteria/inmemory/InMemoryPersonTest.java
+++ b/criteria/inmemory/test/org/immutables/criteria/inmemory/InMemoryPersonTest.java
@@ -32,6 +32,7 @@ public class InMemoryPersonTest extends AbstractPersonTest  {
             Feature.ORDER_BY,
             Feature.QUERY_WITH_PROJECTION,
             Feature.QUERY_WITH_OFFSET, Feature.REGEX,
+            Feature.STRING_EMPTY,
             Feature.STRING_PREFIX_SUFFIX,
             Feature.ITERABLE_SIZE,
             Feature.ITERABLE_CONTAINS,

--- a/criteria/mongo/test/org/immutables/criteria/mongo/MongoPersonTest.java
+++ b/criteria/mongo/test/org/immutables/criteria/mongo/MongoPersonTest.java
@@ -41,6 +41,7 @@ public class MongoPersonTest extends AbstractPersonTest {
     return EnumSet.of(Feature.DELETE, Feature.QUERY, Feature.QUERY_WITH_LIMIT,
             Feature.QUERY_WITH_PROJECTION,
             Feature.QUERY_WITH_OFFSET, Feature.ORDER_BY, Feature.REGEX,
+            Feature.STRING_EMPTY,
             Feature.STRING_PREFIX_SUFFIX,
             Feature.ITERABLE_SIZE,
             Feature.ITERABLE_CONTAINS,


### PR DESCRIPTION
Adds support to OQL generator for subset of String queries

Regex, length, and empty queries currently fail for Immutables but pass for a regular POJO; this likely indicates an issue with the PDX (De)Serialisation.