### PR TITLE
SuppressedWarnings: if it's deprecated, also suppress forRemoval

### DIFF
--- a/value-processor/src/org/immutables/value/processor/meta/SuppressedWarnings.java
+++ b/value-processor/src/org/immutables/value/processor/meta/SuppressedWarnings.java
@@ -27,6 +27,7 @@ final class SuppressedWarnings {
   private static final String GENERATED = "generated";
   private static final String RAWTYPES = "rawtypes";
   private static final String DEPRECATION = "deprecation";
+  private static final String REMOVAL = "removal";
   private static final String IMMUTABLES_FROM = "immutables:from";
   private static final String IMMUTABLES_SUBTYPE = "immutables:subtype";
   private static final String IMMUTABLES_UNTYPE = "immutables:untype";
@@ -137,6 +138,7 @@ final class SuppressedWarnings {
     }
     if (deprecated) {
       generatedSuppressions.add(DEPRECATION);
+      generatedSuppressions.add(REMOVAL);
     }
     return new SuppressedWarnings(
         all,


### PR DESCRIPTION
Newer Java allows you to mark things as `@Deprecated(forRemoval=true)` which requires a separate warning to be suppressed.

For simplicity's sake, just always add it to the suppress list since it's not harmful if unused.