### PR TITLE
fix(sec): upgrade com.google.guava:guava to 30.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <junit5.version>5.6.3</junit5.version>
     <hamcrest.version>1.3</hamcrest.version>
     <mockito.verion>3.12.4</mockito.verion>
-    <guava.version>19.0</guava.version>
+    <guava.version>30.0-jre</guava.version>
     <gson.version>2.8.8</gson.version>
     <slf4j.version>1.7.28</slf4j.version>
     <rxjava2.version>2.2.19</rxjava2.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.guava:guava 19.0
- [CVE-2018-10237](https://www.oscs1024.com/hd/CVE-2018-10237)


### What did I do？
Upgrade com.google.guava:guava from 19.0 to 30.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS