### PR TITLE
Unit tests for Modifiable to extend an inner class/interface

### DIFF
--- a/value-fixture/src/org/immutables/fixture/modifiable/WithModifiableInterface.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/WithModifiableInterface.java
@@ -1,0 +1,44 @@
+/*
+   Copyright 2016 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.fixture.modifiable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.immutables.value.Value;
+
+/**
+ * This class illustrates an Immutables object with an interface which the
+ * Modifiable version implements.
+ */
+@Value.Immutable
+@Value.Modifiable
+abstract class WithModifiableInterface {
+    public abstract List<Float> getPrices();
+    abstract List<Float> getPricesWithSalesTax();
+
+    interface Modifiable
+    {
+        List<Float> getPrices();
+
+        public Modifiable setPricesWithSalesTax(Iterable<Float> prices);
+
+        default void computePricesWithTaxRate(float salesTaxRate)
+        {
+            setPricesWithSalesTax(this.getPrices().stream()
+                    .map(x -> x*(1.0f+salesTaxRate)).collect(Collectors.toList()));
+        }
+    }
+}

--- a/value-fixture/src/org/immutables/fixture/modifiable/WithModifiableSuperclass.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/WithModifiableSuperclass.java
@@ -1,0 +1,41 @@
+/*
+   Copyright 2016 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.fixture.modifiable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.immutables.value.Value;
+
+/**
+ * This class illustrates an Immutables object with an internal class from
+ * which the Modifiable version extends.
+ */
+@Value.Modifiable
+abstract class WithModifiableSuperclass {
+    abstract List<Float> getPrices();
+    abstract List<Float> getPricesWithSalesTax();
+
+    static abstract class Modifiable extends WithModifiableSuperclass
+    {
+        abstract Modifiable setPricesWithSalesTax(Iterable<Float> prices);
+
+        void computePricesWithTaxRate(float salesTaxRate)
+        {
+            setPricesWithSalesTax(this.getPrices().stream()
+                    .map(x -> x*(1.0f+salesTaxRate)).collect(Collectors.toList()));
+        }
+    }
+}

--- a/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
+++ b/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
@@ -323,4 +323,24 @@ public class ModifiablesTest {
     check(ModifiableDefaultMap.create().putAllMap(Collections.emptyMap()).mapIsSet());
     check(ModifiableDefaultMap.create().putAllMap(Collections.singletonMap("a", "b")).mapIsSet());
   }
+
+  @Test
+  public void modifiablesWithInnerSuperclass() {
+    ModifiableWithModifiableSuperclass m1 = ModifiableWithModifiableSuperclass.create();
+    m1.addPrices(1.00f);
+    m1.addPrices(2.00f);
+    m1.computePricesWithTaxRate(0.06f);
+    check(m1.getPrices()).isOf(1.00f, 2.00f);
+    check(m1.getPricesWithSalesTax()).isOf(1.06f, 2.12f);
+  }
+
+  @Test
+  public void modifiablesWithInnerInterface() {
+    ModifiableWithModifiableInterface m1 = ModifiableWithModifiableInterface.create();
+    m1.addPrices(1.00f);
+    m1.addPrices(2.00f);
+    m1.computePricesWithTaxRate(0.06f);
+    check(m1.getPrices()).isOf(1.00f, 2.00f);
+    check(m1.getPricesWithSalesTax()).isOf(1.06f, 2.12f);
+  }
 }

--- a/value-processor/src/org/immutables/value/processor/meta/Constitution.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Constitution.java
@@ -694,6 +694,12 @@ public abstract class Constitution {
       super(names().namings.typeInnerBuilder);
     }
 
+    @Override
+    protected boolean isApplicableTo(Protoclass p) {
+      return p.kind().isValue();
+    }
+
+    @Override
     protected boolean isExtending(TypeElement element) {
       if (element.getKind() == ElementKind.CLASS) {
         String superclassString = SourceExtraction.getSuperclassString(element);
@@ -705,6 +711,7 @@ public abstract class Constitution {
       return false;
     }
 
+    @Override
     protected void lateValidateExtending(TypeElement t) {
       super.lateValidateExtending(t);
 
@@ -728,10 +735,17 @@ public abstract class Constitution {
       super(names().namings.typeInnerModifiable);
     }
 
+    @Override
+    protected boolean isApplicableTo(Protoclass p) {
+      return p.kind().isModifiable();
+    }
+
+    @Override
     protected boolean isExtending(TypeElement t) {
       return false;
     }
 
+    @Override
     protected void lateValidateSuper(TypeElement t) {
       super.lateValidateSuper(t);
 
@@ -850,12 +864,20 @@ public abstract class Constitution {
       }
     }
 
+    /**
+     * Used to determine if the inner class we're looking for is revelant
+     * given the annotations on the prototype class.  For example, there's
+     * no point in doing anything with an Modifiable inner class if it's
+     * not setup with the Value.Modifiable annotation.
+     */
+    protected abstract boolean isApplicableTo(Protoclass p);
+
     protected abstract boolean isExtending(TypeElement t);
 
     @Nullable
     private TypeElement findBaseClassElement() {
       Protoclass protoclass = protoclass();
-      if (!protoclass.kind().isValue()) {
+      if (!isApplicableTo(protoclass)) {
         return null;
       }
       for (Element t : protoclass.sourceElement().getEnclosedElements()) {


### PR DESCRIPTION
Here are a few simple unit tests illustrating the functionality included in the previous pull request (#1140).

I discover one issue which is fixed here -- all my original test classes had both Value.Immutable and Value.Modifiable annotations;  and this change would fail to kick in if Value.Immutable was set.  This has been corrected, as illustrated in one of the attached tests.