### PR TITLE
Use source retention for serial annotations

### DIFF
--- a/serial/src/org/immutables/serial/Serial.java
+++ b/serial/src/org/immutables/serial/Serial.java
@@ -39,6 +39,7 @@ public @interface Serial {
    * is not strictly needed if structural is present.
    */
   @Target({ElementType.TYPE, ElementType.PACKAGE, ElementType.ANNOTATION_TYPE})
+  @Retention(RetentionPolicy.SOURCE)
   public @interface Version {
     long value();
   }
@@ -59,5 +60,6 @@ public @interface Serial {
    * {@link Version} annotation is missing, serialized form will have serial version 0L assigned.
    */
   @Target({ElementType.TYPE, ElementType.PACKAGE, ElementType.ANNOTATION_TYPE})
+  @Retention(RetentionPolicy.SOURCE)
   public @interface Structural {}
 }


### PR DESCRIPTION
I believe the intent here was that the Serial annotations not be retained in the compiled .class files, as the `@Serial` is annotated with Source retention and the annotations within are not copied to the generated immutable.

However, the retention meta-annotation does not apply to nested annotation definitions, so ultimately usages of `@Serial.Version` were being included in the generated classfile for the immutable _definition_, leading to problems finding the classfile if the Serial artifact was not on the classpath.


Here's a dump of the bytecode for an immutable definition with Serial.Version - you can clearly see the annotation is included by the compiler. (h/t @kmclarnon)

```
// class version 61.0 (61)
// access flags 0x601
public abstract interface com/hubspot/PersonIF {

  // compiled from: PersonIF.java

  @Lcom/hubspot/immutables/style/HubSpotStyle;() // invisible

  @Lorg/immutables/value/Value$Immutable;() // invisible

  @Lorg/immutables/serial/Serial$Version;(value=-22940920492L) // invisible
  // access flags 0x2609
  public static abstract INNERCLASS org/immutables/value/Value$Default org/immutables/value/Value Default
  // access flags 0x2609
  public static abstract INNERCLASS org/immutables/value/Value$Immutable org/immutables/value/Value Immutable
  // access flags 0x2609
  public static abstract INNERCLASS org/immutables/serial/Serial$Version org/immutables/serial/Serial Version
```

@suruuK @stevie400 @jaredstehler @PtrTeixeira @ggs5427