### PR TITLE
Allows NaturalOrdering for Comparable type hierarchies

### DIFF
--- a/value-fixture/src/org/immutables/fixture/jdkonly/JdkColl.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/JdkColl.java
@@ -36,4 +36,21 @@ public interface JdkColl {
 
   @Value.ReverseOrder
   NavigableSet<Integer> navs();
+
+  @Value.NaturalOrder
+  SortedSet<Elem> elems();
+
+  @Value.Immutable
+  interface Elem extends ComparableElem<Integer> {
+  }
+
+  interface ComparableElem<T extends Comparable<T>> extends Comparable<ComparableElem<T>> {
+
+    T getValue();
+
+    @Override
+    default int compareTo(ComparableElem<T> other) {
+      return getValue().compareTo(other.getValue());
+    }
+  }
 }

--- a/value-fixture/test/org/immutables/fixture/jdkonly/JdkOnlyTest.java
+++ b/value-fixture/test/org/immutables/fixture/jdkonly/JdkOnlyTest.java
@@ -46,12 +46,14 @@ public class JdkOnlyTest {
         .addOrds(4, 6, 5)
         .addAllOrds(Arrays.asList(8, 7, 9))
         .addPols(RetentionPolicy.RUNTIME, RetentionPolicy.RUNTIME)
+        .addElems(ImmutableElem.builder().value(1).build(), ImmutableElem.builder().value(2).build())
         .build();
 
     check(coll.ints()).hasContentInAnyOrder(1, 2, 3, 4, 5, 6);
     check(coll.navs()).hasContentInAnyOrder(3, 2, 1);
     check(coll.ords()).hasContentInAnyOrder(4, 5, 6, 7, 8, 9);
     check(coll.pols()).hasContentInAnyOrder(RetentionPolicy.RUNTIME);
+    check(coll.elems()).hasContentInAnyOrder(ImmutableElem.builder().value(1).build(), ImmutableElem.builder().value(2).build());
   }
 
   @Test

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -4433,7 +4433,7 @@ private static <K extends Enum<K>, V> java.util.Map<K, V> createUnmodifiableEnum
 [/if]
 [/output.trim][/let]
 
-private static <K extends Comparable<K>, V> java.util.[unmodifiableSortedMapInterface]<K, V> createUnmodifiableSortedMap(boolean reverse, boolean checkNulls, boolean skipNulls, java.util.Map<? extends K, ? extends V> map) {
+private static <K extends Comparable<? super K>, V> java.util.[unmodifiableSortedMapInterface]<K, V> createUnmodifiableSortedMap(boolean reverse, boolean checkNulls, boolean skipNulls, java.util.Map<? extends K, ? extends V> map) {
   java.util.TreeMap<K, V> sortedMap = reverse
       ? new java.util.TreeMap<K, V>(java.util.Collections.<K>reverseOrder())
       : new java.util.TreeMap<K, V>();

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -4357,7 +4357,7 @@ private static <T extends Enum<T>> java.util.Set<T> createUnmodifiableEnumSet(It
 [/if]
 [/output.trim][/let]
 
-private static <T extends Comparable<T>> java.util.[unmodifiableSortedSetInterface]<T> createUnmodifiableSortedSet(boolean reverse, java.util.List<T> list) {
+private static <T extends Comparable<? super T>> java.util.[unmodifiableSortedSetInterface]<T> createUnmodifiableSortedSet(boolean reverse, java.util.List<T> list) {
   java.util.TreeSet<T> set = reverse
       ? new java.util.TreeSet<T>(java.util.Collections.<T>reverseOrder())
       : new java.util.TreeSet<T>();


### PR DESCRIPTION
Tried to write some of our code to use the `@Value.NaturalOrder` annotation for comparable wrapped types and it failed. A simple fix was to use an upper bound wildcard in the generated code. Also added a testcase with an example.