### PR TITLE
Truncate strings or values of type variables in `toString` method that are longer than a defined length

### DIFF
--- a/value-annotations/src/org/immutables/value/Value.java
+++ b/value-annotations/src/org/immutables/value/Value.java
@@ -1406,6 +1406,12 @@ public @interface Value {
     Class<? extends Annotation>[] allowedClasspathAnnotations() default {};
 
     /**
+     * Setting to cut strings longer than a defined length when calling the toString method.
+     * @return string limit
+     */
+    int limitStringLengthInToString() default 1000;
+
+    /**
      * If implementation visibility is more restrictive than visibility of abstract value type, then
      * implementation type will not be exposed as a return type of {@code build()} or {@code of()}
      * constructon methods. Builder visibility will follow.

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -3165,6 +3165,14 @@ private int [disambiguateAccessor type 'computeHashCode']() {
 [template generateToString Type type]
 [if not type.toStringDefined]
 
+static String objectToString(Object input, int limit) {
+    if (input == null) {
+        return null;
+    }
+    String output = input.toString();
+    return output.length() > limit ? output.substring(0, limit).concat("…") : output;
+}
+
 /**
  * Prints the immutable value {@code [type.name]}[if type.equivalenceAttributes] with attribute values[/if].
  * @return A string representation of the value
@@ -4380,6 +4388,6 @@ private static final long serialVersionUID = [literal serialVersion];
 
 [template castObject String typename][if typename ne 'java.lang.Object']([typename]) [/if][/template]
 
-[template maybeMasked Attribute a String value][if a.redactedMask][literal.string a.redactedMask][else][value][/if][/template]
+[template maybeMasked Attribute a String value][if a.redactedMask][literal.string a.redactedMask][else if a.limitStringLengthInToString and (a.stringType or a.optionalStringType)]objectToString([value], [a.limitStringLengthInToString])[else if a.limitStringLengthInToString and a.hasTypeVariables]objectToString([value], [a.limitStringLengthInToString])[else][value][/if][/template]
 
 [template hiddenMutableState Type type][if type allowsClasspathAnnotation 'com.google.errorprone.annotations.Immutable']@SuppressWarnings("Immutable")[/if][/template]

--- a/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
+++ b/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
@@ -399,6 +399,9 @@ public abstract class StyleInfo implements ValueMirrors.Style {
     throw new UnsupportedOperationException("Use StyleInfo.allowedClasspathAnnotationsNames() instead");
   }
 
+  @Value.Parameter
+  public abstract int limitStringLengthInToString();
+
   static StyleInfo infoFrom(StyleMirror input) {
     return ImmutableStyleInfo.of(
         input.get(),
@@ -481,6 +484,7 @@ public abstract class StyleInfo implements ValueMirrors.Style {
         input.addAllBuilder(),
         input.getBuilders(),
         input.nullableAnnotation(),
-        ImmutableSet.copyOf(input.allowedClasspathAnnotationsName()));
+        ImmutableSet.copyOf(input.allowedClasspathAnnotationsName()),
+        input.limitStringLengthInToString());
   }
 }

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -167,6 +167,10 @@ public final class ValueAttribute extends TypeIntrospectionBase implements HasSt
     return String.class.getName().equals(rawTypeName);
   }
 
+  public boolean isOptionalStringType() {
+    return isOptionalType() && getGenericArgs().equals("<" + String.class.getName() + ">");
+  }
+
   public boolean charType() {
     return returnType.getKind() == TypeKind.CHAR;
   }
@@ -1855,6 +1859,14 @@ public final class ValueAttribute extends TypeIntrospectionBase implements HasSt
 
   public String atNullableInSupertypeLocal() {
     return nullabilityInSupertype != null ? nullabilityInSupertype.asLocalPrefix() : "";
+  }
+
+  public int getLimitStringLengthInToString() {
+    return protoclass().styles().style().limitStringLengthInToString();
+  }
+
+  public boolean isLimitStringLengthInToString() {
+    return protoclass().styles().style().limitStringLengthInToString() > 0;
   }
 
   enum ToName implements Function<ValueAttribute, String> {

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -249,6 +249,8 @@ public final class ValueMirrors {
 
     String nullableAnnotation() default "Nullable";
 
+    int limitStringLengthInToString() default 1000;
+
     Class<? extends Annotation>[] allowedClasspathAnnotations() default {};
 
     public enum ImplementationVisibility {


### PR DESCRIPTION
The idea is to avoid errors when logging immutable objects which carry a lot of data encoded as strings or type variables. This saves us from writing custom `toString` methods to avoid excessive logging when a lot of data gets transported with an immutable to be logged.

Please let me know what you think about it.