### PR TITLE
Update Generated.java to be documented.

### DIFF
--- a/value-annotations/src/org/immutables/value/Generated.java
+++ b/value-annotations/src/org/immutables/value/Generated.java
@@ -15,6 +15,7 @@
  */
 package org.immutables.value;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import org.immutables.value.Value.Style;
@@ -28,6 +29,7 @@ import org.immutables.value.Value.Style;
  * use {@code org.immutables:annotate} module to inject annotations at various places in generated code.
  * Can be disabled by {@link Style#allowedClasspathAnnotations()}.
  */
+@Documented
 @Target(ElementType.TYPE)
 public @interface Generated {
   /**


### PR DESCRIPTION
Update the generated annotation to appear in the JavaDoc headers for generated code. This is currently not the case, but is useful information to include to show users of a library using immutables that the type is generated rather than explicitly defined in the project source code.