### PR TITLE
Add Opens follow up.

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -63,22 +63,6 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Add-Opens>jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</Add-Opens>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <profiles>
     <profile>
       <id>pargen</id>

--- a/value-fixture/pom.xml
+++ b/value-fixture/pom.xml
@@ -262,6 +262,27 @@
       </build>
     </profile>
     <profile>
+      <id>jdk16</id>
+      <activation>
+        <jdk>[16,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <compilerArgs combine.children="override">
+                <!-- required by javac detection logic in immutables -->
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>jdk16-errorprone</id>
       <activation>
         <jdk>[16,)</jdk>


### PR DESCRIPTION
Turns out Add-Opens never worked.

The reason it worked prior is that errorprone related opens are declared globally and therefore Immutables always had access to privileged compiler APIs.

This PR reinstates necessary flags back not to be deceived by what's going on.