### PR TITLE
Added eclipse compiler to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '13', '14', '15' ]
+        java: [ '8', '11', '15' ]
+        compiler: [ 'javac', 'ecj' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK
@@ -23,4 +24,4 @@ jobs:
     - name: print Java version
       run: java -version
     - name: Run tests
-      run: mvn --batch-mode --no-transfer-progress clean test
+      run: mvn --batch-mode --no-transfer-progress clean test -P${{ matrix.compiler }}

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -41,9 +41,9 @@
     </dependency>
     <dependency>
       <!-- only to have compile-time ECJ classes -->
-      <groupId>org.eclipse.jdt.core.compiler</groupId>
+      <groupId>org.eclipse.jdt</groupId>
       <artifactId>ecj</artifactId>
-      <version>4.4</version>
+      <version>3.25.0</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>

--- a/value-fixture/pom.xml
+++ b/value-fixture/pom.xml
@@ -216,7 +216,7 @@
     <profile>
       <id>jdk11</id>
       <activation>
-        <jdk>11</jdk>
+        <jdk>[11,17)</jdk>
       </activation>
       <properties>
         <maven.compiler.compilerVersion>11</maven.compiler.compilerVersion>
@@ -257,6 +257,9 @@
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
               <compilerId>eclipse</compilerId>
+              <compilerArgs combine.children="override">
+                <arg>-Xlint:unchecked</arg>
+              </compilerArgs>
             </configuration>
             <dependencies>
               <dependency>

--- a/value-fixture/pom.xml
+++ b/value-fixture/pom.xml
@@ -224,5 +224,31 @@
         <maven.compiler.target>11</maven.compiler.target>
       </properties>
     </profile>
+    <profile>
+      <id>ecj</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerId>eclipse</compilerId>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-compiler-eclipse</artifactId>
+                <version>2.8.8</version>
+              </dependency>
+              <dependency>
+                <groupId>org.eclipse.jdt</groupId>
+                <artifactId>ecj</artifactId>
+                <version>3.25.0</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/value-fixture/pom.xml
+++ b/value-fixture/pom.xml
@@ -228,6 +228,30 @@
       <id>ecj</id>
       <build>
         <plugins>
+          <!-- TODO: There's still a problem with some of the fixtures being compiled by ECJ.
+               And there's no way to exclude them using maven compiler plugin so we temporarily
+               delete them -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals><goal>clean</goal></goals>
+                <configuration>
+                  <filesets>
+                    <fileset>
+                      <directory>src/org/immutables/fixture/with</directory>
+                      <followSymlinks>false</followSymlinks>
+                      <includes>
+                        <include>Enc.java</include>
+                      </includes>
+                    </fileset>
+                  </filesets>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>

--- a/value-processor/src/org/immutables/value/processor/meta/Constitution.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Constitution.java
@@ -753,7 +753,7 @@ public abstract class Constitution {
         String superclassString = SourceExtraction.getSuperclassString(t);
         String rawSuperclass = SourceTypes.extract(superclassString).getKey();
         // We need to extend the base class
-        if (!rawSuperclass.equals(typeAbstract().toString())) {
+        if (!typeAbstract().toString().endsWith(rawSuperclass)) {
           protoclass()
                   .report()
                   .withElement(t)


### PR DESCRIPTION
Added eclipse compiler to build matrix. It only affects value-fixture module compilation.

Some fixtures didn't work so I fixed them.
Some fixtures still didn't work and it was much harder to figure out the right fix for them. So i temporarily excluded them from the eclipse compilation.

I also removed so EOLed Java versions from the build matrix to speed things up.