### PR TITLE
Forward Encoding method parameter annotations

### DIFF
--- a/value-processor/src/org/immutables/value/processor/encode/EncodedElement.java
+++ b/value-processor/src/org/immutables/value/processor/encode/EncodedElement.java
@@ -18,6 +18,7 @@ package org.immutables.value.processor.encode;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.immutables.generator.Naming;
@@ -276,18 +277,37 @@ public abstract class EncodedElement {
     @Value.Parameter
     abstract Type type();
 
+    @Value.Parameter
+    abstract List<String> annotations();
+
     @Override
     public String toString() {
-      return name() + ": " + type();
+      String annotationStr = "";
+      if (!annotations().isEmpty()) {
+        annotationStr = Joiner.on(' ').join(annotations()) + ' ';
+      }
+      return annotationStr + name() + ": " + type();
     }
 
     static Param of(String name, Type type) {
-      return ImmutableEncodedElement.Param.of(name, type);
+      return ImmutableEncodedElement.Param.of(name, type, ImmutableList.of());
+    }
+
+    static Param of(String name, Type type, List<String> annotations) {
+      return ImmutableEncodedElement.Param.of(name, type, annotations);
     }
 
     public static Param from(String input, Type.Parser parser) {
+      // continuously take annotations from the start of the string
+      List<String> annotations = new ArrayList<>();
+      while (input.startsWith("@")) {
+        String[] split = input.split(" ", 2);
+        annotations.add(split[0]);
+        input = split[1];
+      }
+
       List<String> parts = COLON_SPLITTER.splitToList(input);
-      return of(parts.get(0), parser.parse(parts.get(1)));
+      return of(parts.get(0), parser.parse(parts.get(1)), annotations);
     }
   }
 

--- a/value-processor/src/org/immutables/value/processor/encode/Encodings.java
+++ b/value-processor/src/org/immutables/value/processor/encode/Encodings.java
@@ -757,7 +757,8 @@ public abstract class Encodings extends AbstractTemplate {
       for (VariableElement v : method.getParameters()) {
         result.add(Param.of(
             v.getSimpleName().toString(),
-            typesReader.get(v.asType())));
+            typesReader.get(v.asType()),
+            ImmutableList.copyOf(annotationsFrom(v))));
       }
       if (!result.isEmpty() && method.isVarArgs()) {
         Param last = Iterables.getLast(result);

--- a/value-processor/src/org/immutables/value/processor/encode/Renderers.generator
+++ b/value-processor/src/org/immutables/value/processor/encode/Renderers.generator
@@ -123,7 +123,7 @@ this.[inst.directField f] = [inst.codeThisFields f];
 
 [doc inst el]
 [annots el]
-[if el.private]private [else]public [/if][if el.final]final [/if][type.typeImmutable.simple][type.generics.args] [inst.namer el]([for p in el.params][if not for.first], [/if][inst.typer p.type] [p.name][/for])[throwsClause inst el] {
+[if el.private]private [else]public [/if][if el.final]final [/if][type.typeImmutable.simple][type.generics.args] [inst.namer el]([for p in el.params][if not for.first], [/if][for ann in p.annotations][ann] [/for][inst.typer p.type] [p.name][/for])[throwsClause inst el] {
   [inst.typer el.type] newValue = [if el.oneLiner][inst.fragmentOf el][else]with_[inst.namer el]([for p in el.params][if not for.first], [/if][p.name][/for])[/if];
   [if not inst.encoding.impl.virtual]
   if (this.[a.name] == newValue) return this;
@@ -149,7 +149,7 @@ private[if not el.usesThis] static[/if] [inst.typer el.type] with_[inst.namer el
 [ann]
   [/for]
 [/if]
-[if el.private]private [else]public [/if][if el.final]final [/if][builderReturnType a] [inst.namer el]([for p in el.params][if not for.first], [/if][inst.typer p.type] [p.name][/for])[throwsClause inst el] [inst.codeOf el]return [builderReturnThis a][/inst.codeOf]
+[if el.private]private [else]public [/if][if el.final]final [/if][builderReturnType a] [inst.namer el]([for p in el.params][if not for.first], [/if][for ann in p.annotations][ann] [/for][inst.typer p.type] [p.name][/for])[throwsClause inst el] [inst.codeOf el]return [builderReturnThis a][/inst.codeOf]
 [/for]
 [/template]
 


### PR DESCRIPTION
Fixes https://github.com/immutables/immutables/issues/1307.

Method parameter annotations in Encodings are now stored in `Param#annotations()`, and the toString/parsing is adjusted to support this with the format `"@Foo @Bar param: Type"`. The Renderers generator is updated to add these annotations to the generated source.

I'm very new to the codebase, so please let me know if you have any suggestions.