### PR TITLE
No explicit opens by using Add Opens manifest entry.

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -63,6 +63,22 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Add-Opens>jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</Add-Opens>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>pargen</id>

--- a/value-fixture/pom.xml
+++ b/value-fixture/pom.xml
@@ -262,27 +262,6 @@
       </build>
     </profile>
     <profile>
-      <id>jdk16</id>
-      <activation>
-        <jdk>[16,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <fork>true</fork>
-              <compilerArgs combine.children="append">
-                <!-- required by javac detection logic in immutables -->
-                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-              </compilerArgs>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>jdk16-errorprone</id>
       <activation>
         <jdk>[16,)</jdk>


### PR DESCRIPTION
Turns out we can include required module patches via manifest entry.