### PR TITLE
Fix counts in WriteResult for upsert operation

### DIFF
--- a/criteria/mongo/src/org/immutables/criteria/mongo/MongoSession.java
+++ b/criteria/mongo/src/org/immutables/criteria/mongo/MongoSession.java
@@ -237,7 +237,7 @@ class MongoSession implements Backend.Session {
     Publisher<BulkWriteResult> publisher = ((MongoCollection<Object>) collection).bulkWrite(docs);
     return Flowable.fromPublisher(publisher).map(x -> WriteResult.empty()
             .withUpdatedCount(x.getModifiedCount())
-            .withInsertedCount(x.getInsertedCount())
+            .withInsertedCount(operation.upsert() ? x.getUpserts().size() : x.getInsertedCount())
             .withDeletedCount(x.getDeletedCount()));
   }
 

--- a/criteria/mongo/test/org/immutables/criteria/mongo/MongoWriteResultTest.java
+++ b/criteria/mongo/test/org/immutables/criteria/mongo/MongoWriteResultTest.java
@@ -88,4 +88,24 @@ class MongoWriteResultTest {
     check(result2.insertedCount().getAsLong()).is(0L);
     check(result2.deletedCount().getAsLong()).is(0L);
   }
+
+  @Test
+  void upsert() {
+    ImmutablePerson person1 = generator.next();
+    WriteResult result = repository.upsert(person1);
+    check(result.insertedCount().getAsLong()).is(1L);
+    check(result.deletedCount().getAsLong()).is(0L);
+    check(result.updatedCount().getAsLong()).is(0L);
+
+    result = repository.upsert(person1.withFullName("name1"));
+    check(result.insertedCount().getAsLong()).is(0L);
+    check(result.deletedCount().getAsLong()).is(0L);
+    check(result.updatedCount().getAsLong()).is(1L);
+
+    WriteResult result2 = repository.upsertAll(ImmutableList.of(person1.withFullName("name2"), generator.next()));
+    check(result2.insertedCount().getAsLong()).is(1L);
+    check(result2.deletedCount().getAsLong()).is(0L);
+    check(result2.updatedCount().getAsLong()).is(1L);
+  }
+
 }


### PR DESCRIPTION
This PR fixes insert counters for the upsert operation described in https://github.com/immutables/immutables/issues/1376  Mongo doesn't provide it as `insertedCount`, but it could be get from the size of `upserts` collection