### PR TITLE
Support Sub-Collection Queries for InMemory and MongoDB

### DIFF
--- a/criteria/common/src/org/immutables/criteria/expression/Path.java
+++ b/criteria/common/src/org/immutables/criteria/expression/Path.java
@@ -117,6 +117,14 @@ public class Path implements Expression {
   public static Path ofClass(Class<?> type) {
     return new Path(null, type);
   }
+  
+  public static Path combine(Path parent, Path sub) {
+    if (parent != null) {
+      return new Path(parent, sub.element());
+    } else {
+      return sub;
+    }
+  }
 
   /**
    * Returns current path in java bean format: {@code foo.bar.qux}. For root path returns

--- a/criteria/common/test/org/immutables/criteria/personmodel/Toy.java
+++ b/criteria/common/test/org/immutables/criteria/personmodel/Toy.java
@@ -16,33 +16,25 @@
 
 package org.immutables.criteria.personmodel;
 
+import org.immutables.criteria.Criteria;
+import org.immutables.value.Value;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-import java.util.List;
-import java.util.Optional;
-
-import org.immutables.criteria.Criteria;
-import org.immutables.value.Value;
-
 @Value.Immutable
 @Criteria
-@JsonSerialize(as = ImmutablePet.class)
-@JsonDeserialize(as = ImmutablePet.class)
+@JsonSerialize(as = ImmutableToy.class)
+@JsonDeserialize(as = ImmutableToy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public interface Pet {
+public interface Toy {
 
-  enum PetType {
-    dog, cat, fish, hamster, parrot,
-    tiger, panda, iguana, frog, gecko
+  enum ToyType { 
+    ball, ring, robot 
   }
 
   String name();
 
-  PetType type();
-
-  Optional<Address> address();
-
-  List<Toy> toys();
+  ToyType type();
 }

--- a/criteria/inmemory/src/org/immutables/criteria/inmemory/ExpressionInterpreter.java
+++ b/criteria/inmemory/src/org/immutables/criteria/inmemory/ExpressionInterpreter.java
@@ -158,6 +158,20 @@ class ExpressionInterpreter implements Function<Object, Object> {
 
         return prev;
       }
+      
+      if (op == IterableOperators.ANY) {
+        Preconditions.checkArgument(call.arguments().size() == 2, "Expected two arguments for %s got %s", call, call.arguments().size());
+        
+        final Object left = call.arguments().get(0).accept(this);
+        Preconditions.checkArgument(left instanceof Iterable, "%s is not iterable", left);
+        @SuppressWarnings("unchecked")
+        final Iterable<Object> leftIterable = (Iterable<Object>) left;
+        Preconditions.checkArgument(call.arguments().get(1) instanceof Call, "%s is not a call", call.arguments().get(1));
+        final Call rightCall = (Call) call.arguments().get(1);
+
+        final Stream<Object> stream = StreamSupport.stream(leftIterable.spliterator(), false);
+        return stream.anyMatch(r -> ExpressionInterpreter.of(rightCall).asPredicate().test(r));
+      }
 
       if (op.arity() == Operator.Arity.BINARY) {
         Preconditions.checkArgument(call.arguments().size() == 2, "Expected two arguments for %s got %s", call, call.arguments().size());

--- a/criteria/inmemory/test/org/immutables/criteria/inmemory/InMemoryPersonTest.java
+++ b/criteria/inmemory/test/org/immutables/criteria/inmemory/InMemoryPersonTest.java
@@ -28,15 +28,19 @@ public class InMemoryPersonTest extends AbstractPersonTest  {
 
   @Override
   protected Set<Feature> features() {
-    return EnumSet.of(Feature.DELETE, Feature.QUERY, Feature.QUERY_WITH_LIMIT,
+    return EnumSet.of(Feature.DELETE, 
+            Feature.QUERY, 
+            Feature.QUERY_WITH_LIMIT,
             Feature.ORDER_BY,
             Feature.QUERY_WITH_PROJECTION,
-            Feature.QUERY_WITH_OFFSET, Feature.REGEX,
+            Feature.QUERY_WITH_OFFSET, 
+            Feature.REGEX,
             Feature.DELETE_BY_QUERY,
             Feature.STRING_EMPTY,
             Feature.STRING_PREFIX_SUFFIX,
             Feature.ITERABLE_SIZE,
             Feature.ITERABLE_CONTAINS,
+            Feature.ITERABLE_ANY,
             Feature.STRING_LENGTH);
   }
 
@@ -44,5 +48,4 @@ public class InMemoryPersonTest extends AbstractPersonTest  {
   protected Backend backend() {
     return backend;
   }
-
 }

--- a/criteria/mongo/src/org/immutables/criteria/mongo/FindVisitor.java
+++ b/criteria/mongo/src/org/immutables/criteria/mongo/FindVisitor.java
@@ -132,7 +132,7 @@ class FindVisitor extends AbstractExpressionVisitor<Bson> {
       List<Path> paths = new ArrayList<>();
       while (currentPath.parent().isPresent()) {
         paths.add(currentPath);
-        currentPath = currentPath.parent().orElseThrow();
+        currentPath = currentPath.parent().get();
       }
       Collections.reverse(paths);
       for (Path tmpPath : paths) {

--- a/criteria/mongo/test/org/immutables/criteria/mongo/MongoPersonTest.java
+++ b/criteria/mongo/test/org/immutables/criteria/mongo/MongoPersonTest.java
@@ -38,13 +38,18 @@ public class MongoPersonTest extends AbstractPersonTest {
 
   @Override
   protected Set<Feature> features() {
-    return EnumSet.of(Feature.DELETE, Feature.QUERY, Feature.QUERY_WITH_LIMIT,
+    return EnumSet.of(Feature.DELETE, 
+            Feature.QUERY, 
+            Feature.QUERY_WITH_LIMIT,
             Feature.QUERY_WITH_PROJECTION,
-            Feature.QUERY_WITH_OFFSET, Feature.ORDER_BY, Feature.REGEX,
+            Feature.QUERY_WITH_OFFSET, 
+            Feature.ORDER_BY, 
+            Feature.REGEX,
             Feature.STRING_EMPTY,
             Feature.STRING_PREFIX_SUFFIX,
             Feature.ITERABLE_SIZE,
             Feature.ITERABLE_CONTAINS,
+            Feature.ITERABLE_ANY,
             Feature.STRING_LENGTH
     );
   }
@@ -53,6 +58,4 @@ public class MongoPersonTest extends AbstractPersonTest {
   protected Backend backend() {
     return backend;
   }
-
-
 }


### PR DESCRIPTION
Criteria does not seem to support any() queries in sub-collections as described in the [documentation](https://immutables.github.io/criteria.html). 

Accordingly, the example
`person.pets.any().name.contains("fluffy"); // person has a pet which sounds like fluffy` 
from the documentation does not work out of the box and leads to exceptions. [asereda-gs](https://github.com/asereda-gs) confirms this in his [comment](https://github.com/immutables/immutables/issues/1457#issuecomment-1705632115) to the issue #1457.

This PR addresses this and adds support for any() queries for the InMemory and MongoDB backends and extends the AbstractPersonTest with corresponding tests. 