### PR TITLE
Make Modifiables working with JPA through a new jpaFriendlyModifiable style attribut

### DIFF
--- a/testing/src/org/immutables/matcher/ModifierMatcher.java
+++ b/testing/src/org/immutables/matcher/ModifierMatcher.java
@@ -1,0 +1,36 @@
+package org.immutables.matcher;
+
+import static org.hamcrest.CoreMatchers.not;
+
+import java.lang.reflect.Method;
+
+import org.hamcrest.Matcher;
+import org.immutables.matcher.internal.IsFinal;
+
+/**
+ * Some utilitary methods that check modifier
+ */
+public class ModifierMatcher {
+  /**
+   * Create a matcher for {@link Method} that check it can't be overrided.
+   *
+   * @return the created matcher
+   */
+  public static final Matcher<Object> finalModifier() {
+    return new IsFinal();
+  }
+
+  /**
+   * Create a matcher for {@link Method} that check it can be overrided.
+   *
+   * @return the created matcher
+   */
+  public static final Matcher<Object> notFinalModifier() {
+    return not(finalModifier());
+  }
+
+  /**
+   * Unreachable constructor
+   */
+  private ModifierMatcher() {}
+}

--- a/testing/src/org/immutables/matcher/internal/IsFinal.java
+++ b/testing/src/org/immutables/matcher/internal/IsFinal.java
@@ -1,0 +1,29 @@
+package org.immutables.matcher.internal;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+/**
+ * Check that the method can't be overrided.
+ */
+public class IsFinal extends BaseMatcher<Object> {
+  @Override
+  public boolean matches(final Object item) {
+    if (Method.class.isAssignableFrom(item.getClass())) {
+      return Modifier.isFinal(((Method) item).getModifiers());
+    } else if (Field.class.isAssignableFrom(item.getClass())) {
+      return Modifier.isFinal(((Field) item).getModifiers());
+    } else {
+      throw new IllegalArgumentException("Wrong type! Method or Field allowed");
+    }
+  }
+
+  @Override
+  public void describeTo(final Description description) {
+    description.appendText("final");
+  }
+}

