### PR TITLE
Include org.immutables:data in bill of materials

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -174,6 +174,11 @@
                 <artifactId>encode</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>data</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
As spotted in GH-1554, the `data` module is not currently in the bill of materials.

This change includes it so that this dependency can be managed via `<dependencyManagement/>` on the BOM module.