### PR TITLE
Re-try to resolve types in java.lang

### DIFF
--- a/value-fixture/src-java-11/org/immutables/fixture/module/ModuleIF.java
+++ b/value-fixture/src-java-11/org/immutables/fixture/module/ModuleIF.java
@@ -1,0 +1,8 @@
+package org.immutables.fixture.module;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(typeAbstract = {"*IF"}, typeImmutable = "*")
+public interface ModuleIF {
+}

--- a/value-fixture/src-java-11/org/immutables/fixture/module/subpackage/HasModuleField.java
+++ b/value-fixture/src-java-11/org/immutables/fixture/module/subpackage/HasModuleField.java
@@ -1,0 +1,11 @@
+package org.immutables.fixture.module.subpackage;
+
+import org.immutables.fixture.module.Module;
+import org.immutables.value.Value;
+
+
+@Value.Immutable
+@Value.Style(headerComments = true)
+public interface HasModuleField {
+        Module getModule();
+}

--- a/value-processor/src/org/immutables/value/processor/meta/TypeStringProvider.java
+++ b/value-processor/src/org/immutables/value/processor/meta/TypeStringProvider.java
@@ -174,6 +174,14 @@ class TypeStringProvider {
       }
 
       hasMaybeUnresolvedYetAfter |= importsResolver.unresolved;
+    } else if (typeName.equals("java.lang." + typeElement.getSimpleName())) {
+      // Because java.lang is automatically imported, you can have type names that are "resolved,"
+      // but aren't the names that are actually imported in the source file
+      String simpleName = type.asElement().getSimpleName().toString();
+      String guessedName = importsResolver.apply(simpleName);
+      if (!importsResolver.unresolved) {
+        typeName = guessedName;
+      }
     }
 
     buffer.append(typeName);


### PR DESCRIPTION
Because `java.lang` types get automatically imported, they can be "resolved" without being resolved to the same thing that they are in the source file. This ultimately winds up preventing the generated code from compiling.

I'd love any guidance you're willing to give around this / around testing this out. Thank you!

Closes #1475 