### PR TITLE
When modifiable has modifiable default field, Immutables produces syntactically invalid code.

### DIFF
--- a/value-fixture/src/org/immutables/fixture/modifiable/BeanFriendly.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/BeanFriendly.java
@@ -42,6 +42,39 @@ public interface BeanFriendly {
   @Nullable
   Mod getMod();
 
+  @Value.Default
+  default Mod getDefaultMod() {
+    return ImmutableMod.builder().build();
+  }
+
+  @Nullable
+  @Value.Default
+  default Mod getDefaultNullableMod() {
+    return ImmutableMod.builder().build();
+  }
+
+  @Value.Derived
+  default Mod getDerivedMod() {
+    return getDefaultMod();
+  }
+
+  @Nullable
+  @Value.Derived
+  default Mod getDerivedNullableMod() {
+    return getDefaultMod();
+  }
+
+  @Value.Lazy
+  default Mod getLazyMod() {
+    return getDefaultMod();
+  }
+
+  @Nullable
+  @Value.Lazy
+  default Mod getLazyNullableMod() {
+    return getDefaultMod();
+  }
+
   @Nullable
   List<Integer> getExtra();
 

--- a/value-processor/src/org/immutables/value/processor/Modifiables.generator
+++ b/value-processor/src/org/immutables/value/processor/Modifiables.generator
@@ -503,13 +503,36 @@ public [thisReturnType type] [type.names.from]([type.typeModifiable] instance) {
   }
 [/if]
 [if v.generateLazy]
+  [if v.attributeValueKindModifyFrom]
+  [v.type] [v.name] = [invokeSuper v].[v.names.get]();
+  return [v.name] instanceof [v.attributeValueType.constitution.typeModifiable.absoluteRaw]
+      ? ([v.attributeValueType.constitution.typeModifiable.absolute]) [v.name]
+      : [v.attributeValueType.constitution.factoryCreate]().[v.attributeValueType.names.from]([v.name]);
+  [else]
   return [invokeSuper v].[v.names.get]();
+  [/if]
 [else if v.generateDerived]
+  [if v.attributeValueKindModifyFrom]
+  [v.type] [v.name] = [invokeSuper v].[v.names.get]();
+  return [v.name] instanceof [v.attributeValueType.constitution.typeModifiable.absoluteRaw]
+      ? ([v.attributeValueType.constitution.typeModifiable.absolute]) [v.name]
+      : [v.attributeValueType.constitution.factoryCreate]().[v.attributeValueType.names.from]([v.name]);
+  [else]
   return [invokeSuper v].[v.names.get]();
+  [/if]
 [else if v.generateDefault]
-  return [isSet v]()
-      ? [v.name]
-      : [invokeSuper v].[v.names.get]();
+  if ([isSet v]()) {
+    return [v.name];
+  } else {
+    [if v.attributeValueKindModifyFrom]
+    [v.type] [v.name] = [invokeSuper v].[v.names.get]();
+    return [v.name] instanceof [v.attributeValueType.constitution.typeModifiable.absoluteRaw]
+        ? ([v.attributeValueType.constitution.typeModifiable.absolute]) [v.name]
+        : [v.attributeValueType.constitution.factoryCreate]().[v.attributeValueType.names.from]([v.name]);
+    [else]
+    return [invokeSuper v].[v.names.get]();
+    [/if]
+  }
 [else]
   [if v.nullableCollector andnot v.nullable]
   if ([v.name] == null) {


### PR DESCRIPTION
When modifiable has modifiable default field, Immutables produces syntactically invalid code.

Same is true for derived and lazy.

BEFORE:

```
...
  @Override
  public final ModifiableMod getDefaultMod() {
    return defaultModIsSet()
      ? defaultMod
      : BeanFriendly.super.getDefaultMod(); // doesn't compile because return type of super getDefaultMod is not type of ModifiableMod
  }
...
```

AFTER:

```
...
  @Override
  public final ModifiableMod getDefaultMod() {
    if (defaultModIsSet()) {
      return defaultMod;
    } else {
      BeanFriendly.Mod defaultMod = BeanFriendly.super.getDefaultMod();
      return defaultMod instanceof ModifiableMod
          ? (ModifiableMod) defaultMod
          : new ModifiableMod().from(defaultMod);
    }
  }
...
```