### PR TITLE
fixing #1407 - Default value with explicit null should use default.

### DIFF
--- a/value-fixture/src/org/immutables/fixture/jackson/StagedEntity.java
+++ b/value-fixture/src/org/immutables/fixture/jackson/StagedEntity.java
@@ -1,0 +1,20 @@
+package org.immutables.fixture.jackson;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+
+@Value.Style(stagedBuilder = true)
+@JsonDeserialize(as = ImmutableStagedEntity.class)
+public interface StagedEntity {
+  String getRequired();
+  @Value.Default
+  default String getOptional() {
+    return "default";
+  }
+  @Value.Default
+  default boolean getOptionalPrimitive() {
+    return false;
+  }
+}

--- a/value-fixture/test/org/immutables/fixture/jackson/ObjectMappedTest.java
+++ b/value-fixture/test/org/immutables/fixture/jackson/ObjectMappedTest.java
@@ -243,4 +243,14 @@ public class ObjectMappedTest {
 
     check(OBJECT_MAPPER.writeValueAsString(values)).is(json);
   }
+
+  @Test
+  public void jsonStagedEntityRoundtrip() throws Exception {
+    String json = "{\"required\":\"id\",\"optional\":null,\"optionalPrimitive\":null}";
+
+    StagedEntity nullable =
+        OBJECT_MAPPER.readValue(json, StagedEntity.class);
+
+    check(OBJECT_MAPPER.writeValueAsString(nullable)).is("{\"required\":\"id\",\"optional\":\"default\",\"optionalPrimitive\":false}");
+  }
 }

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -2879,8 +2879,10 @@ static final [output.linesShortable]class Json[type.generics]
   [eachLine v.initializerInjectedAnnotations]
   public void [v.names.beanSet]([v.atNullability][v.type] [v.name]) {
     this.[v.name] = [v.name];
-    [if v.primitive or (v.requiresTrackIsSet andnot v.jacksonAnyGetter)]
+    [if v.primitive]
     this.[disambiguateField type (v.name 'IsSet')] = true;
+    [else if v.requiresTrackIsSet andnot v.jacksonAnyGetter]
+    this.[disambiguateField type (v.name 'IsSet')] = [if v.nullable]true[else]null != [v.name][/if];
     [/if]
   }
 [/for]


### PR DESCRIPTION
Fixing an issue with Jackson and staged builder feature interaction.

Essentially, null values are not allowed when the immutable entry is identified as not nullable.