### PR TITLE
1387 criteria reader doesn't respect getter prefixes

### DIFF
--- a/criteria/mongo/src/org/immutables/criteria/mongo/MongoSession.java
+++ b/criteria/mongo/src/org/immutables/criteria/mongo/MongoSession.java
@@ -38,17 +38,7 @@ import org.bson.codecs.EncoderContext;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
-import org.immutables.criteria.backend.Backend;
-import org.immutables.criteria.backend.BackendException;
-import org.immutables.criteria.backend.DefaultResult;
-import org.immutables.criteria.backend.ExpressionNaming;
-import org.immutables.criteria.backend.KeyExtractor;
-import org.immutables.criteria.backend.PathNaming;
-import org.immutables.criteria.backend.ProjectedTuple;
-import org.immutables.criteria.backend.StandardOperations;
-import org.immutables.criteria.backend.UniqueCachedNaming;
-import org.immutables.criteria.backend.WatchEvent;
-import org.immutables.criteria.backend.WriteResult;
+import org.immutables.criteria.backend.*;
 import org.immutables.criteria.expression.Collation;
 import org.immutables.criteria.expression.ExpressionConverter;
 import org.immutables.criteria.expression.Path;
@@ -78,13 +68,14 @@ class MongoSession implements Backend.Session {
     this.collection = Objects.requireNonNull(collection, "collection");
     this.keyExtractor = Objects.requireNonNull(keyExtractor, "keyExtractor");
 
-    PathNaming pathNaming = PathNaming.defaultNaming();
-    KeyExtractor.KeyMetadata metadata = keyExtractor.metadata();
+
+    final KeyExtractor.KeyMetadata metadata = keyExtractor.metadata();
     if (metadata.isKeyDefined() && metadata.isExpression() && metadata.keys().size() == 1) {
-      Path idProperty = Visitors.toPath(Iterables.getOnlyElement(metadata.keys()));
-      pathNaming = new MongoPathNaming(idProperty, pathNaming);
+      final Path idProperty = Visitors.toPath(Iterables.getOnlyElement(metadata.keys()));
+      this.pathNaming = new MongoPathNaming(idProperty, new JavaBeanNaming());
+    } else {
+      this.pathNaming = new JavaBeanNaming();
     }
-    this.pathNaming = pathNaming;
     this.converter = Mongos.converter(this.pathNaming, collection.getCodecRegistry());
   }
 

