### PR TITLE
Could org.immutables:testing:2.9.1-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -43,21 +43,45 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>${junit5.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apiguardian</groupId>
+          <artifactId>apiguardian-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit5.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apiguardian</groupId>
+          <artifactId>apiguardian-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <version>${junit5.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apiguardian</groupId>
+          <artifactId>apiguardian-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <version>${junit5.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apiguardian</groupId>
+          <artifactId>apiguardian-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -72,11 +96,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <version>${hamcrest.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-integration</artifactId>
       <version>${hamcrest.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Hi! I found the pom file of project **_org.immutables:testing:2.9.1-SNAPSHOT_** introduced **_18_** dependencies. However, among them, **_2_** libraries (**_11%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.hamcrest:hamcrest-integration:jar:1.3:compile
org.apiguardian:apiguardian-api:jar:1.1.0:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_org.apiguardian:apiguardian-api:jar:1.1.0:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_org.immutables:testing:2.9.1-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_org.immutables:testing:2.9.1-SNAPSHOT_**’s maven tests.

Best regards
![image](https://user-images.githubusercontent.com/78527112/166401968-f415a64d-941c-4684-8560-e9dc02ce6e92.png)
