### PR TITLE
Write META-INF/services files when annotation processing is over

### DIFF
--- a/generator/src/org/immutables/generator/AbstractGenerator.java
+++ b/generator/src/org/immutables/generator/AbstractGenerator.java
@@ -86,6 +86,9 @@ public abstract class AbstractGenerator extends AbstractProcessor {
       if (!round.processingOver() && !round.errorRaised()) {
         process();
       }
+      if (round.processingOver()) {
+        StaticEnvironment.writeServiceFiles();
+      }
       StaticEnvironment.shutdown();
     } catch (Exception ex) {
       processingEnv.getMessager()

--- a/generator/src/org/immutables/generator/Output.java
+++ b/generator/src/org/immutables/generator/Output.java
@@ -189,14 +189,14 @@ public final class Output {
       Invokable body = (Invokable) parameters[1];
 
       ResourceKey key = new ResourceKey("", META_INF_SERVICES + interfaceName);
-      AppendServiceFile servicesFile = getFiles().appendResourceFiles.get(key);
+      AppendServiceFile servicesFile = getServiceFiles().appendResourceFiles.get(key);
       body.invoke(new Invokation(servicesFile.consumer));
       return null;
     }
   };
 
   private final static class ResourceKey {
-    private static Joiner PACKAGE_RESOURCE_JOINER = Joiner.on('.').skipNulls();
+    private static final Joiner PACKAGE_RESOURCE_JOINER = Joiner.on('.').skipNulls();
 
     final String packageName;
     final String relativeName;
@@ -391,6 +391,19 @@ public final class Output {
     }
   }
 
+  private static ServiceFiles getServiceFiles() {
+    return StaticEnvironment.getServiceFilesInstance(ServiceFiles.class, ServiceFilesSupplier.INSTANCE);
+  }
+
+  private enum ServiceFilesSupplier implements Supplier<ServiceFiles> {
+    INSTANCE;
+
+    @Override
+    public ServiceFiles get() {
+      return new ServiceFiles();
+    }
+  }
+
   // Do not use guava cache to slim down minimized jar
   @NotThreadSafe
   private static abstract class Cache<K, V> {
@@ -424,6 +437,12 @@ public final class Output {
       }
     };
 
+    @Override
+    public void complete() {
+    }
+  }
+
+  private static class ServiceFiles implements StaticEnvironment.Completable {
     final Cache<ResourceKey, AppendServiceFile> appendResourceFiles = new Cache<ResourceKey, AppendServiceFile>() {
       @Override
       public AppendServiceFile load(ResourceKey key) throws Exception {


### PR DESCRIPTION
When generating with another annotation processor classes that will be processed by the _Immutables_ generators that also write files in `META-INF/services` the Java Compiler issues a warning like
`javax.annotation.processing.FilerException: Attempt to reopen a file for path /my/project/build/classes/java/main/META-INF/services/com.google.gson.TypeAdapterFactory`. To workaround this problem we should write these files when the annotation processing is over.