### PR TITLE
#1189: criteria-geode backend toLowerCase/toUpperCase add parentheses

### DIFF
--- a/criteria/geode/src/org/immutables/criteria/geode/GeodeQueryVisitor.java
+++ b/criteria/geode/src/org/immutables/criteria/geode/GeodeQueryVisitor.java
@@ -115,9 +115,9 @@ class GeodeQueryVisitor extends AbstractExpressionVisitor<Oql> {
             "Size should be == 1 for unary operator %s but was %s", op, args.size());
 
     Expression arg0 = args.get(0);
+    String path = arg0.accept(this).oql();
     if (op instanceof OptionalOperators) {
       // use IS_DEFINED / IS_UNDEFINED functions
-      String path = arg0.accept(this).oql();
       String expr;
       if (op == OptionalOperators.IS_PRESENT) {
         expr = String.format("is_defined(%s) AND %s != null", path, path);
@@ -126,9 +126,9 @@ class GeodeQueryVisitor extends AbstractExpressionVisitor<Oql> {
       }
       return oql(expr);
     } else if (op == Operators.NOT) {
-      return oql("NOT (" + arg0.accept(this).oql() + ")");
-    }  else if (op == IterableOperators.IS_EMPTY || op == StringOperators.TO_LOWER_CASE || op == StringOperators.TO_UPPER_CASE) {
-      return oql(arg0.accept(this).oql() + "." + toMethodName(op));
+      return oql(String.format("NOT (%s)", path));
+    } else if (op == IterableOperators.IS_EMPTY || op == StringOperators.TO_LOWER_CASE || op == StringOperators.TO_UPPER_CASE) {
+      return oql(String.format("%s.%s()", path, toMethodName(op)));
     }
 
     throw new UnsupportedOperationException("Unknown unary operator " + call);

--- a/criteria/geode/test/org/immutables/criteria/geode/GeodeQueryVisitorTest.java
+++ b/criteria/geode/test/org/immutables/criteria/geode/GeodeQueryVisitorTest.java
@@ -68,8 +68,8 @@ class GeodeQueryVisitorTest {
 
         @Test
         void filterCollection() {
-            oql(person.interests.isEmpty()).is("interests.isEmpty");
-            oql(person.interests.notEmpty()).is("NOT (interests.isEmpty)");
+            oql(person.interests.isEmpty()).is("interests.isEmpty()");
+            oql(person.interests.notEmpty()).is("NOT (interests.isEmpty())");
             oql(person.interests.hasSize(1)).is("interests.size = $1");
             oql(person.interests.contains("OSS")).is("interests.contains($1)");
         }
@@ -114,13 +114,13 @@ class GeodeQueryVisitorTest {
 
         @Test
         void upperLower() {
-            oql(person.fullName.toUpperCase().is("A")).is("fullName.toUpperCase = $1");
-            oql(person.fullName.toLowerCase().is("A")).is("fullName.toLowerCase = $1");
-            oql(person.fullName.toLowerCase().isNot("A")).is("fullName.toLowerCase != $1");
-            oql(person.fullName.toLowerCase().in(Arrays.asList("a", "b"))).is("fullName.toLowerCase IN $1");
-            oql(person.fullName.toLowerCase().notIn(Arrays.asList("a", "b"))).is("NOT (fullName.toLowerCase IN $1)");
-            oql(person.fullName.toLowerCase().toUpperCase().is("A")).is("fullName.toLowerCase.toUpperCase = $1");
-            oql(person.fullName.toLowerCase().endsWith("A")).is("fullName.toLowerCase.endsWith($1)");
+            oql(person.fullName.toUpperCase().is("A")).is("fullName.toUpperCase() = $1");
+            oql(person.fullName.toLowerCase().is("A")).is("fullName.toLowerCase() = $1");
+            oql(person.fullName.toLowerCase().isNot("A")).is("fullName.toLowerCase() != $1");
+            oql(person.fullName.toLowerCase().in(Arrays.asList("a", "b"))).is("fullName.toLowerCase() IN $1");
+            oql(person.fullName.toLowerCase().notIn(Arrays.asList("a", "b"))).is("NOT (fullName.toLowerCase() IN $1)");
+            oql(person.fullName.toLowerCase().toUpperCase().is("A")).is("fullName.toLowerCase().toUpperCase() = $1");
+            oql(person.fullName.toLowerCase().endsWith("A")).is("fullName.toLowerCase().endsWith($1)");
         }
 
 
@@ -149,13 +149,13 @@ class GeodeQueryVisitorTest {
 
         @Test
         void upperLower() {
-            oql(person.fullName.toUpperCase().is("A")).is("fullName.toUpperCase = 'A'");
-            oql(person.fullName.toLowerCase().is("A")).is("fullName.toLowerCase = 'A'");
-            oql(person.fullName.toLowerCase().isNot("A")).is("fullName.toLowerCase != 'A'");
-            oql(person.fullName.toLowerCase().in(Arrays.asList("a", "b"))).is("fullName.toLowerCase IN SET('a', 'b')");
-            oql(person.fullName.toLowerCase().notIn(Arrays.asList("a", "b"))).is("NOT (fullName.toLowerCase IN SET('a', 'b'))");
-            oql(person.fullName.toLowerCase().toUpperCase().is("A")).is("fullName.toLowerCase.toUpperCase = 'A'");
-            oql(person.fullName.toLowerCase().endsWith("A")).is("fullName.toLowerCase.endsWith('A')");
+            oql(person.fullName.toUpperCase().is("A")).is("fullName.toUpperCase() = 'A'");
+            oql(person.fullName.toLowerCase().is("A")).is("fullName.toLowerCase() = 'A'");
+            oql(person.fullName.toLowerCase().isNot("A")).is("fullName.toLowerCase() != 'A'");
+            oql(person.fullName.toLowerCase().in(Arrays.asList("a", "b"))).is("fullName.toLowerCase() IN SET('a', 'b')");
+            oql(person.fullName.toLowerCase().notIn(Arrays.asList("a", "b"))).is("NOT (fullName.toLowerCase() IN SET('a', 'b'))");
+            oql(person.fullName.toLowerCase().toUpperCase().is("A")).is("fullName.toLowerCase().toUpperCase() = 'A'");
+            oql(person.fullName.toLowerCase().endsWith("A")).is("fullName.toLowerCase().endsWith('A')");
         }
 
         @Test
@@ -198,8 +198,8 @@ class GeodeQueryVisitorTest {
 
         @Test
         void filterCollection() {
-            oql(person.interests.isEmpty()).is("interests.isEmpty");
-            oql(person.interests.notEmpty()).is("NOT (interests.isEmpty)");
+            oql(person.interests.isEmpty()).is("interests.isEmpty()");
+            oql(person.interests.notEmpty()).is("NOT (interests.isEmpty())");
             oql(person.interests.hasSize(1)).is("interests.size = 1");
             oql(person.interests.contains("OSS")).is("interests.contains('OSS')");
         }

--- a/criteria/geode/test/org/immutables/criteria/geode/OqlGeneratorTest.java
+++ b/criteria/geode/test/org/immutables/criteria/geode/OqlGeneratorTest.java
@@ -131,16 +131,16 @@ class OqlGeneratorTest {
   @Test
   void upperLower() {
     check(generate(person.fullName.toLowerCase().is("a")))
-            .is("SELECT * FROM /myRegion WHERE fullName.toLowerCase = $1");
+            .is("SELECT * FROM /myRegion WHERE fullName.toLowerCase() = $1");
 
     check(generate(Query.of(Person.class).withFilter(toExpression(person.fullName.toUpperCase().is("A")))))
-            .is("SELECT * FROM /myRegion WHERE fullName.toUpperCase = $1");
+            .is("SELECT * FROM /myRegion WHERE fullName.toUpperCase() = $1");
 
     check(generate(Query.of(Person.class).withFilter(toExpression(person.fullName.toUpperCase().toLowerCase().is("A")))))
-            .is("SELECT * FROM /myRegion WHERE fullName.toUpperCase.toLowerCase = $1");
+            .is("SELECT * FROM /myRegion WHERE fullName.toUpperCase().toLowerCase() = $1");
 
     check(generate(Query.of(Person.class).withFilter(toExpression(person.fullName.toUpperCase().toLowerCase().toUpperCase().is("A")))))
-            .is("SELECT * FROM /myRegion WHERE fullName.toUpperCase.toLowerCase.toUpperCase = $1");
+            .is("SELECT * FROM /myRegion WHERE fullName.toUpperCase().toLowerCase().toUpperCase() = $1");
 
   }
 


### PR DESCRIPTION
This was a small change so I took a crack at it. Below is the log evidence that toUpperCase and toLowerCase is now working in my example app:

```
Jun 17, 2020 2:37:58 AM org.immutables.criteria.geode.SyncSelect call
FINE: Querying Geode with oql=[SELECT * FROM /person WHERE name.toLowerCase() = $1]  with 1 variables [$1=garrett]
Jun 17, 2020 2:37:58 AM Main main
INFO: toLowerCase() number of results: 2
Jun 17, 2020 2:37:58 AM org.immutables.criteria.geode.SyncSelect call
FINE: Querying Geode with oql=[SELECT * FROM /person WHERE name.toUpperCase() = $1]  with 1 variables [$1=GARRETT]
Jun 17, 2020 2:37:58 AM Main main
INFO: toUpperCase() number of results: 2
Jun 17, 2020 2:37:58 AM org.immutables.criteria.geode.SyncSelect call
FINE: Querying Geode with oql=[SELECT * FROM /person WHERE name = $1]  with 1 variables [$1=garrett]
Jun 17, 2020 2:37:58 AM Main main
INFO: is number of results: 1
```