### PR TITLE
Fix 'yield outside of switch expression'

### DIFF
--- a/value-fixture/src/nonimmutables/YieldField.java
+++ b/value-fixture/src/nonimmutables/YieldField.java
@@ -1,0 +1,9 @@
+package nonimmutables;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface YieldField {
+
+    int getYield();
+}

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -2408,7 +2408,7 @@ if ([v.name]Value != null) {
   [v.names.init]([v.name]Value);
 }
   [else]
-[v.names.init](instance.[v.names.get]());
+this.[v.names.init](instance.[v.names.get]());
   [/if]
 [/template]
 


### PR DESCRIPTION
When using Immutables with Java versions supporting switch expressions (and the new `yield` keyword) and if one decides to define an immutable interface with say `getYield()` method:
```java
@Value.Immutable
public interface SomeInterface {
    int getYield();
}
```
the value processor generates an immutable class implementation which won't compile since the internal generated Builder class would have the following copying method:
```java
    @CanIgnoreReturnValue 
    public final Builder from(SomeInterface instance) {
      Objects.requireNonNull(instance, "instance");
      yield(instance.getYield()); <-- here the compiler will fail with 'Yield outside of switch expression'
      return this;
    }

```

It's enough to prepend the method call with `this.` and the compilation passes.