### PR TITLE
Support for vavr option.

### DIFF
--- a/value-fixture/pom.xml
+++ b/value-fixture/pom.xml
@@ -150,6 +150,11 @@
       <version>2.0.0-RC4</version>
     </dependency>
     <dependency>
+      <groupId>io.vavr</groupId>
+      <artifactId>vavr</artifactId>
+      <version>0.10.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.annotation</artifactId>
       <version>2.0.0</version>

--- a/value-fixture/src/org/immutables/fixture/jdkonly/UsingAllOptionals.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/UsingAllOptionals.java
@@ -48,6 +48,9 @@ public interface UsingAllOptionals {
   @Value.Parameter
   javaslang.control.Option<String> jso();
 
+  @Value.Parameter
+  io.vavr.control.Option<String> vo();
+
   class Use {
     @SuppressWarnings("CheckReturnValue")
     void use() {
@@ -59,6 +62,7 @@ public interface UsingAllOptionals {
               .d1(1.1)
               .l1(OptionalLong.empty())
               .jso(javaslang.control.Option.none())
+              .vo(io.vavr.control.Option.none())
               .build();
 
       Objects.equals(value.v1(), value.v2());

--- a/value-processor/src/org/immutables/value/processor/meta/AttributeTypeKind.java
+++ b/value-processor/src/org/immutables/value/processor/meta/AttributeTypeKind.java
@@ -89,7 +89,8 @@ public enum AttributeTypeKind {
       "io.atlassian.fugue.Option"),
   OPTION_JAVASLANG(
       "Option",
-      "javaslang.control.Option"),
+      "javaslang.control.Option",
+      "io.vavr.control.Option"),
   CUSTOM_COLLECTION("", "");
 
   private final String[] rawTypes;


### PR DESCRIPTION
Javaslang was renamed to vavr quite a while back. Bringing back the support for new names.