### PR TITLE
can't override static builder for the builder-in-disguise pattern

### DIFF
--- a/value-fixture/src/org/immutables/fixture/modifiable/BuilderInDisguise.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/BuilderInDisguise.java
@@ -11,9 +11,10 @@ import org.immutables.value.Value;
     typeModifiable = "*Builder", // modifiable will be generated as "FooBuilder"
     toImmutable = "build",  // rename "toImmutable" method to "build"
     set = "*", // adjust to your taste: setters with no prefixes like in default builders.
-    create = "new" // plain constructor to create builder, just as example
+    create = "new", // plain constructor to create builder, just as example
+    builder = "immutableBuilder" // rename the immutable builder to disguise it
 )  // style could also put on package or as meta annotation
-@Value.Immutable
+//@Value.Immutable(builder = false) - requires @Style.allParameters
 @Value.Modifiable
 public abstract class BuilderInDisguise {
   public abstract String getName();

--- a/value-fixture/src/org/immutables/fixture/modifiable/BuilderInDisguise.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/BuilderInDisguise.java
@@ -1,0 +1,24 @@
+package org.immutables.fixture.modifiable;
+
+import java.util.List;
+
+import org.immutables.value.Value;
+
+// from https://github.com/immutables/immutables/issues/234#issuecomment-170574928
+// which is referenced in the docs
+
+@Value.Style(
+    typeModifiable = "*Builder", // modifiable will be generated as "FooBuilder"
+    toImmutable = "build",  // rename "toImmutable" method to "build"
+    set = "*", // adjust to your taste: setters with no prefixes like in default builders.
+    create = "new" // plain constructor to create builder, just as example
+)  // style could also put on package or as meta annotation
+@Value.Immutable
+@Value.Modifiable
+public abstract class BuilderInDisguise {
+  public abstract String getName();
+  public abstract List<Integer> getCounts();
+  public static BuilderInDisguiseBuilder builder() {  // just for convenience, can create builder directly
+    return new BuilderInDisguiseBuilder();
+  }
+}


### PR DESCRIPTION
can't override static builder for the builder-in-disguise pattern (from https://github.com/immutables/immutables/issues/234#issuecomment-170574928) which is referenced in the docs

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project value-fixture: Compilation failure
[ERROR] /Users/nezda/code/immutables/value-fixture/target/generated-sources/annotations/org/immutables/fixture/modifiable/ImmutableBuilderInDisguise.java:[156,51] error: builder() in ImmutableBuilderInDisguise cannot hide builder() in BuilderInDisguise
[ERROR]   return type Builder is not compatible with BuilderInDisguiseBuilder