### PR TITLE
Fix repository generation for custom generic types

### DIFF
--- a/mongo/test/org/immutables/mongo/fixture/MongoContext.java
+++ b/mongo/test/org/immutables/mongo/fixture/MongoContext.java
@@ -29,6 +29,9 @@ import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoDatabase;
 import de.bwaldvogel.mongo.MongoServer;
 import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
+import org.immutables.mongo.fixture.generic.GenericType;
+import org.immutables.mongo.fixture.generic.GenericTypeJsonSerializer;
+import org.immutables.mongo.fixture.generic.ImmutableGenericType;
 import org.immutables.mongo.fixture.holder.Holder;
 import org.immutables.mongo.fixture.holder.HolderJsonSerializer;
 import org.immutables.mongo.fixture.holder.ImmutableHolder;
@@ -128,6 +131,9 @@ public class MongoContext extends ExternalResource implements AutoCloseable  {
     final HolderJsonSerializer custom = new HolderJsonSerializer();
     gson.registerTypeAdapter(Holder.class, custom);
     gson.registerTypeAdapter(ImmutableHolder.class, custom);
+    final GenericTypeJsonSerializer genericTypeJsonSerializer = new GenericTypeJsonSerializer();
+    gson.registerTypeAdapter(GenericType.class, genericTypeJsonSerializer);
+    gson.registerTypeAdapter(ImmutableGenericType.class, genericTypeJsonSerializer);
 
     return gson.create();
   }

--- a/mongo/test/org/immutables/mongo/fixture/generic/GenericHolder.java
+++ b/mongo/test/org/immutables/mongo/fixture/generic/GenericHolder.java
@@ -1,0 +1,39 @@
+/*
+   Copyright 2017 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.mongo.fixture.generic;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.gson.Gson;
+import org.immutables.mongo.Mongo;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+@Gson.TypeAdapters
+@Mongo.Repository("genericHolder")
+@Value.Immutable
+@JsonSerialize(as = ImmutableGenericHolder.class)
+@JsonDeserialize(as = ImmutableGenericHolder.class)
+public interface GenericHolder {
+
+  @Mongo.Id
+  String id();
+
+  GenericType<?> value();
+
+  List<GenericType<?>> listOfValues();
+}

--- a/mongo/test/org/immutables/mongo/fixture/generic/GenericType.java
+++ b/mongo/test/org/immutables/mongo/fixture/generic/GenericType.java
@@ -1,0 +1,31 @@
+/*
+   Copyright 2017 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.mongo.fixture.generic;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableGenericType.class)
+@JsonDeserialize(as = ImmutableGenericType.class)
+public interface GenericType<T> {
+  String TYPE_PROPERTY = "@class";
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = TYPE_PROPERTY)
+  T value();
+}

--- a/mongo/test/org/immutables/mongo/fixture/generic/GenericTypeJsonSerializer.java
+++ b/mongo/test/org/immutables/mongo/fixture/generic/GenericTypeJsonSerializer.java
@@ -1,0 +1,81 @@
+/*
+   Copyright 2017 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.mongo.fixture.generic;
+
+import com.google.gson.*;
+import org.immutables.mongo.fixture.holder.ImmutableHolder;
+
+import java.lang.reflect.Type;
+
+/**
+ * Custom serializer which allows to (JSON) store different types of objects inside same class :
+ * {@link GenericType}
+ */
+public class GenericTypeJsonSerializer implements JsonSerializer<GenericType>, JsonDeserializer<GenericType> {
+
+  private static final String VALUE_PROPERTY = "value";
+
+  @Override
+  public GenericType deserialize(JsonElement json, Type type, JsonDeserializationContext context) throws JsonParseException {
+    JsonObject root = (JsonObject) json;
+
+    ImmutableGenericType.Builder builder = ImmutableGenericType.builder();
+
+    JsonElement value = root.get(VALUE_PROPERTY);
+    if (value == null) {
+      throw new JsonParseException(String.format("%s not found for %s in JSON", VALUE_PROPERTY, type));
+    }
+
+    if (value.isJsonObject()) {
+      final String valueTypeName = value.getAsJsonObject().get(GenericType.TYPE_PROPERTY).getAsString();
+      try {
+        Class<?> valueType = Class.forName(valueTypeName);
+        builder.value(context.deserialize(value, valueType));
+      } catch (ClassNotFoundException e) {
+        throw new JsonParseException(String.format("Couldn't construct value class %s for %s", valueTypeName, type), e);
+      }
+    } else if (value.isJsonPrimitive()) {
+      final JsonPrimitive primitive = value.getAsJsonPrimitive();
+      if (primitive.isString()) {
+        builder.value(primitive.getAsString());
+      } else if (primitive.isNumber()) {
+        builder.value(primitive.getAsInt());
+      } else if (primitive.isBoolean()) {
+        builder.value(primitive.getAsBoolean());
+      }
+    } else {
+      throw new JsonParseException(
+          String.format("Couldn't deserialize %s : %s. Not a primitive or object", VALUE_PROPERTY, value));
+    }
+
+    return builder.build();
+
+  }
+
+  @Override
+  public JsonElement serialize(GenericType src, Type type, JsonSerializationContext context) {
+    JsonObject root = new JsonObject();
+    JsonElement value = context.serialize(src.value());
+
+    if (value.isJsonObject()) {
+      value.getAsJsonObject().addProperty(GenericType.TYPE_PROPERTY, src.value().getClass().getName());
+    }
+
+    root.add(VALUE_PROPERTY, value);
+    return root;
+  }
+
+}

