### PR TITLE
Added support for the 'required' attribute for the generated JSON Property Annotation

### DIFF
--- a/value-annotations/src/org/immutables/value/Value.java
+++ b/value-annotations/src/org/immutables/value/Value.java
@@ -1143,6 +1143,8 @@ public @interface Value {
      */
     boolean forceJacksonPropertyNames() default true;
 
+    boolean setJacksonPropertyRequired() default true;
+
     /**
      * @return if put {@code JsonIgnore} on fields, defaults to {@code false}
      */

--- a/value-fixture/src/org/immutables/fixture/jackson/JacksonNullable.java
+++ b/value-fixture/src/org/immutables/fixture/jackson/JacksonNullable.java
@@ -1,0 +1,18 @@
+package org.immutables.fixture.jackson;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableJacksonNullable.class)
+@JsonDeserialize(builder = ImmutableJacksonNullable.Builder.class)
+public interface JacksonNullable {
+
+    String notNullable();
+
+    @Nullable
+    String nullable();
+}

--- a/value-fixture/test/org/immutables/fixture/jackson/JsonPropertyTest.java
+++ b/value-fixture/test/org/immutables/fixture/jackson/JsonPropertyTest.java
@@ -1,0 +1,26 @@
+package org.immutables.fixture.jackson;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class JsonPropertyTest {
+
+    @Test
+    void testJsonPropertyExistsOnGetterWithRequired() throws NoSuchMethodException {
+        JsonProperty nullableGetterJsonProperty = ImmutableJacksonNullable.class.getMethod("nullable").getAnnotation(JsonProperty.class);
+        JsonProperty notNullableGetterJsonProperty = ImmutableJacksonNullable.class.getMethod("notNullable").getAnnotation(JsonProperty.class);
+
+        Assertions.assertFalse(nullableGetterJsonProperty.required());
+        Assertions.assertTrue(notNullableGetterJsonProperty.required());
+    }
+
+    @Test
+    void testJsonPropertyExistsOnBuilderSetterWithRequired() throws NoSuchMethodException {
+        JsonProperty nullableBuilderSetterJsonProperty = ImmutableJacksonNullable.Builder.class.getMethod("nullable", String.class).getAnnotation(JsonProperty.class);
+        JsonProperty notNullableBuilderSetterJsonProperty = ImmutableJacksonNullable.Builder.class.getMethod("notNullable", String.class).getAnnotation(JsonProperty.class);
+
+        Assertions.assertFalse(nullableBuilderSetterJsonProperty.required());
+        Assertions.assertTrue(notNullableBuilderSetterJsonProperty.required());
+    }
+}

--- a/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
+++ b/value-processor/src/org/immutables/value/processor/meta/StyleInfo.java
@@ -293,6 +293,10 @@ public abstract class StyleInfo implements ValueMirrors.Style {
 
   @Value.Parameter
   @Override
+  public abstract boolean setJacksonPropertyRequired();
+
+  @Value.Parameter
+  @Override
   public abstract boolean forceJacksonIgnoreFields();
 
   @Value.Parameter
@@ -531,6 +535,7 @@ public abstract class StyleInfo implements ValueMirrors.Style {
         input.overshadowImplementation(),
         input.implementationNestedInBuilder(),
         input.forceJacksonPropertyNames(),
+        input.setJacksonPropertyRequired(),
         input.forceJacksonIgnoreFields(),
         input.forceEqualsInWithers(),
         input.jacksonIntegration(),

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -223,6 +223,8 @@ public final class ValueMirrors {
 
     boolean forceJacksonPropertyNames() default true;
 
+    boolean setJacksonPropertyRequired() default true;
+
     boolean forceJacksonIgnoreFields() default false;
 
     boolean forceEqualsInWithers() default false;


### PR DESCRIPTION
Hi,

Raising this PR to solve this issue raised a while back: https://github.com/immutables/immutables/issues/924.

Essentially when we generate a Value class, we are adding an 'JsonProperty' annotation, but this does not have the 'required=true' flag set for non-nullable fields.

This is useful when inspecting the classes for things like generating API specs and JSON Schemas.

I have set this to be controlled by a style flag, so users can disable this functionality if needed.

As seen in the docs (https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-annotations/latest/com/fasterxml/jackson/annotation/JsonProperty.html#required--), this should not actually affect deserialization behaviour for most users of Immutables, as they would be using the builder for deserialisation.

