### PR TITLE
Avoid invalidating Gson type adapter cache when creating Mongo Repository

### DIFF
--- a/mongo/pom.xml
+++ b/mongo/pom.xml
@@ -141,6 +141,7 @@
             <configuration>
               <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
               <argLine>--add-opens=java.base/java.util=ALL-UNNAMED</argLine>
+              <argLine>--add-opens=java.base/java.util.regex=ALL-UNNAMED</argLine>
               <argLine>--add-opens=java.base/java.time=ALL-UNNAMED</argLine>
             </configuration>
           </plugin>

--- a/mongo/src/org/immutables/mongo/repository/RepositorySetup.java
+++ b/mongo/src/org/immutables/mongo/repository/RepositorySetup.java
@@ -24,7 +24,6 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapterFactory;
 import com.mongodb.DB;
 import com.mongodb.MongoClient;
-import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoClientURI;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
@@ -220,22 +219,7 @@ public final class RepositorySetup {
     public Builder gson(Gson gson) {
       checkNotNull(gson, "gson");
 
-      // Will be used as a factory for BSON types (if Gson does not have one). By default, uses
-      // TypeAdapter(s) from Gson if they're explicitly defined (not a ReflectiveTypeAdapter).
-      // Otherwise delegate to BSON codec.
-      TypeAdapterFactory bsonAdapterFactory = GsonCodecs.delegatingTypeAdapterFactory(
-              MongoClientSettings.getDefaultCodecRegistry()
-      );
-
-      // Appending new TypeAdapterFactory to allow Gson and Bson adapters to co-exists.
-      // Depending on the type we may need to use one or another. For instance,
-      // Date should be serialized by Gson (even if Bson has codec for it).
-      // But ObjectId / Decimal128 by BSON (if Gson doesn't have a type adapter for it).
-      // Document or BsonDocument should only be handled by BSON (it's unlikely that users have direct dependency on them in POJOs).
-      // So newGson is a way to extend existing Gson instance with "BSON TypeAdapter(s)"
-      Gson newGson = gson.newBuilder()
-              .registerTypeAdapterFactory(bsonAdapterFactory)
-              .create();
+      Gson newGson = GsonCodecs.newGsonWithBsonSupport(gson);
 
       // expose new Gson as CodecRegistry. Using fromRegistries() for caching
       CodecRegistry codecRegistry = CodecRegistries.fromRegistries(GsonCodecs.codecRegistryFromGson(newGson));

--- a/mongo/src/org/immutables/mongo/repository/RepositorySetup.java
+++ b/mongo/src/org/immutables/mongo/repository/RepositorySetup.java
@@ -120,21 +120,21 @@ public final class RepositorySetup {
         return member.getName();
       }
     };
+  }
 