--- a/criteria/mongo/test/issue1387/org/immutables/criteria/mongo/Sample.java
+++ b/criteria/mongo/test/issue1387/org/immutables/criteria/mongo/Sample.java
@@ -1,0 +1,56 @@
+package issue1387.org.immutables.criteria.mongo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.criteria.Criteria;
+import org.immutables.value.Value;
+
+import java.util.UUID;
+
+@Value.Immutable
+@Criteria.Repository
+@Criteria
+@JsonSerialize(as = ImmutableSample.class)
+@JsonDeserialize(as = ImmutableSample.class)
+ public interface Sample{
+
+    @Criteria.Id
+    @JsonProperty("_id")
+    public String getId();
+
+
+    //getter
+    public String getName();
+
+    //property name
+    public String surname();
+
+
+    public static Sample createRandom() {
+        final Sample sample = Sample.builder()
+                .id(UUID.randomUUID().toString())
+                .name("Name " + System.currentTimeMillis())
+                .surname("Surname " + System.currentTimeMillis())
+                .build();
+        return sample;
+    }
+
+    /**
+     *
+     */
+    public static final class Builder extends ImmutableSample.Builder {
+        Builder() {
+
+        }
+    }
+
+    /**
+     * Get the builder
+     *
+     * @return
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+}

--- a/criteria/mongo/test/issue1387/org/immutables/criteria/mongo/SampleTest.java
+++ b/criteria/mongo/test/issue1387/org/immutables/criteria/mongo/SampleTest.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoDatabase;
+import de.bwaldvogel.mongo.MongoServer;
+import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.immutables.criteria.mongo.MongoBackend;
 import org.immutables.criteria.mongo.MongoSetup;
@@ -13,107 +15,142 @@ import org.immutables.criteria.mongo.bson4jackson.BsonModule;
 import org.immutables.criteria.mongo.bson4jackson.IdAnnotationModule;
 import org.immutables.criteria.mongo.bson4jackson.JacksonCodecs;
 import org.immutables.criteria.repository.sync.SyncReader;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.*;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * This test is created to in the context of https://github.com/immutables/immutables/issues/1387 .
+ * Specifically it tests that @<code>*Repository.find(Criterion<T>)</code> can work using fields specified with getters.
+ * E.g. getName() and getSurname() work with the update
+ *
+ * @author Spyros Koukas
+ */
 public class SampleTest {
+
+    private final String databaseName = "test";
+
+
+    private String mongoConnectionString;
+    private MongoServer mongoServer;
+    private MongoClient mongoClient;
+    private SampleRepository sampleRepository;
+
+    @Before
+    public void beforeTest() {
+        try {
+            this.mongoServer = new MongoServer(new MemoryBackend());
+            this.mongoServer.bind();
+            final InetSocketAddress socketAddress = this.mongoServer.getLocalAddress();
+            this.mongoConnectionString = "mongodb://" + socketAddress.getHostString() + ":" + socketAddress.getPort();
+
+        } catch (final Exception exception) {
+            Assume.assumeNoException("Exception while creating Mongo Server for tests", exception);
+        }
+        try {
+            this.mongoClient = MongoClients.create(this.mongoConnectionString);
+
+        } catch (final Exception exception) {
+            Assume.assumeNoException("Exception while creating Mongo Client for tests", exception);
+        }
+
+        try {
+            final CodecRegistry registry = JacksonCodecs.registryFromMapper(new ObjectMapper().registerModule(new BsonModule())  // register default codecs like Jsr310, BsonValueCodec, ValueCodecProvider etc.
+                    .registerModule(new GuavaModule()) // for Immutable* classes from Guava (eg. ImmutableList)
+                    .registerModule(new Jdk8Module()) // used for java 8 types like Optional / OptionalDouble etc.
+                    .registerModule(new IdAnnotationModule())); // used for Criteria.Id to '_id' attribute mapping);
+            final MongoDatabase mongoDatabase = this.mongoClient.getDatabase(this.databaseName).withCodecRegistry(registry);
+
+            final MongoSetup setup = MongoSetup.of(mongoDatabase);
+            final MongoBackend mongoBackend = new MongoBackend(setup);
+            this.sampleRepository = new SampleRepository(mongoBackend);
+            for (int i = 0; i < 10; i++) {
+                sampleRepository.insert(Sample.createRandom());
+            }
+        } catch (final Exception exception) {
+            Assume.assumeNoException("Exception while creating random samples", exception);
+        }
+    }
+
+    @After
+    public void afterTest() {
+        try {
+            if (this.mongoClient != null) {
+                this.mongoClient.close();
+                this.mongoClient = null;
+            }
+        } catch (final Exception exception) {
+            //Silent
+        }
+        try {
+            if (this.mongoServer != null) {
+                this.mongoServer.shutdown();
+                this.mongoServer = null;
+            }
+        } catch (final Exception exception) {
+            //Silent
+        }
+        this.sampleRepository = null;
+    }
 
 
     @Test
     public void getSampleByIdMongoBackend() {
-        final String databaseName="test";
-        ObjectMapper mapper = new ObjectMapper()
-                .registerModule(new BsonModule())  // register default codecs like Jsr310, BsonValueCodec, ValueCodecProvider etc.
-                .registerModule(new GuavaModule()) // for Immutable* classes from Guava (eg. ImmutableList)
-                .registerModule(new Jdk8Module()) // used for java 8 types like Optional / OptionalDouble etc.
-                .registerModule(new IdAnnotationModule()); // used for Criteria.Id to '_id' attribute mapping
-//        mapper.getPropertyNamingStrategy().nameForGetterMethod()
-        final CodecRegistry registry = JacksonCodecs.registryFromMapper(mapper);
 
 
-        final MongoClient client = MongoClients.create("mongodb://127.0.0.1/"+databaseName);
+        try {
 
-        final MongoDatabase mongoDatabase = client.getDatabase(databaseName).withCodecRegistry(registry);
-        final MongoSetup setup = MongoSetup.of(mongoDatabase);
-        final MongoBackend mongoBackend = new MongoBackend(setup);
-        final SampleRepository sampleRepository = new SampleRepository(mongoBackend);
-        for (int i = 0; i < 10; i++) {
-            sampleRepository.insert(Sample.createRandom());
+            final Optional<Sample> sampleOptional = this.sampleRepository.findAll().fetch().stream().findAny();
+            Assume.assumeTrue(sampleOptional.isPresent());
+            final Sample sample = sampleOptional.get();
+            final String sampleId = sample.getId();
+
+            final SyncReader<Sample> syncReader = this.sampleRepository.find(SampleCriteria.sample.id.is(sampleId));
+            final List<Sample> samples = syncReader.fetch();
+            Assert.assertTrue("Could not fetch any elements by id:[" + sampleId + "]", !samples.isEmpty());
+        } catch (final Exception exception) {
+            Assume.assumeNoException(exception);
+            throw new RuntimeException(exception);
         }
-        final Optional<Sample> sampleOptional = sampleRepository.findAll().fetch().stream().findAny();
-        Assume.assumeTrue(sampleOptional.isPresent());
-        final Sample sample = sampleOptional.get();
-        final String sampleId = sample.getId();
-
-        final SyncReader<Sample> syncReader = sampleRepository.find(SampleCriteria.sample.id.is(sampleId));
-        final List<Sample> samples = syncReader.fetch();
-        Assert.assertTrue("Could not fetch any elements by id:[" + sampleId+"]", !samples.isEmpty());
     }
 
 
     @Test
     public void getSampleByNameMongoBackend() {
-        final String databaseName="test";
-        ObjectMapper mapper = new ObjectMapper()
-                .registerModule(new BsonModule())  // register default codecs like Jsr310, BsonValueCodec, ValueCodecProvider etc.
-                .registerModule(new GuavaModule()) // for Immutable* classes from Guava (eg. ImmutableList)
-                .registerModule(new Jdk8Module()) // used for java 8 types like Optional / OptionalDouble etc.
-                .registerModule(new IdAnnotationModule()); // used for Criteria.Id to '_id' attribute mapping
-        final CodecRegistry registry = JacksonCodecs.registryFromMapper(mapper);
-
-
-        final MongoClient client = MongoClients.create("mongodb://127.0.0.1/"+databaseName);
-
-        final MongoDatabase mongoDatabase = client.getDatabase(databaseName).withCodecRegistry(registry);
-        final MongoSetup setup = MongoSetup.of(mongoDatabase);
-        final MongoBackend mongoBackend = new MongoBackend(setup);
-        final SampleRepository sampleRepository = new SampleRepository(mongoBackend);
-        for (int i = 0; i < 1; i++) {
-            sampleRepository.insert(Sample.createRandom());
+        try {
+            final Optional<Sample> sampleOptional = this.sampleRepository.findAll().fetch().stream().findAny();
+            Assume.assumeTrue(sampleOptional.isPresent());
+            final Sample sample = sampleOptional.get();
+            final String sampleName = sample.getName();
+            final SampleCriteria criterion = SampleCriteria.sample.name.is(sampleName);
+            final SyncReader<Sample> syncReader = this.sampleRepository.find(criterion);
+            final List<Sample> samples = syncReader.fetch();
+            Assert.assertTrue("Could not fetch any elements by sampleName:[" + sampleName + "]", !samples.isEmpty());
+        } catch (final Exception exception) {
+            Assume.assumeNoException(exception);
+            throw new RuntimeException(exception);
         }
-        final Optional<Sample> sampleOptional = sampleRepository.findAll().fetch().stream().findAny();
-        Assume.assumeTrue(sampleOptional.isPresent());
-        final Sample sample = sampleOptional.get();
-        final String sampleName = sample.getName();
-        final SampleCriteria criterion=SampleCriteria.sample.name.is(sampleName);
-        final SyncReader<Sample> syncReader = sampleRepository.find(criterion);
-        final List<Sample> samples = syncReader.fetch();
-        Assert.assertTrue("Could not fetch any elements by sampleName:[" + sampleName+"]", !samples.isEmpty());
     }
 
 
     @Test
     public void getSampleBySurnameMongoBackend() {
-        final String databaseName="test";
-        ObjectMapper mapper = new ObjectMapper()
-                .registerModule(new BsonModule())  // register default codecs like Jsr310, BsonValueCodec, ValueCodecProvider etc.
-                .registerModule(new GuavaModule()) // for Immutable* classes from Guava (eg. ImmutableList)
-                .registerModule(new Jdk8Module()) // used for java 8 types like Optional / OptionalDouble etc.
-                .registerModule(new IdAnnotationModule()); // used for Criteria.Id to '_id' attribute mapping
-        final CodecRegistry registry = JacksonCodecs.registryFromMapper(mapper);
+        try {
 
-
-        final MongoClient client = MongoClients.create("mongodb://127.0.0.1/"+databaseName);
-
-        final MongoDatabase mongoDatabase = client.getDatabase(databaseName).withCodecRegistry(registry);
-        final MongoSetup setup = MongoSetup.of(mongoDatabase);
-        final MongoBackend mongoBackend = new MongoBackend(setup);
-        final SampleRepository sampleRepository = new SampleRepository(mongoBackend);
-        for (int i = 0; i < 1; i++) {
-            sampleRepository.insert(Sample.createRandom());
+            final Optional<Sample> sampleOptional = this.sampleRepository.findAll().fetch().stream().findAny();
+            Assume.assumeTrue(sampleOptional.isPresent());
+            final Sample sample = sampleOptional.get();
+            final String sampleSurname = sample.surname();
+            final SampleCriteria criterion = SampleCriteria.sample.surname.is(sampleSurname);
+            final SyncReader<Sample> syncReader = this.sampleRepository.find(criterion);
+            final List<Sample> samples = syncReader.fetch();
+            Assert.assertTrue("Could not fetch any elements by sampleSurname:[" + sampleSurname + "]", !samples.isEmpty());
+        } catch (final Exception exception) {
+            Assume.assumeNoException(exception);
+            throw new RuntimeException(exception);
         }
-        final Optional<Sample> sampleOptional = sampleRepository.findAll().fetch().stream().findAny();
-        Assume.assumeTrue(sampleOptional.isPresent());
-        final Sample sample = sampleOptional.get();
-        final String sampleSurname = sample.surname();
-        final SampleCriteria criterion=SampleCriteria.sample.surname.is(sampleSurname);
-        final SyncReader<Sample> syncReader = sampleRepository.find(criterion);
-        final List<Sample> samples = syncReader.fetch();
-        Assert.assertTrue("Could not fetch any elements by sampleSurname:[" + sampleSurname+"]", !samples.isEmpty());
     }
 
 }

--- a/criteria/mongo/test/issue1387/org/immutables/criteria/mongo/SampleTest.java
+++ b/criteria/mongo/test/issue1387/org/immutables/criteria/mongo/SampleTest.java
@@ -1,0 +1,119 @@
+package issue1387.org.immutables.criteria.mongo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import com.mongodb.reactivestreams.client.MongoDatabase;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.immutables.criteria.mongo.MongoBackend;
+import org.immutables.criteria.mongo.MongoSetup;
+import org.immutables.criteria.mongo.bson4jackson.BsonModule;
+import org.immutables.criteria.mongo.bson4jackson.IdAnnotationModule;
+import org.immutables.criteria.mongo.bson4jackson.JacksonCodecs;
+import org.immutables.criteria.repository.sync.SyncReader;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+public class SampleTest {
+
+
+    @Test
+    public void getSampleByIdMongoBackend() {
+        final String databaseName="test";
+        ObjectMapper mapper = new ObjectMapper()
+                .registerModule(new BsonModule())  // register default codecs like Jsr310, BsonValueCodec, ValueCodecProvider etc.
+                .registerModule(new GuavaModule()) // for Immutable* classes from Guava (eg. ImmutableList)
+                .registerModule(new Jdk8Module()) // used for java 8 types like Optional / OptionalDouble etc.
+                .registerModule(new IdAnnotationModule()); // used for Criteria.Id to '_id' attribute mapping
+//        mapper.getPropertyNamingStrategy().nameForGetterMethod()
+        final CodecRegistry registry = JacksonCodecs.registryFromMapper(mapper);
+
+
+        final MongoClient client = MongoClients.create("mongodb://127.0.0.1/"+databaseName);
+
+        final MongoDatabase mongoDatabase = client.getDatabase(databaseName).withCodecRegistry(registry);
+        final MongoSetup setup = MongoSetup.of(mongoDatabase);
+        final MongoBackend mongoBackend = new MongoBackend(setup);
+        final SampleRepository sampleRepository = new SampleRepository(mongoBackend);
+        for (int i = 0; i < 10; i++) {
+            sampleRepository.insert(Sample.createRandom());
+        }
+        final Optional<Sample> sampleOptional = sampleRepository.findAll().fetch().stream().findAny();
+        Assume.assumeTrue(sampleOptional.isPresent());
+        final Sample sample = sampleOptional.get();
+        final String sampleId = sample.getId();
+
+        final SyncReader<Sample> syncReader = sampleRepository.find(SampleCriteria.sample.id.is(sampleId));
+        final List<Sample> samples = syncReader.fetch();
+        Assert.assertTrue("Could not fetch any elements by id:[" + sampleId+"]", !samples.isEmpty());
+    }
+
+
+    @Test
+    public void getSampleByNameMongoBackend() {
+        final String databaseName="test";
+        ObjectMapper mapper = new ObjectMapper()
+                .registerModule(new BsonModule())  // register default codecs like Jsr310, BsonValueCodec, ValueCodecProvider etc.
+                .registerModule(new GuavaModule()) // for Immutable* classes from Guava (eg. ImmutableList)
+                .registerModule(new Jdk8Module()) // used for java 8 types like Optional / OptionalDouble etc.
+                .registerModule(new IdAnnotationModule()); // used for Criteria.Id to '_id' attribute mapping
+        final CodecRegistry registry = JacksonCodecs.registryFromMapper(mapper);
+
+
+        final MongoClient client = MongoClients.create("mongodb://127.0.0.1/"+databaseName);
+
+        final MongoDatabase mongoDatabase = client.getDatabase(databaseName).withCodecRegistry(registry);
+        final MongoSetup setup = MongoSetup.of(mongoDatabase);
+        final MongoBackend mongoBackend = new MongoBackend(setup);
+        final SampleRepository sampleRepository = new SampleRepository(mongoBackend);
+        for (int i = 0; i < 1; i++) {
+            sampleRepository.insert(Sample.createRandom());
+        }
+        final Optional<Sample> sampleOptional = sampleRepository.findAll().fetch().stream().findAny();
+        Assume.assumeTrue(sampleOptional.isPresent());
+        final Sample sample = sampleOptional.get();
+        final String sampleName = sample.getName();
+        final SampleCriteria criterion=SampleCriteria.sample.name.is(sampleName);
+        final SyncReader<Sample> syncReader = sampleRepository.find(criterion);
+        final List<Sample> samples = syncReader.fetch();
+        Assert.assertTrue("Could not fetch any elements by sampleName:[" + sampleName+"]", !samples.isEmpty());
+    }
+
+
+    @Test
+    public void getSampleBySurnameMongoBackend() {
+        final String databaseName="test";
+        ObjectMapper mapper = new ObjectMapper()
+                .registerModule(new BsonModule())  // register default codecs like Jsr310, BsonValueCodec, ValueCodecProvider etc.
+                .registerModule(new GuavaModule()) // for Immutable* classes from Guava (eg. ImmutableList)
+                .registerModule(new Jdk8Module()) // used for java 8 types like Optional / OptionalDouble etc.
+                .registerModule(new IdAnnotationModule()); // used for Criteria.Id to '_id' attribute mapping
+        final CodecRegistry registry = JacksonCodecs.registryFromMapper(mapper);
+
+
+        final MongoClient client = MongoClients.create("mongodb://127.0.0.1/"+databaseName);
+
+        final MongoDatabase mongoDatabase = client.getDatabase(databaseName).withCodecRegistry(registry);
+        final MongoSetup setup = MongoSetup.of(mongoDatabase);
+        final MongoBackend mongoBackend = new MongoBackend(setup);
+        final SampleRepository sampleRepository = new SampleRepository(mongoBackend);
+        for (int i = 0; i < 1; i++) {
+            sampleRepository.insert(Sample.createRandom());
+        }
+        final Optional<Sample> sampleOptional = sampleRepository.findAll().fetch().stream().findAny();
+        Assume.assumeTrue(sampleOptional.isPresent());
+        final Sample sample = sampleOptional.get();
+        final String sampleSurname = sample.surname();
+        final SampleCriteria criterion=SampleCriteria.sample.surname.is(sampleSurname);
+        final SyncReader<Sample> syncReader = sampleRepository.find(criterion);
+        final List<Sample> samples = syncReader.fetch();
+        Assert.assertTrue("Could not fetch any elements by sampleSurname:[" + sampleSurname+"]", !samples.isEmpty());
+    }
+
+}


### PR DESCRIPTION
This is an attempt to fix autogenerated Criteria that do not work in `find()` in the `MongoBackend` an issue also described in https://github.com/immutables/immutables/issues/1387 with more details.
The conversion from the property names to the MongoDB fields seems to take place in `MongoSession.java`.
There the `_id` property was handled individually and all other properties were delegated to `PathNaming.defaultNaming()` which returned the path as a field name.  This did not work in MongoDB filter queries. As for example it returned `getDescription` instead of `description` and the filter query required the field name, being `description`.
Replacing the `PathNaming.defaultNaming()` with the `JavaBeanNaming()` provides accurate field name transitions.

2 tests have also been included that test that `find() `works with the `ID`, with a getter of the form `getProperty()' and with a getter of the form `property()'.  I named properties more specifically to facilitate any potential future references.

PS: This PR solves some cases and improves the situation, but more changes should be examined. For instance taking into account the `@JsonProperty` annotation.

