### PR TITLE
Bean friendly modifiable from method return converted result.

### DIFF
--- a/value-fixture/src/org/immutables/fixture/modifiable/BeanFriendly.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/BeanFriendly.java
@@ -27,10 +27,11 @@ import org.immutables.value.Value;
     deepImmutablesDetection = true,
     create = "new",
     get = {"get*", "is*"})
-public interface BeanFriendly {
+public interface BeanFriendly extends Identifiable {
 
   boolean isPrimary();
 
+  @Override
   int getId();
 
   String getDescription();
@@ -48,4 +49,8 @@ public interface BeanFriendly {
   @Value.Immutable
   @Value.Modifiable
   public interface Mod {}
+}
+
+interface Identifiable {
+  int getId();
 }

--- a/value-fixture/test/org/immutables/fixture/modifiable/BeanFriendlyTest.java
+++ b/value-fixture/test/org/immutables/fixture/modifiable/BeanFriendlyTest.java
@@ -60,5 +60,8 @@ public class BeanFriendlyTest {
     check(immutableBean.getId()).is(1000);
     check(immutableBean.getNames()).isOf("name", "name2");
     check(immutableBean.getOptions()).is(ImmutableMap.of("foo", "bar"));
+
+    // from works as with Immutable
+    BeanFriendly mutableFromImmutable = new ModifiableBeanFriendly().from(immutableBean);
   }
 }

--- a/value-fixture/test/org/immutables/fixture/modifiable/BeanFriendlyTest.java
+++ b/value-fixture/test/org/immutables/fixture/modifiable/BeanFriendlyTest.java
@@ -62,6 +62,7 @@ public class BeanFriendlyTest {
     check(immutableBean.getOptions()).is(ImmutableMap.of("foo", "bar"));
 
     // from works as with Immutable
-    BeanFriendly mutableFromImmutable = new ModifiableBeanFriendly().from(immutableBean);
+    BeanFriendly mutableFromImmutable1 = new ModifiableBeanFriendly().from(immutableBean);
+    BeanFriendly.Mod mutableFromImmutable2 = new ModifiableMod().from(immutableBean.getMod());
   }
 }

--- a/value-processor/src/org/immutables/value/processor/Modifiables.generator
+++ b/value-processor/src/org/immutables/value/processor/Modifiables.generator
@@ -366,10 +366,10 @@ public static[type.generics.def] [thisReturnType type] [type.names.create]() {
 [docReturnThis type]
  */
 [atCanIgnoreReturnValue type]
-public [thisSetterReturnType type] [type.names.from]([s.type] instance) {
+public [thisReturnType type] [type.names.from]([s.type] instance) {
   [im.requireNonNull type](instance, "instance");
   from((Object) instance);
-  [thisSetterReturn type]
+  [thisReturn type]
 }
   [/for]
 


### PR DESCRIPTION
Modifiable's `from` method with bean friendly flag turned on returns void in the case where the modifiable class has 1 or more extended interfaces. 

This cause two issuers:

- it's inconsistent with from method that's generated for Modifiable that doesn't extend any extra interfaces
- it causes syntactic errors in Modifiable class in certain scenarios.

This change is focused on fixing these issues.