-    /**
-     * Uses {@link Gson#fieldNamingStrategy()} to translate names.
-     */
-    class GsonNamingStrategy implements FieldNamingStrategy {
-      private final Gson gson;
+  /**
+   * Uses {@link Gson#fieldNamingStrategy()} to translate names.
+   */
+  public static class GsonNamingStrategy implements FieldNamingStrategy {
+    private final Gson gson;
 
-      private GsonNamingStrategy(Gson gson) {
-        this.gson = Preconditions.checkNotNull(gson, "gson");
-      }
+    public GsonNamingStrategy(Gson gson) {
+      this.gson = Preconditions.checkNotNull(gson, "gson");
+    }
 
-      @Override
-      public String translateName(Member member) {
-        return gson.fieldNamingStrategy().translateName((Field) member);
-      }
+    @Override
+    public String translateName(Member member) {
+      return gson.fieldNamingStrategy().translateName((Field) member);
     }
   }
 
@@ -224,7 +224,7 @@ public final class RepositorySetup {
       // expose new Gson as CodecRegistry. Using fromRegistries() for caching
       CodecRegistry codecRegistry = CodecRegistries.fromRegistries(GsonCodecs.codecRegistryFromGson(newGson));
 
-      return codecRegistry(codecRegistry, new FieldNamingStrategy.GsonNamingStrategy(gson));
+      return codecRegistry(codecRegistry, new GsonNamingStrategy(gson));
     }
 
     /**

--- a/mongo/test/org/immutables/mongo/bson4gson/GsonCodecsTest.java
+++ b/mongo/test/org/immutables/mongo/bson4gson/GsonCodecsTest.java
@@ -1,7 +1,10 @@
 package org.immutables.mongo.bson4gson;
 
+import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapter;
+import com.google.gson.internal.bind.ReflectiveTypeAdapterFactory;
+import org.bson.BsonDecimal128;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;
 import org.bson.BsonType;
@@ -22,7 +25,7 @@ public class GsonCodecsTest {
   }
 
   @Test
-  public void dateCodec() throws IOException {
+  public void typeAdapterFromDateCodec() throws IOException {
     TypeAdapter<Date> adapter = GsonCodecs.typeAdapterFromCodec(new DateCodec());
     Date date = new Date();
     BsonDocument doc = new BsonDocument();
@@ -36,4 +39,16 @@ public class GsonCodecsTest {
     check(doc.get("$date").getBsonType()).is(BsonType.DATE_TIME);
     check(doc.get("$date").asDateTime().getValue()).is(date.getTime());
   }
+
+  @Test
+  public void newGsonWithBsonSupport() {
+    Gson gson = new Gson();
+    Gson actual = GsonCodecs.newGsonWithBsonSupport(gson);
+
+    check(actual).not().same(gson);
+
+    check(gson.getAdapter(BsonDecimal128.class)).isA(ReflectiveTypeAdapterFactory.Adapter.class);
+    check(actual.getAdapter(BsonDecimal128.class)).not().isA(ReflectiveTypeAdapterFactory.Adapter.class);
+  }
+
 }

--- a/mongo/test/org/immutables/mongo/fixture/GsonRepoTest.java
+++ b/mongo/test/org/immutables/mongo/fixture/GsonRepoTest.java
@@ -1,0 +1,190 @@
+/*
+   Copyright 2016 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package org.immutables.mongo.fixture;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.BsonDocument;
+import org.bson.BsonNull;
+import org.bson.types.ObjectId;
+import org.immutables.gson.Gson;
+import org.immutables.mongo.Mongo;
+import org.immutables.mongo.bson4jackson.JacksonCodecs;
+import org.immutables.mongo.repository.RepositorySetup;
+import org.immutables.mongo.types.TypeAdapters;
+import org.immutables.value.Value;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.text.DateFormat;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Locale;
+import java.util.ServiceLoader;
+import java.util.UUID;
+
+import static org.immutables.check.Checkers.check;
+
+/**
+ * Tests for repository using <a href="https://github.com/FasterXML/jackson">Jackson</a> library.
+ *
+ * @see JacksonCodecs
+ */
+public class GsonRepoTest {
+
+  @Rule
+  public final MongoContext context = MongoContext.create();
+
+  private GsonEntityRepository repository;
+  private MongoCollection<BsonDocument> collection;
+
+  @Before
+  public void setUp() throws Exception {
+    final MongoDatabase database = context.database();
+    this.collection = database.getCollection("gsonEntity").withDocumentClass(BsonDocument.class);
+
+    GsonBuilder gson = new GsonBuilder();
+
+    // this one is no longer auto-registered
+    gson.registerTypeAdapterFactory(new TypeAdapters());
+    for (TypeAdapterFactory factory : ServiceLoader.load(TypeAdapterFactory.class)) {
+      gson.registerTypeAdapterFactory(factory);
+    }
+
+    RepositorySetup setup = RepositorySetup.builder()
+        .database(database)
+        .gson(gson.create())
+        .executor(MoreExecutors.newDirectExecutorService())
+        .build();
+
+    this.repository = new GsonEntityRepository(setup);
+  }
+
+  @Test
+  public void withDate() {
+    final Date date = new Date();
+    final ObjectId id = ObjectId.get();
+    final GsonEntity entity = ImmutableGsonEntity.builder()
+        .id(id)
+        .prop1("prop11")
+        .prop2("prop22")
+        .date(new Date(date.getTime()))
+        .build();
+
+    repository.insert(entity).getUnchecked();
+
+    check(collection.countDocuments()).is(1L);
+
+    // Gson serialises Date using SimpleDateFormat, which loses milliseconds
+    final Date expectedDate = Date.from(
+        ZonedDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault())
+            .truncatedTo(ChronoUnit.SECONDS)
+            .toInstant());
+    final GsonEntity expected = ImmutableGsonEntity.builder().from(entity)
+        .date(expectedDate)
+        .build();
+
+    final GsonEntity actual = repository.findAll().fetchAll().getUnchecked().get(0);
+    check(expected).is(actual);
+
+    final BsonDocument doc = collection.find().first();
+    check(doc.keySet()).hasContentInAnyOrder("_id", "prop1", "prop_two", "date", "uuid");
+    final String expectedDateAsString = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.US).format(expectedDate);
+    check(doc.get("date").asString().getValue()).is(expectedDateAsString);
+    check(doc.get("_id").asObjectId().getValue()).is(id);
+  }
+
+  /**
+   * persist empty Optional of Date
+   */
+  @Test
+  public void nullDate() {
+    final GsonEntity expected = ImmutableGsonEntity.builder()
+        .id(ObjectId.get())
+        .prop1("prop11")
+        .prop2("prop22")
+        .build();
+
+    repository.insert(expected).getUnchecked();
+
+    final GsonEntity actual = repository.findAll()
+        .fetchAll().getUnchecked().get(0);
+
+    check(expected.date().asSet()).isEmpty();
+    check(expected).is(actual);
+    final BsonDocument doc = collection.find().first();
+    check(doc.keySet()).hasContentInAnyOrder("_id", "prop1", "prop_two", "date", "uuid");
+    check(doc.get("date")).is(BsonNull.VALUE);
+  }
+
+  @Test
+  public void criteria() {
+    final Date date = Date.from(ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS).toInstant());
+
+    final ObjectId id = ObjectId.get();
+    final UUID uuid = UUID.randomUUID();
+    final GsonEntity expected = ImmutableGsonEntity.builder()
+        .id(id)
+        .prop1("prop11")
+        .prop2("prop22")
+        .date(date)
+        .uuid(uuid)
+        .build();
+
+    repository.insert(expected).getUnchecked();
+
+    check(repository.find(repository.criteria().prop1("prop11")).fetchAll().getUnchecked()).hasContentInAnyOrder(expected);
+    check(repository.find(repository.criteria().prop1("missing")).fetchAll().getUnchecked()).isEmpty();
+    check(repository.find(repository.criteria().prop2("prop22")).fetchAll().getUnchecked()).hasContentInAnyOrder(expected);
+    check(repository.find(repository.criteria().id(id)).fetchAll().getUnchecked()).hasContentInAnyOrder(expected);
+    check(repository.find(repository.criteria().date(date)).fetchAll().getUnchecked()).hasContentInAnyOrder(expected);
+    check(repository.find(repository.criteria().date(new Date(42))).fetchAll().getUnchecked()).isEmpty();
+    check(repository.find(repository.criteria().uuid(uuid)).fetchAll().getUnchecked()).hasContentInAnyOrder(expected);
+    check(repository.find(repository.criteria().uuid(UUID.randomUUID())).fetchAll().getUnchecked()).isEmpty();
+  }
+
+  @Mongo.Repository
+  @Value.Immutable
+  @Gson.TypeAdapters
+  interface GsonEntity {
+
+    @Mongo.Id
+    @JsonProperty("_id")
+    ObjectId id();
+
+    String prop1();
+
+    @SerializedName("prop_two")
+    String prop2();
+
+    Optional<Date> date();
+
+    @Nullable
+    UUID uuid();
+  }
+}


### PR DESCRIPTION
Avoid invalidating Gson type adapter cache when creating Mongo Repository.

We only register the delegatingTypeAdapterFactory if Gson does not have TypeAdapters registered for all Bson related types