--- a/mongo/test/org/immutables/mongo/fixture/generic/GenericTypeTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/generic/GenericTypeTest.java
@@ -1,0 +1,100 @@
+/*
+   Copyright 2017 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.mongo.fixture.generic;
+
+import org.immutables.mongo.fixture.MongoContext;
+import org.immutables.mongo.fixture.holder.ImmutablePrimitives;
+import org.immutables.mongo.fixture.holder.Primitives;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.immutables.check.Checkers.check;
+
+public class GenericTypeTest {
+
+  @Rule
+  public final MongoContext context = MongoContext.create();
+
+  private GenericHolderRepository repository;
+
+  @Before
+  public void setUp() {
+    repository = new GenericHolderRepository(context.setup());
+  }
+
+  @Test
+  public void object() {
+    Primitives prim = ImmutablePrimitives.builder()
+        .booleanValue(true)
+        .byteValue((byte) 4)
+        .shortValue((short) 16)
+        .intValue(1024)
+        .longValue(8096)
+        .floatValue(1.1f)
+        .doubleValue(3.3d)
+        .build();
+
+    GenericHolder genericHolder = ImmutableGenericHolder.builder()
+        .id("h1")
+        .value(ImmutableGenericType.<Primitives>builder().value(prim).build())
+        .build();
+
+    check(repository.upsert(genericHolder).getUnchecked()).is(1);
+
+    final List<GenericHolder> GenericHolders = repository.findAll().fetchAll().getUnchecked();
+
+    check(GenericHolders).hasSize(1);
+    check(GenericHolders.get(0).id()).is("h1");
+    check(GenericHolders.get(0)).is(genericHolder);
+  }
+
+  @Test
+  public void string() {
+    GenericHolder genericHolder = ImmutableGenericHolder.builder()
+        .id("h1")
+        .value(ImmutableGenericType.<String>builder().value("123").build())
+        .build();
+    check(repository.upsert(genericHolder).getUnchecked()).is(1);
+    check(repository.findAll().fetchAll().getUnchecked()).has(genericHolder);
+  }
+
+  @Test
+  public void justInt() {
+    GenericHolder genericHolder = ImmutableGenericHolder.builder()
+        .id("h1")
+        .value(ImmutableGenericType.<Integer>builder().value(123).build())
+        .build();
+    check(repository.upsert(genericHolder).getUnchecked()).is(1);
+    check(repository.findAll().fetchAll().getUnchecked()).has(genericHolder);
+  }
+
+  @Test
+  public void listOfStrings() {
+    GenericHolder genericHolder = ImmutableGenericHolder.builder()
+        .id("h1")
+        .value(ImmutableGenericType.<String>builder().value("123").build())
+        .addListOfValues(
+            ImmutableGenericType.<String>builder().value("a").build(),
+            ImmutableGenericType.<String>builder().value("a").build()
+        )
+        .build();
+    check(repository.upsert(genericHolder).getUnchecked()).is(1);
+    check(repository.findAll().fetchAll().getUnchecked()).has(genericHolder);
+  }
+}

--- a/value-processor/src/org/immutables/value/processor/Repositories.generator
+++ b/value-processor/src/org/immutables/value/processor/Repositories.generator
@@ -802,10 +802,10 @@ public static final class Criteria extends Repositories.Criteria {
 private static class Serialization {
   [for a in allAttributes]
     [if a.requiresMarshalingAdapter]
-  final Encoder<[a.elementType]> [a.name]Encoder;
+  final Encoder<[a.unwrapperOrRawElementType]> [a.name]Encoder;
     [/if]
     [if a.requiresMarshalingSecondaryAdapter]
-  final Encoder<[a.secondaryElementType]> [a.name]SecondaryEncoder;
+  final Encoder<[a.unwrapperOrRawSecondaryElementType]> [a.name]SecondaryEncoder;
     [/if]
   [/for]
   final CodecRegistry registry;
@@ -857,10 +857,10 @@ private static class Serialization {
   [if subs and suppotedSubs]
 [output.error a.originalElement]Repositories do not support inline @Gson.ExpectedSubtypes, please put this annotations
 on the interface nested in class covered with @Gson.TypeAdapters. Or manually register on GsonBuilder following adapter:
-org.immutables.gson.adapter.ExpectedSubtypesAdapter.create(gson, [if secondary][a.typeTokenOfSecondaryElement][else][a.typeTokenOfElement][/if][for s in subs], TypeToken.get([s].class)[/for])
+org.immutables.gson.adapter.ExpectedSubtypesAdapter.create(gson, [if secondary][a.unwrapperOrRawSecondaryElementType][else][a.unwrapperOrRawElementType][/if][for s in subs], TypeToken.get([s].class)[/for])
 [/output.error]
   [else]
-this.[a.name][if secondary]Secondary[/if]Encoder = this.registry.get([if secondary][a.typeTokenOfSecondaryElement][else][a.typeTokenOfElement][/if]);
+this.[a.name][if secondary]Secondary[/if]Encoder = this.registry.get([if secondary][a.unwrapperOrRawSecondaryElementType].class[else][a.unwrapperOrRawElementType].class[/if]);
   [/if]
 [/for]
 [/template]


### PR DESCRIPTION
Generating a Repository class for an immutable with a custom generic type field results in compilation errors ever since generated repositories were changed from using TypeAdapters to use MongoDB's Codec interface.  I understand that the recommended approach is to migrate to the Criteria API, however this will allow upgrading to the latest version of immutables that supports Criteria API and then perform a phased migration to Criteria API.

Below is the code generation before and after this pull request. The compilation errors are due to the initialization of this.valueEncoder and this.listOfValuesEncoder

BEFORE:
```
@Generated(from = "GenericHolder", generator = "Repositories")
  private static class Serialization {
    final Encoder<GenericType<?>> valueEncoder;
    final Encoder<GenericType<?>> listOfValuesEncoder;
    final CodecRegistry registry;
    final String idName;
    final String valueName;
    final String listOfValuesName;

    Serialization(CodecRegistry registry, RepositorySetup.FieldNamingStrategy fieldNamingStrategy) {
      this.registry = registry;
      this.valueEncoder = this.registry.get((TypeToken<GenericType<?>>) TypeToken.getParameterized(GenericType.class, java.lang.Object.class));
      this.listOfValuesEncoder = this.registry.get((TypeToken<GenericType<?>>) TypeToken.getParameterized(GenericType.class, java.lang.Object.class));
      this.idName = "_id";
      this.valueName = translateName(fieldNamingStrategy, "value");
      this.listOfValuesName = translateName(fieldNamingStrategy, "listOfValues");
    }

    @Generated(from = "GenericHolder", generator = "Repositories")
    static final class GenericHolderNamingFields {
      public java.lang.String id;
      public GenericType<?> value;
      public List<GenericType<?>> listOfValues;
    }

    private static String translateName(RepositorySetup.FieldNamingStrategy fieldNamingStrategy, String fieldName) {
      try {
        return fieldNamingStrategy.translateName(
            GenericHolderNamingFields.class.getField(fieldName));
      } catch (NoSuchFieldException noSuchField) {
        throw new AssertionError(noSuchField);
      }
    }
  }
```

AFTER:
```
  @Generated(from = "GenericHolder", generator = "Repositories")
  private static class Serialization {
    final Encoder<GenericType> valueEncoder;
    final Encoder<GenericType> listOfValuesEncoder;
    final CodecRegistry registry;
    final String idName;
    final String valueName;
    final String listOfValuesName;

    Serialization(CodecRegistry registry, RepositorySetup.FieldNamingStrategy fieldNamingStrategy) {
      this.registry = registry;
      this.valueEncoder = this.registry.get(GenericType.class);
      this.listOfValuesEncoder = this.registry.get(GenericType.class);
      this.idName = "_id";
      this.valueName = translateName(fieldNamingStrategy, "value");
      this.listOfValuesName = translateName(fieldNamingStrategy, "listOfValues");
    }

    @Generated(from = "GenericHolder", generator = "Repositories")
    static final class GenericHolderNamingFields {
      public java.lang.String id;
      public GenericType<?> value;
      public List<GenericType<?>> listOfValues;
    }

    private static String translateName(RepositorySetup.FieldNamingStrategy fieldNamingStrategy, String fieldName) {
      try {
        return fieldNamingStrategy.translateName(
            GenericHolderNamingFields.class.getField(fieldName));
      } catch (NoSuchFieldException noSuchField) {
        throw new AssertionError(noSuchField);
      }
    }
  }
```