### PR TITLE
Fix addAll(Iterator<E>) NPE

### DIFF
--- a/value-fixture/src/org/immutables/fixture/nullable/NullablyElements.java
+++ b/value-fixture/src/org/immutables/fixture/nullable/NullablyElements.java
@@ -35,4 +35,10 @@ public interface NullablyElements {
   Map<String, @SkipNulls Integer> sm();
 
   Set<String> rg();
+  
+  Set<@SkipNulls Integer> ri();
+
+  List<@AllowNulls Integer> rj();
+
+  Set<Integer> rk();
 }

--- a/value-fixture/test/org/immutables/fixture/nullable/NullableAttributesTest.java
+++ b/value-fixture/test/org/immutables/fixture/nullable/NullableAttributesTest.java
@@ -254,6 +254,36 @@ public class NullableAttributesTest {
   }
 
   @Test
+  public void skipNullValues3() {
+    ImmutableNullablyElements elements = ImmutableNullablyElements.builder()
+        .addAllRi(Arrays.asList(1, null, 2, null))
+        .build();
+
+    check(elements.ri()).isOf(1, 2);
+  }
+
+  @Test
+  public void allowNulls3() {
+    ImmutableNullablyElements elements = ImmutableNullablyElements.builder()
+        .addAllRj(Arrays.asList(1, null, 2, null))
+        .build();
+
+    check(elements.rj()).isOf(1, null, 2, null);
+  }
+
+  @Test
+  public void banNulls3() {
+    try {
+      ImmutableNullablyElements elements = ImmutableNullablyElements.builder()
+          .addAllRk(Arrays.asList(1, null, 2, null))
+          .build();
+    } catch (NullPointerException ex) {
+      // make sure NPE isn't due to unboxed loop, static code analyzers don't like that
+      check(ex.getStackTrace()[0].getMethodName().equals("requireNonNull"));
+    }
+  }
+
+  @Test
   public void typeUseNullable() {
     ImmutableNullableTypeUseJdtAccepted r = ImmutableNullableTypeUseJdtAccepted.builder()
         .i1(null)

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1616,7 +1616,7 @@ checkNotIsSet([v.names.isSet](), "[v.names.raw]");
     }
     [/if]
     [if v.generateJdkOnly or v.hasAttributeValue]
-    for ([v.unwrappedElementType] element : elements) {
+    for ([v.wrappedElementType] element : elements) {
       [if v.hasAttributeValue]
       [if not v.nullElements.ban]if (element != null) [/if]element = [deepCopyOf v]element[/deepCopyOf];
       [/if]


### PR DESCRIPTION
For boxed types generated code before this fix contains a loop like
```java
    /**
     * Adds elements to {@link T#getIds() ids} set.
     * @param elements An iterable of ids elements
     * @return {@code this} builder for use in a chained invocation
     */
    @CanIgnoreReturnValue 
    public final T.Builder addAllIds(Iterable<Long> elements) {
      Objects.requireNonNull(elements, "ids element");
      if (this.ids == null) {
        this.ids = new ArrayList<Long>();
      }
      for (long element : elements) {
        this.ids.add(Objects.requireNonNull(element, "ids element"));
      }
      return (T.Builder) this;
    }
```
For invalid calls it is still NPE but static code analysis tools like https://github.com/google/error-prone may rightfully complain that requireNonNull is never needed due to iterating with unboxed type.
--For @SkipNulls case it is an NPE instead of skipping null elements - a more clear bug.--