--- a/value-annotations/src/org/immutables/value/Value.java
+++ b/value-annotations/src/org/immutables/value/Value.java
@@ -1213,6 +1213,24 @@ public @interface Value {
     boolean beanFriendlyModifiables() default false;
 
     /**
+     * If enabled modifable type will have non-final getters and collection setters will literally replace 
+     * the previous values. This is modifiable companion types only, not for builders and other types of 
+     * generated artifacts.
+     * <p>
+     * Despite the fact that this option will allows your class to be more JPA compliant, it's at the price 
+     * of some weakness like type collections inconsistency or the possibility to override getter method.
+     * So handle this option with care.
+     * </p>
+     * <p>
+     * <em>Note, we are not supporting JPA specification in any way except that Immutables can
+     * be used/configured to be partially compatible with some of the conventions.</em>
+     * </p>
+     * @return {@code true} for non-final setters and minor tweaks to make modifiables more
+     *         jpa-friendly. {@code false} is the default
+     */
+    boolean jpaFriendlyModifiables() default false;
+
+    /**
      * If enabled mandatory attributes would be auto-propagated to be parameters of value object
      * constuctor.
      * <p>

--- a/value-fixture/src/org/immutables/fixture/modifiable/JpaFriendly.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/JpaFriendly.java
@@ -1,0 +1,87 @@
+/*
+   Copyright 2017 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.fixture.modifiable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Modifiable
+@Value.Style(jpaFriendlyModifiables = true, deepImmutablesDetection = true, create = "new", get = { "get*", "is*" })
+public interface JpaFriendly {
+
+  boolean isPrimary();
+
+  int getId();
+
+  String getDescription();
+
+  List<String> getNames();
+
+  Set<String> getScopes();
+
+  Map<String, String> getOptions();
+
+  @Nullable
+  JpaMod getMod();
+
+  @Value.Default
+  default JpaMod getDefaultMod() {
+    return ImmutableJpaMod.builder().build();
+  }
+
+  @Nullable
+  @Value.Default
+  default JpaMod getDefaultNullableMod() {
+    return ImmutableJpaMod.builder().build();
+  }
+
+  @Value.Derived
+  default JpaMod getDerivedMod() {
+    return getDefaultMod();
+  }
+
+  @Nullable
+  @Value.Derived
+  default JpaMod getDerivedNullableMod() {
+    return getDefaultMod();
+  }
+
+  @Value.Lazy
+  default JpaMod getLazyMod() {
+    return getDefaultMod();
+  }
+
+  @Nullable
+  @Value.Lazy
+  default JpaMod getLazyNullableMod() {
+    return getDefaultMod();
+  }
+
+  @Nullable
+  List<Integer> getExtra();
+
+  @Nullable
+  Set<String> getTargets();
+
+  @Value.Immutable
+  @Value.Modifiable
+  public interface JpaMod {}
+}

--- a/value-fixture/test/org/immutables/fixture/modifiable/BeanFriendlyTest.java
+++ b/value-fixture/test/org/immutables/fixture/modifiable/BeanFriendlyTest.java
@@ -21,11 +21,14 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
+
 import org.junit.jupiter.api.Test;
+
 import static org.immutables.check.Checkers.check;
+import static org.immutables.matcher.ModifierMatcher.notFinalModifier;
 
 public class BeanFriendlyTest {
-
+ 
   @Test
   public void modifiableAsJavaBean() throws Exception {
     ImmutableSet<String> rwProperties =

--- a/value-fixture/test/org/immutables/fixture/modifiable/JpaFriendlyTest.java
+++ b/value-fixture/test/org/immutables/fixture/modifiable/JpaFriendlyTest.java
@@ -1,0 +1,147 @@
+package org.immutables.fixture.modifiable;
+
+import static org.immutables.check.Checkers.check;
+import static org.immutables.matcher.ModifierMatcher.notFinalModifier;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.immutables.value.Value.Style;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Test Modifiables class when {@link Style#jpaFriendlyModifiables} style is activated.
+ */
+public class JpaFriendlyTest {
+  /**
+   * Modifables class with {@link Style#jpaFriendlyModifiables} should be jpa compliante
+   * 
+   * @throws Exception If somethong goes wrong during when scanning the class
+   */
+  @Test
+  public void modifiableAsJpaEntity() throws Exception {
+    ImmutableSet<String> rwProperties = 
+        ImmutableSet.of("primary", "id", "description", "names", "scopes", "options", "extra", "targets");
+
+    FluentIterable<Field> fields = FluentIterable.of(ModifiableJpaFriendly.class.getDeclaredFields());
+
+    check(fields.transform(Field::getName).toSet().containsAll(rwProperties));
+
+    for (Field field : fields) {
+      if (rwProperties.contains(field.getName())) {
+        check(field).is(notFinalModifier());
+        check(getReadMethod(field)).is(notFinalModifier());
+        check(getWriteMethod(field)).notNull();
+      }
+    }
+
+    ModifiableJpaFriendly entity = new ModifiableJpaFriendly();
+    entity.setPrimary(true);
+    entity.setDescription("description");
+    entity.setId(1000);
+    entity.setNames(ImmutableList.of("name"));
+    entity.addScopes("profiles");
+    entity.putOptions("foo", "bar");
+    entity.setTargets(ImmutableSet.of("target1", "target2"));
+
+    // This bean can become immutable.
+    JpaFriendly immutableBean = entity.toImmutable();
+    check(immutableBean.isPrimary());
+    check(immutableBean.getDescription()).is("description");
+    check(immutableBean.getId()).is(1000);
+    check(immutableBean.getNames()).isOf("name");
+    check(immutableBean.getScopes()).isOf("profiles");
+    check(immutableBean.getOptions()).is(ImmutableMap.of("foo", "bar"));
+    check(immutableBean.getTargets()).isOf("target1", "target2");
+  }
+
+  /**
+   * Get field's corresponding getter method.
+   * 
+   * @param field The searched field
+   * @return The corresponding getter method
+   */
+  private static Method getReadMethod(Field field) {
+    Method searchedMethod = null;
+    if (field.getType().equals(boolean.class)) {
+      searchedMethod = getMethodQuietly(ModifiableJpaFriendly.class, booleanGetterMethodName(field));
+    }
+    if (searchedMethod == null) {
+      searchedMethod = getMethodQuietly(ModifiableJpaFriendly.class, getterMethodName(field));
+    }
+    return searchedMethod;
+  }
+
+  /**
+   * Build getter method name for boolean.
+   * 
+   * @param field The searched field
+   * @return The getter method name
+   */
+  private static String booleanGetterMethodName(Field field) {
+    return "is" + capitalize(field.getName());
+  }
+
+  /**
+   * Build getter method name.
+   * 
+   * @param field The searched field
+   * @return The getter method name
+   */
+  private static String getterMethodName(Field field) {
+    return "get" + capitalize(field.getName());
+  }
+
+  /**
+   * Get field's corresponding setter method.
+   * 
+   * @param field The searched field 
+   * @return The corresponding setter method
+   */
+  private static Method getWriteMethod(Field field) {
+    return getMethodQuietly(ModifiableJpaFriendly.class, setterMethodName(field), field.getType());
+  }
+
+  /**
+   * Build setter method name
+   * 
+   * @param field The searched field
+   * @return The setter method name
+   */
+  private static String setterMethodName(Field field) {
+    return "set" + capitalize(field.getName());
+  }
+
+  /**
+   * Capitalize a string
+   * @param s A string
+   * @return The string capitalized
+   */
+  private static String capitalize(String s) {
+    if (s == null || s.isEmpty()) {
+      return s;
+    } else {
+      return s.substring(0, 1).toUpperCase() + s.substring(1);
+    }
+  }
+
+  /**
+   * Get method in a clazz ignoning any problem
+   * @param clazz Class of the searching method
+   * @param name Method's name
+   * @param parameterTypes Types of parameter's method
+   * @return The method
+   */
+  private static Method getMethodQuietly(Class<?> clazz, String name, Class<?>... parameterTypes) {
+    try {
+      return clazz.getMethod(name, parameterTypes);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
+++ b/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
@@ -15,16 +15,24 @@
  */
 package org.immutables.fixture.modifiable;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.immutables.check.Checkers.check;
+import static org.immutables.matcher.ModifierMatcher.finalModifier;
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.util.Collections;
+import java.util.Map;
+
+import org.immutables.fixture.modifiable.FromTypesModifiables.FromType;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
-
-import java.util.Collections;
-import java.util.Map;
-import org.immutables.fixture.modifiable.FromTypesModifiables.FromType;
-import org.junit.jupiter.api.Test;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.immutables.check.Checkers.check;
 
 public class ModifiablesTest {
 
@@ -342,5 +350,14 @@ public class ModifiablesTest {
     m1.computePricesWithTaxRate(0.06f);
     check(m1.getPrices()).isOf(1.00f, 2.00f);
     check(m1.getPricesWithSalesTax()).isOf(1.06f, 2.12f);
+  }
+
+  @Test
+  public void finalReadMethod() throws IntrospectionException {
+    final FluentIterable<PropertyDescriptor> propertyDescriptors = FluentIterable
+        .of(Introspector.getBeanInfo(ModifiableCompanion.class).getPropertyDescriptors());
+    for (final PropertyDescriptor pd : propertyDescriptors) {
+      check(pd.getReadMethod()).allOf(notNullValue(), finalModifier());
+    }
   }
 }

--- a/value-processor/src/org/immutables/value/processor/Modifiables.generator
+++ b/value-processor/src/org/immutables/value/processor/Modifiables.generator
@@ -496,7 +496,7 @@ public [thisReturnType type] [type.names.from]([type.typeModifiable] instance) {
 [eachLine v.accessorInjectedAnnotations]
 [deprecation v]
 @Override
-[v.access]final [v.atNullability][v.implementationModifiableType] [v.names.get]() {
+[v.access][if not type.jpaFriendlyModifiable]final [/if][v.atNullability][v.implementationModifiableType] [v.names.get]() {
 [if v.mandatory]
   if (![isSet v]()) {[-- opportunistically reuse attributes check --]
     [disambiguateAccessor type 'checkRequiredAttributes']();
@@ -629,7 +629,10 @@ public final [thisSetterReturnType type] [v.names.addv]([v.unwrappedElementType]
 [deprecation v]
 [eachLine v.initializerInjectedAnnotations]
 [atCanIgnoreReturnValue type]
-public [thisSetterReturnType type] [v.names.set]([v.atNullability][if type.beanFriendlyModifiable][v.type][else]Iterable<[v.consumedElementType]>[/if] elements) {
+public [thisSetterReturnType type] [v.names.set]([v.atNullability][if type.beanFriendlyModifiable or type.jpaFriendlyModifiable][v.type][else]Iterable<[v.consumedElementType]>[/if] elements) {
+  [if type.jpaFriendlyModifiable]
+  this.[v.name] = elements;
+  [else]
   [if v.nullable]
   if (elements == null) {
     this.[v.name] = null;
@@ -647,6 +650,7 @@ public [thisSetterReturnType type] [v.names.set]([v.atNullability][if type.beanF
   this.[v.name].clear();
   [/if]
   [v.names.addAll](elements);
+  [/if]
   [thisSetterReturn type]
 }
 
@@ -944,7 +948,7 @@ public [thisSetterReturnType type] [v.names.set]([v.atNullability][v.type] [v.na
 [template defineOrResetField Attribute v Boolean declare][defineOrResetFieldAlt v declare false][/template]
 
 [template defineOrResetFieldAlt Attribute v Boolean declare Boolean deferAllocation]
-[let fn][if not v.nullableCollector] final[/if][/let]
+[let fn][if v.finalField] final[/if][/let]
   [if v.containerType]
     [if v.generateEnumMap]
 [if declare]private[fn] java.util.EnumMap[v.genericArgs] [/if][v.name] = [if declare and v.nullableCollector]null[else]new java.util.EnumMap[v.genericArgs]([v.elementType].class)[/if];
@@ -965,9 +969,9 @@ public [thisSetterReturnType type] [v.names.set]([v.atNullability][v.type] [v.na
     [else if v.generateEnumSet]
 [if declare]private[fn] java.util.EnumSet[v.genericArgs] [/if][v.name] = [if declare and v.nullableCollector]null[else]java.util.EnumSet.noneOf([v.elementType].class)[/if];
     [else if v.setType]
-[if declare]private[fn] java.util.LinkedHashSet[v.genericArgs] [/if][v.name] = [if declare and v.nullableCollector]null[else]new java.util.LinkedHashSet[v.genericArgs]([if deferAllocation]0[/if])[/if];
+[if declare]private[fn] java.util.[if not v.style.jpaFriendlyModifiables]LinkedHash[/if]Set[v.genericArgs] [/if][v.name] = [if declare and v.nullableCollector]null[else]new java.util.LinkedHashSet[v.genericArgs]([if deferAllocation]0[/if])[/if];
     [else if v.listType]
-[if declare]private[fn] java.util.ArrayList[v.genericArgs] [/if][v.name] = [if declare and v.nullableCollector]null[else]new java.util.ArrayList[v.genericArgs]([if deferAllocation]0[/if])[/if];
+[if declare]private[fn] java.util.[if not v.style.jpaFriendlyModifiables]Array[/if]List[v.genericArgs] [/if][v.name] = [if declare and v.nullableCollector]null[else]new java.util.ArrayList[v.genericArgs]([if deferAllocation]0[/if])[/if];
     [else if v.optionalType]
 [if declare]private [v.type] [/if][v.name] = [optionalEmpty v];
     [else]

--- a/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
+++ b/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
@@ -303,6 +303,10 @@ public abstract class StyleInfo implements ValueMirrors.Style {
 
   @Value.Parameter
   @Override
+  public abstract boolean jpaFriendlyModifiables();
+
+  @Value.Parameter
+  @Override
   public abstract boolean allMandatoryParameters();
 
   @Value.Parameter
@@ -469,6 +473,7 @@ public abstract class StyleInfo implements ValueMirrors.Style {
         input.stagedBuilder(),
         input.builtinContainerAttributes(),
         input.beanFriendlyModifiables(),
+        input.jpaFriendlyModifiables(),
         input.allMandatoryParameters(),
         input.transientDerivedFields(),
         input.finalInstanceFields(),

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -1629,6 +1629,10 @@ public final class ValueAttribute extends TypeIntrospectionBase implements HasSt
     return typeKind.isCollectionOrMapping()
         && (isNullable() || containingType.isDeferCollectionAllocation());
   }
+  
+  public boolean isFinalField() {
+    return !(isNullableCollector() || style().jpaFriendlyModifiables());
+  }
 
   public boolean isDeferCollectionAllocation() {
     return typeKind.isCollectionOrMapping()

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -225,6 +225,8 @@ public final class ValueMirrors {
 
     boolean beanFriendlyModifiables() default false;
 
+    boolean jpaFriendlyModifiables() default false;
+
     boolean allMandatoryParameters() default false;
 
     String redactedMask() default "";

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -290,6 +290,10 @@ public final class ValueType extends TypeIntrospectionBase implements HasStyleIn
     return style().beanFriendlyModifiables();
   }
 
+  public boolean isJpaFriendlyModifiable() {
+    return style().jpaFriendlyModifiables();
+  }
+
   private boolean noGuavaInClasspath() {
     return !constitution.protoclass().environment().hasGuavaLib();
   }


### PR DESCRIPTION
This is a proposal that fixes #1230 by allowing the `jpaFriendlyModifiables` styles attribut to disable final modifier on getter method and use abstraction for collection rather than the concrete one.

I make an attribut similar to `beanFriendlyModifiables` who does some modification on the generator to make the rendered class compliant for a specific use case. Maybe it can be split in two attributs, one removing the final modifier, the other readjustint collection setters.