### PR TITLE
Allow specifying visibility as string

### DIFF
--- a/value-annotations/src/org/immutables/value/Value.java
+++ b/value-annotations/src/org/immutables/value/Value.java
@@ -917,6 +917,14 @@ public @interface Value {
     ImplementationVisibility visibility() default ImplementationVisibility.SAME;
 
     /**
+     * Specify the mode in which visibility of generated value type is derived from abstract value
+     * type. Specifying this will override {@link #visibility()} and the reason why this option as a string exists,
+     * is to avoid javac warnings mentioned in <a href="https://github.com/immutables/immutables/issues/291">#291</a>.
+     * @return implementation visibility as string
+     */
+    String visibilityString() default "";
+
+    /**
      * Specify whether init, copy and factory methods and constructors for an unwrapped {@code X} of
      * {@code Optional<X>}
      * should accept {@code null} values as empty value. By default nulls are rejected in favor of
@@ -1171,6 +1179,15 @@ public @interface Value {
      * @return implementation visibility
      */
     BuilderVisibility builderVisibility() default BuilderVisibility.PUBLIC;
+
+    /**
+     * Specify the mode in which visibility of generated value type is derived from abstract value
+     * type. Specifying this will override {@link #builderVisibility()} and the reason why this option as
+     * a string exists, is to avoid javac warnings mentioned in
+     * <a href="https://github.com/immutables/immutables/issues/291">#291</a>.
+     * @return implementation visibility as string
+     */
+    String builderVisibilityString() default "";
 
     /**
      * Runtime exception to throw when an immutable object is in an invalid state. I.e. when some

--- a/value-fixture/src/org/immutables/fixture/style/MoreVisibleImplementationAsString.java
+++ b/value-fixture/src/org/immutables/fixture/style/MoreVisibleImplementationAsString.java
@@ -1,0 +1,38 @@
+/*
+   Copyright 2014 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.fixture.style;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Style.ImplementationVisibility;
+
+/**
+ * Feature combination
+ * <ul>
+ * <li>Implementation is public
+ * <li>Builder is package-protected
+ * </ul>
+ */
+@Value.Immutable
+@Value.Style(visibilityString = "PUBLIC", builderVisibilityString = "PACKAGE")
+class MoreVisibleImplementationAsString {
+
+  @SuppressWarnings("CheckReturnValue")
+  void use() {
+    ImmutableMoreVisibleImplementationAsString.Builder moreVisibleBuilder = ImmutableMoreVisibleImplementationAsString.builder();
+    MoreVisibleImplementationAsString moreVisibleImplementation = moreVisibleBuilder.build();
+    moreVisibleImplementation.use();
+  }
+}

--- a/value-fixture/test/org/immutables/fixture/style/StyleTest.java
+++ b/value-fixture/test/org/immutables/fixture/style/StyleTest.java
@@ -29,6 +29,13 @@ public class StyleTest {
   }
 
   @Test
+  public void publicVisibilityString() {
+    check(!Modifier.isPublic(MoreVisibleImplementationAsString.class.getModifiers()));
+    check(Modifier.isPublic(ImmutableMoreVisibleImplementationAsString.class.getModifiers()));
+    check(!Modifier.isPublic(ImmutableMoreVisibleImplementationAsString.Builder.class.getModifiers()));
+  }
+
+  @Test
   public void packageVisibility() {
     check(Modifier.isPublic(LoweredVisibility.class.getModifiers()));
     check(!Modifier.isPublic(ImmutableLoweredVisibility.class.getModifiers()));

--- a/value-processor/src/org/immutables/value/processor/meta/Constitution.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Constitution.java
@@ -39,6 +39,7 @@ import org.immutables.value.processor.meta.Proto.Protoclass;
 import org.immutables.value.processor.meta.Reporter.About;
 import org.immutables.value.processor.meta.Styles.PackageNaming;
 import org.immutables.value.processor.meta.Styles.UsingName.TypeNames;
+import org.immutables.value.processor.meta.ValueMirrors.Style.BuilderVisibility;
 import org.immutables.value.processor.meta.ValueMirrors.Style.ImplementationVisibility;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -62,7 +63,14 @@ public abstract class Constitution {
 
 	@Value.Derived
 	public Visibility implementationVisibility() {
-		if (style().visibility() == ImplementationVisibility.PRIVATE
+    ImplementationVisibility visibility;
+    if (!style().visibilityString().isEmpty()) {
+      visibility = ImplementationVisibility.valueOf(style().visibilityString());
+    } else {
+      visibility = style().visibility();
+    }
+
+		if (visibility == ImplementationVisibility.PRIVATE
 				&& !protoclass().features().builder()
 				&& !protoclass().kind().isNested()) {
 			protoclass()
@@ -73,12 +81,17 @@ public abstract class Constitution {
 									"required");
 			return Visibility.PACKAGE;
 		}
-		return protoclass().visibility().forImplementation(style().visibility());
+		return protoclass().visibility().forImplementation(visibility);
 	}
 
 	@Value.Derived
 	public Visibility builderVisibility() {
-		Visibility visibility = protoclass().visibility().forBuilder(style().builderVisibility());
+    Visibility visibility;
+    if (!style().builderVisibilityString().isEmpty()) {
+      visibility = protoclass().visibility().forBuilder(BuilderVisibility.valueOf(style().builderVisibilityString()));
+    } else {
+      visibility = protoclass().visibility().forBuilder(style().builderVisibility());
+    }
 		if (visibility == Visibility.PUBLIC && protoclass().styles().style().stagedBuilder()
 				&& isNestedFactoryOrConstructor()) {
 			return Visibility.PRIVATE;

--- a/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
+++ b/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
@@ -233,6 +233,10 @@ public abstract class StyleInfo implements ValueMirrors.Style {
 
   @Value.Parameter
   @Override
+  public abstract String visibilityString();
+
+  @Value.Parameter
+  @Override
   public abstract boolean optionalAcceptNullable();
 
   @Value.Parameter
@@ -302,6 +306,10 @@ public abstract class StyleInfo implements ValueMirrors.Style {
   @Value.Parameter
   @Override
   public abstract BuilderVisibility builderVisibility();
+
+  @Value.Parameter
+  @Override
+  public abstract String builderVisibilityString();
 
   @Value.Parameter
   public abstract String throwForInvalidImmutableStateName();
@@ -500,6 +508,7 @@ public abstract class StyleInfo implements ValueMirrors.Style {
         ImmutableSet.copyOf(input.passAnnotationsName()),
         ImmutableSet.copyOf(input.additionalJsonAnnotationsName()),
         input.visibility(),
+        input.visibilityString(),
         input.optionalAcceptNullable(),
         input.generateSuppressAllWarnings(),
         input.privateNoargConstructor(),
@@ -518,6 +527,7 @@ public abstract class StyleInfo implements ValueMirrors.Style {
         input.weakInterning(),
         input.alwaysPublicInitializers(),
         input.builderVisibility(),
+        input.builderVisibilityString(),
         input.throwForInvalidImmutableStateName(),
         input.throwForNullPointerName(),
         input.depluralize(),

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -193,6 +193,8 @@ public final class ValueMirrors {
 
     ImplementationVisibility visibility() default ImplementationVisibility.SAME;
 
+    String visibilityString() default "";
+
     boolean optionalAcceptNullable() default false;
 
     boolean generateSuppressAllWarnings() default true;
@@ -228,6 +230,8 @@ public final class ValueMirrors {
     boolean alwaysPublicInitializers() default true;
 
     BuilderVisibility builderVisibility() default BuilderVisibility.PUBLIC;
+
+    String builderVisibilityString() default "";
 
     Class<? extends Exception> throwForInvalidImmutableState() default IllegalStateException.class;
 


### PR DESCRIPTION
In https://github.com/apache/iceberg/pull/8099 we would like to use a custom style annotation to modify the name of the generated enclosing class (mainly to keep API compatibility).



```
@Value.Enclosing
@Value.Style(typeImmutableEnclosing = "ImmutableSnapshotTable")
interface BaseSnapshotTable extends SnapshotTable {

  @Value.Immutable
  interface Result extends SnapshotTable.Result {}
}
```
Now we'd also like to configure `visibility = Value.Style.ImplementationVisibility.PUBLIC` so that the generated class is publicly visible. 

However, doing that would mean that we'd be forcing a compile-time dependency to consumers due to the issue described in https://github.com/immutables/immutables/issues/291 and the currently suggested workaround for this is to have something like
```
@Target({ElementType.PACKAGE, ElementType.TYPE})
@Retention(RetentionPolicy.SOURCE)
@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC)
@interface ImmutablesPublic {}
```

But applying both `@Value.Style(typeImmutableEnclosing = "ImmutableSnapshotTable")` and `@ImmutablesPublic` doesn't work due to applying two Style definitions on the class. 

One could argue to move `@Value.Style(typeImmutableEnclosing = "ImmutableSnapshotTable")` into `@ImmutablesPublic` but it's not feasible to create X custom meta annotations.

Hence my suggestion would be to allow specifying the visibility as a string in order to avoid the issue described in #291 and to not have to introduce custom meta annotations.

@elucash could you take a look at this please?
