### PR TITLE
Fix five flaky tests in value-fixture

### DIFF
--- a/value-fixture/test/org/immutables/fixture/jackson/BugsTest.java
+++ b/value-fixture/test/org/immutables/fixture/jackson/BugsTest.java
@@ -65,6 +65,7 @@ public class BugsTest {
     check(info.abraCadabra()).is(1);
     check(info.focusPocus());
 
-    check(json).is("{'abra_cadabra':1,'focus_pocus':true}".replace('\'', '"'));
+    check(json).matches("\\{(?:'abra_cadabra':1,'focus_pocus':true|'focus_pocus':true,'abra_cadabra':1)}"
+            .replace('\'', '"'));
   }
 }

--- a/value-fixture/test/org/immutables/fixture/jackson/ObjectMappedTest.java
+++ b/value-fixture/test/org/immutables/fixture/jackson/ObjectMappedTest.java
@@ -149,8 +149,9 @@ public class ObjectMappedTest {
   @Test
   public void anyGetterSetter() throws Exception {
     String json = "{\"A\":1,\"B\":true}";
+    String jsonRegex = "\\{(?:\"A\":1,\"B\":true|\"B\":true,\"A\":1)}";
     AnyGetterSetter value = OBJECT_MAPPER.readValue(json, AnyGetterSetter.class);
-    check(OBJECT_MAPPER.writeValueAsString(value)).is(json);
+    check(OBJECT_MAPPER.writeValueAsString(value)).matches(jsonRegex);
   }
 
   @Test
@@ -163,15 +164,19 @@ public class ObjectMappedTest {
   @Test
   public void jacksonMetaAnnotated() throws Exception {
     String json = "{\"X\":1,\"A\":1,\"B\":true}";
+    String jsonRegex = "\\{(?:\"X\":1,(?:\"A\":1,\"B\":true|\"B\":true,\"A\":1)|"
+            + "\"B\":true,(?:\"X\":1,\"A\":1|\"A\":1,\"X\":1)|"
+            + "\"A\":1,(?:\"B\":true,\"X\":1|\"X\":1,\"B\":true))}";
     ImmutableJacksonUsingMeta value = OBJECT_MAPPER.readValue(json, ImmutableJacksonUsingMeta.class);
-    check(OBJECT_MAPPER.writeValueAsString(value)).is(json);
+    check(OBJECT_MAPPER.writeValueAsString(value)).matches(jsonRegex);
   }
 
   @Test
   public void keywordNames() throws Exception {
     String json = "{\"long\":111,\"default\":true}";
+    String jsonRegex = "\\{(?:\"long\":111,\"default\":true|\"default\":true,\"long\":111)}";
     KeywordNames value = OBJECT_MAPPER.readValue(json, KeywordNames.class);
-    check(OBJECT_MAPPER.writeValueAsString(value)).is(json);
+    check(OBJECT_MAPPER.writeValueAsString(value)).matches(jsonRegex);
   }
 
   @Test

--- a/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
+++ b/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
@@ -210,8 +210,8 @@ public class ModifiablesTest {
     check(m.a()).isOf("a", "b", "c");
     check(m.b()).isOf("d", "e");
 
-    check(m.c().values()).isOf(1, 2);
-    check(m.c().keySet()).isOf("x", "y");
+    check(m.c().values()).hasContentInAnyOrder(1, 2);
+    check(m.c().keySet()).hasContentInAnyOrder("x", "y");
 
     check(m.d().isEmpty());
 


### PR DESCRIPTION
These were all detected with [NonDex](https://github.com/TestingResearchIllinois/NonDex); these fixes make the tests agnostic to the order of items in collections or entries in JSON objects.