### PR TITLE
Fix `toBuilder` generator with generics

### DIFF
--- a/value-fixture/src/org/immutables/fixture/builder/ToBuilderMethod.java
+++ b/value-fixture/src/org/immutables/fixture/builder/ToBuilderMethod.java
@@ -11,6 +11,13 @@ public interface ToBuilderMethod {
   }
 
   @Value.Immutable
+  @Value.Style(toBuilder = "toBuilder")
+  interface ToBuilderClassicWithGenerics<T> {
+    int a();
+    T b();
+  }
+
+  @Value.Immutable
   @Value.Style(toBuilder = "toBuilder", overshadowImplementation = true)
   interface ToBuilderSandwich {
     int a();

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -207,7 +207,7 @@ public static[type.generics.def] [factoryBuildStageBuilderType type] [type.facto
    * with attibute values of {@code this} instance to easily create modified copies.
    * @return A new [type.typeValue.simple] builder with attributes of {@code this} instance
    */
-  public [type.typeBuilder.relative][type.generics.args] [type.names.toBuilder]() {
+  public [type.typeBuilder.relative] [type.names.toBuilder]() {
     return [castBuildStagedBuilder type][type.factoryBuilder.relative]()[/castBuildStagedBuilder].[type.names.from](this);
   }
 [/if]


### PR DESCRIPTION
This is meant to resolve #1459 as follows:
```diff
   /**
    * Creates a builder for {@link ImmutableToBuilderClassicWithGenerics ImmutableToBuilderClassicWithGenerics}.prefilled
    * with attibute values of {@code this} instance to easily create modified copies.
    * @return A new ImmutableToBuilderClassicWithGenerics builder with attributes of {@code this} instance
    */
-  public ImmutableToBuilderClassicWithGenerics.Builder<T><T> toBuilder()
+  public ImmutableToBuilderClassicWithGenerics.Builder<T> toBuilder() {
     return ImmutableToBuilderClassicWithGenerics.<T>builder().from(this);
   }
```
(snippet comes from `value-fixture/target/generated-sources/annotations/org/immutables/fixture/builder/ImmutableToBuilderClassicWithGenerics.java`)