### PR TITLE
detect the Eclipse compiler without using the TCCL

### DIFF
--- a/generator/src/org/immutables/generator/SourceOrdering.java
+++ b/generator/src/org/immutables/generator/SourceOrdering.java
@@ -67,6 +67,9 @@ import org.eclipse.jdt.internal.compiler.lookup.SourceTypeBinding;
  * </ul>
  * <p>
  * <em>Based on a workaround idea provided by Christian Humer</em>
+ * 
+ * NOTE: The Eclipse bug is fixed, and this workaround can be disabled by setting the system property
+ * {@code org.immutables.disableEclipseOrderingProvider=true}.
  */
 public final class SourceOrdering {
   private SourceOrdering() {}
@@ -97,7 +100,7 @@ public final class SourceOrdering {
   }
 
   private static OrderingProvider createProvider() {
-    if (Compiler.ECJ.isPresent()) {
+    if (Compiler.ECJ.isPresent() && !Boolean.getBoolean("org.immutables.disableEclipseOrderingProvider")) {
       return new EclipseCompilerOrderingProvider();
     }
     return DEFAULT_PROVIDER;

--- a/value-processor/src/org/immutables/processor/CallStack.java
+++ b/value-processor/src/org/immutables/processor/CallStack.java
@@ -1,0 +1,29 @@
+/*
+   Copyright 2023 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.processor;
+
+/**
+ * Provides classes (and not just class names) of the call stack.
+ * <p>
+ * NOTE: Extending SecurityManager is a convenient hack that works for Java 8 through 19.
+ * StackWalker would be preferred when the compatibility level gets raised to Java 9. 
+ */
+public class CallStack extends SecurityManager {
+
+  public Class<?>[] getCallingClasses() {
+    return getClassContext();
+  }
+}


### PR DESCRIPTION
Fixes #1451.

The current implementation depends on the thread context class loader being set to `org.eclipse.osgi.internal.framework.ContextFinder` which is true in Eclipse IDE, but not in the JDT Language Server used by Visual Studio Code.

In addition, it seems that the `EclipseCompilerOrderingProvider` is no longer required. It can be disabled by defining the system property `-Dorg.immutables.disableEclipseOrderingProvider=true` in the VS code setting `java.jdt.ls.vmargs`.

(The system property and the `EclipseCompilerOrderingProvider` should both be removed if this is confirmed.)

Moreover, `java.jdt.ls.vmargs` should include `-DmaxCompiledUnitsAtOnce=10000` for large projects (see #1450).  