### PR TITLE
Remove redundant equality checks in with... methods on enum members

### DIFF
--- a/value-fixture/src/org/immutables/fixture/with/WithEnums.java
+++ b/value-fixture/src/org/immutables/fixture/with/WithEnums.java
@@ -1,0 +1,16 @@
+package org.immutables.fixture.with;
+
+import org.immutables.value.Value;
+
+import java.math.RoundingMode;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+@Value.Immutable
+public abstract class WithEnums {
+  public abstract RoundingMode getRoundingMode();
+  @Nullable
+  public abstract RoundingMode getNullableRoundingMode();
+  public abstract Optional<RoundingMode> getMaybeRoundingMode();
+}

--- a/value-fixture/test/org/immutables/fixture/with/WithEnumsTest.java
+++ b/value-fixture/test/org/immutables/fixture/with/WithEnumsTest.java
@@ -1,0 +1,27 @@
+package org.immutables.fixture.with;
+
+import org.junit.Test;
+
+import java.math.RoundingMode;
+
+import static org.immutables.check.Checkers.check;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class WithEnumsTest {
+  private static final ImmutableWithEnums TEST_IMMUTABLE = ImmutableWithEnums.builder()
+          .roundingMode(RoundingMode.CEILING)
+          .maybeRoundingMode(RoundingMode.HALF_DOWN)
+          .nullableRoundingMode(RoundingMode.UNNECESSARY)
+          .build();
+
+  @Test
+  public void doNotAllowNullEnumValueInNonNullableWith() {
+    assertThrows(NullPointerException.class, () -> TEST_IMMUTABLE.withRoundingMode(null));
+  }
+
+  @Test
+  public void allowNullEnumValueInNullableWith() {
+    ImmutableWithEnums withNullableRoundingMode = TEST_IMMUTABLE.withNullableRoundingMode(null);
+    check(withNullableRoundingMode.getNullableRoundingMode()).isNull();
+  }
+}

--- a/value-fixture/test/org/immutables/fixture/with/WithEnumsTest.java
+++ b/value-fixture/test/org/immutables/fixture/with/WithEnumsTest.java
@@ -3,6 +3,7 @@ package org.immutables.fixture.with;
 import org.junit.Test;
 
 import java.math.RoundingMode;
+import java.util.Optional;
 
 import static org.immutables.check.Checkers.check;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,6 +13,11 @@ public class WithEnumsTest {
           .roundingMode(RoundingMode.CEILING)
           .maybeRoundingMode(RoundingMode.HALF_DOWN)
           .nullableRoundingMode(RoundingMode.UNNECESSARY)
+          .build();
+  private static final ImmutableWithEnums TEST_IMMUTABLE_WITH_NULLS = ImmutableWithEnums.builder()
+          .roundingMode(RoundingMode.DOWN)
+          .maybeRoundingMode(Optional.empty())
+          .nullableRoundingMode(null)
           .build();
 
   @Test
@@ -23,5 +29,35 @@ public class WithEnumsTest {
   public void allowNullEnumValueInNullableWith() {
     ImmutableWithEnums withNullableRoundingMode = TEST_IMMUTABLE.withNullableRoundingMode(null);
     check(withNullableRoundingMode.getNullableRoundingMode()).isNull();
+  }
+
+  @Test
+  public void withOnEqualEnumValueIsSameInstance() {
+    check(TEST_IMMUTABLE.withRoundingMode(RoundingMode.CEILING)).same(TEST_IMMUTABLE);
+    check(TEST_IMMUTABLE.withMaybeRoundingMode(RoundingMode.HALF_DOWN)).same(TEST_IMMUTABLE);
+    check(TEST_IMMUTABLE.withNullableRoundingMode(RoundingMode.UNNECESSARY)).same(TEST_IMMUTABLE);
+  }
+
+  @Test
+  public void withOnNullEnumValueIsSameInstance() {
+    check(TEST_IMMUTABLE_WITH_NULLS.withNullableRoundingMode(null)).same(TEST_IMMUTABLE_WITH_NULLS);
+    check(TEST_IMMUTABLE_WITH_NULLS.withMaybeRoundingMode(Optional.empty())).same(TEST_IMMUTABLE_WITH_NULLS);
+  }
+
+  @Test
+  public void withOnDifferentEnumValueIsNotSameInstance() {
+    check(TEST_IMMUTABLE.withRoundingMode(RoundingMode.FLOOR)).not().same(TEST_IMMUTABLE);
+    check(TEST_IMMUTABLE.withNullableRoundingMode(RoundingMode.HALF_UP)).not().same(TEST_IMMUTABLE);
+    check(TEST_IMMUTABLE.withMaybeRoundingMode(RoundingMode.CEILING)).not().same(TEST_IMMUTABLE);
+  }
+
+  @Test
+  public void withOnNullEnumValueWithEnumValueIsNotSameInstance() {
+    check(TEST_IMMUTABLE_WITH_NULLS.withNullableRoundingMode(RoundingMode.CEILING))
+            .not().same(TEST_IMMUTABLE_WITH_NULLS);
+    check(TEST_IMMUTABLE_WITH_NULLS.withMaybeRoundingMode(RoundingMode.UNNECESSARY))
+            .not().same(TEST_IMMUTABLE_WITH_NULLS);
+    check(TEST_IMMUTABLE_WITH_NULLS.withMaybeRoundingMode(Optional.of(RoundingMode.HALF_UP)))
+            .not().same(TEST_IMMUTABLE_WITH_NULLS);
   }
 }

--- a/value-fixture/test/org/immutables/fixture/with/WithEnumsTest.java
+++ b/value-fixture/test/org/immutables/fixture/with/WithEnumsTest.java
@@ -1,6 +1,6 @@
 package org.immutables.fixture.with;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.RoundingMode;
 import java.util.Optional;
@@ -59,5 +59,52 @@ public class WithEnumsTest {
             .not().same(TEST_IMMUTABLE_WITH_NULLS);
     check(TEST_IMMUTABLE_WITH_NULLS.withMaybeRoundingMode(Optional.of(RoundingMode.HALF_UP)))
             .not().same(TEST_IMMUTABLE_WITH_NULLS);
+  }
+
+  @Test
+  public void withOnDifferentEnumValueIsEqualTo() {
+    ImmutableWithEnums testImmutableWithFloorRoundingMode = ImmutableWithEnums.builder()
+            .roundingMode(RoundingMode.FLOOR)
+            .maybeRoundingMode(RoundingMode.HALF_DOWN)
+            .nullableRoundingMode(RoundingMode.UNNECESSARY)
+            .build();
+
+    check(TEST_IMMUTABLE.withRoundingMode(RoundingMode.FLOOR)).is(testImmutableWithFloorRoundingMode);
+  }
+
+  @Test
+  public void withOnNullEnumValueWithEnumValueIsEqualTo() {
+    ImmutableWithEnums testImmutableWithFloorNullableRoundingMode = ImmutableWithEnums.builder()
+            .roundingMode(RoundingMode.DOWN)
+            .maybeRoundingMode(Optional.empty())
+            .nullableRoundingMode(RoundingMode.FLOOR)
+            .build();
+
+    check(TEST_IMMUTABLE_WITH_NULLS.withNullableRoundingMode(RoundingMode.FLOOR))
+            .is(testImmutableWithFloorNullableRoundingMode);
+  }
+
+  @Test
+  public void withOnOptionalEnumValueWithEnumValueIsEqualTo() {
+    ImmutableWithEnums testImmutableWithHalfDownMaybeRoundingMode = ImmutableWithEnums.builder()
+            .roundingMode(RoundingMode.DOWN)
+            .maybeRoundingMode(RoundingMode.HALF_DOWN)
+            .nullableRoundingMode(null)
+            .build();
+
+    check(TEST_IMMUTABLE_WITH_NULLS.withMaybeRoundingMode(RoundingMode.HALF_DOWN))
+            .is(testImmutableWithHalfDownMaybeRoundingMode);
+  }
+
+  @Test
+  public void withOnOptionalEnumValueWithEmptyOptionalIsEqualTo() {
+    ImmutableWithEnums testImmutableWithEmptyMaybeRoundingMode = ImmutableWithEnums.builder()
+            .roundingMode(RoundingMode.CEILING)
+            .maybeRoundingMode(Optional.empty())
+            .nullableRoundingMode(RoundingMode.UNNECESSARY)
+            .build();
+
+    check(TEST_IMMUTABLE.withMaybeRoundingMode(Optional.empty()))
+            .is(testImmutableWithEmptyMaybeRoundingMode);
   }
 }

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -3422,7 +3422,7 @@ public final [type.typeImmutable.relative] [v.names.with]([unwrappedOptionalType
 public final [type.typeImmutable.relative] [v.names.with]([v.rawType][if not v.jdkSpecializedOptional]<[v.consumedElementType]>[/if] optional) {
   [immutableImplementationType v] value = [valueFromValue v 'optional'];
 [if v.jdkOptional]
-  [if v.hasSimpleScalarElementType]
+  [if v.hasSimpleScalarElementType andnot v.enumType]
   if ([objectsEqual type](this.[v.name], value)) return this;
   [else]
   if (this.[v.name] == value) return this;
@@ -3480,7 +3480,7 @@ public final [type.typeImmutable.relative] [v.names.with]([v.atNullability][v.ty
   if (Float.floatToIntBits(this.[v.name]) == Float.floatToIntBits(value)) return this;
     [else if v.double]
   if (Double.doubleToLongBits(this.[v.name]) == Double.doubleToLongBits(value)) return this;
-    [else if v.primitive or v.enumType]
+    [else if v.primitive]
   if (this.[v.name] == value) return this;
     [else if v.hasSimpleScalarElementType or v.isSuppressedOptional]
     [-- moved to after value assignment --]
@@ -3499,7 +3499,9 @@ public final [type.typeImmutable.relative] [v.names.with]([v.atNullability][v.ty
     [else if v.nullable]
     [if v.hasSimpleScalarElementType or v.isSuppressedOptional]
     [-- moved from conditions in the beginning of the method --]
-      [if v.nullable or type.generateNoargConstructor]
+      [if v.enumType]
+  if (this.[v.name] == value) return this;
+      [else if v.nullable or type.generateNoargConstructor]
   if ([objectsEqual type](this.[v.name], value)) return this;
       [else]
   if (this.[v.name].equals(value)) return this;
@@ -3510,7 +3512,9 @@ public final [type.typeImmutable.relative] [v.names.with]([v.atNullability][v.ty
   [v.atNullabilityLocal][immutableImplementationType v] newValue = [valueFromValue v 'value'];
     [if v.hasSimpleScalarElementType or v.isSuppressedOptional]
     [-- moved from conditions in the beginning of the method --]
-      [if v.nullable or type.generateNoargConstructor]
+      [if v.enumType]
+  if (this.[v.name] == newValue) return this;
+      [else if v.nullable or type.generateNoargConstructor]
   if ([objectsEqual type](this.[v.name], newValue)) return this;
       [else]
   if (this.[v.name].equals(newValue)) return this;


### PR DESCRIPTION
This PR removes redundant equality checks in `with...` methods on enum members (it was often checking for equality twice). For example:

_Given:_
```java
@Value.Immutable
public abstract class WithEnums {
  public abstract RoundingMode getRoundingMode();
  @Nullable public abstract RoundingMode getNullableRoundingMode();
  public abstract Optional<RoundingMode> getMaybeRoundingMode();
}
```

_Before: (Javadoc removed for brevity)_

```java
...
  public final ImmutableWithEnums withRoundingMode(RoundingMode value) {
    if (this.roundingMode == value) return this;
    RoundingMode newValue = Objects.requireNonNull(value, "roundingMode");
    if (this.roundingMode.equals(newValue)) return this;
    return new ImmutableWithEnums(newValue, this.nullableRoundingMode, this.maybeRoundingMode);
  }

  public final ImmutableWithEnums withNullableRoundingMode(@Nullable RoundingMode value) {
    if (this.nullableRoundingMode == value) return this;
    if (Objects.equals(this.nullableRoundingMode, value)) return this;
    return new ImmutableWithEnums(this.roundingMode, value, this.maybeRoundingMode);
  }

  public final ImmutableWithEnums withMaybeRoundingMode(RoundingMode value) {
    @Nullable RoundingMode newValue = Objects.requireNonNull(value, "maybeRoundingMode");
    if (this.maybeRoundingMode == newValue) return this;
    return new ImmutableWithEnums(this.roundingMode, this.nullableRoundingMode, newValue);
  }

  @SuppressWarnings("unchecked") // safe covariant cast
  public final ImmutableWithEnums withMaybeRoundingMode(Optional<? extends RoundingMode> optional) {
    @Nullable RoundingMode value = optional.orElse(null);
    if (Objects.equals(this.maybeRoundingMode, value)) return this;
    return new ImmutableWithEnums(this.roundingMode, this.nullableRoundingMode, value);
  }
...
```

_After: (Javadoc removed for brevity)_

```java
...
  public final ImmutableWithEnums withRoundingMode(RoundingMode value) {
    RoundingMode newValue = Objects.requireNonNull(value, "roundingMode");
    if (this.roundingMode == newValue) return this;
    return new ImmutableWithEnums(newValue, this.nullableRoundingMode, this.maybeRoundingMode);
  }

  public final ImmutableWithEnums withNullableRoundingMode(@Nullable RoundingMode value) {
    if (this.nullableRoundingMode == value) return this;
    return new ImmutableWithEnums(this.roundingMode, value, this.maybeRoundingMode);
  }

  public final ImmutableWithEnums withMaybeRoundingMode(RoundingMode value) {
    @Nullable RoundingMode newValue = Objects.requireNonNull(value, "maybeRoundingMode");
    if (this.maybeRoundingMode == newValue) return this;
    return new ImmutableWithEnums(this.roundingMode, this.nullableRoundingMode, newValue);
  }

  @SuppressWarnings("unchecked") // safe covariant cast
  public final ImmutableWithEnums withMaybeRoundingMode(Optional<? extends RoundingMode> optional) {
    @Nullable RoundingMode value = optional.orElse(null);
    if (this.maybeRoundingMode == value) return this;
    return new ImmutableWithEnums(this.roundingMode, this.nullableRoundingMode, value);
  }
...
```