### PR TITLE
GH-1557: Fix erroneous code generation for TypeTokens of raw annotated types

### DIFF
--- a/data/test/org/immutables/data/CustomNullableAnnotation.java
+++ b/data/test/org/immutables/data/CustomNullableAnnotation.java
@@ -1,0 +1,12 @@
+package org.immutables.data;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Target({ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomNullableAnnotation {}

--- a/data/test/org/immutables/data/DataTest.java
+++ b/data/test/org/immutables/data/DataTest.java
@@ -33,7 +33,7 @@ public class DataTest {
   public void verifyAndBuild() {
     Dtt_ dtt = _Dtt();
     Builder<Dtt> b = dtt.builder();
-    check(b.verify()).hasSize(2);
+    check(b.verify()).hasSize(1);
 
     try {
       b.build();

--- a/data/test/org/immutables/data/Dtt.java
+++ b/data/test/org/immutables/data/Dtt.java
@@ -17,6 +17,7 @@ import org.immutables.value.Value.Parameter;
 public interface Dtt {
   int a();
 
+  @CustomNullableAnnotation
   String b();
 
   @Value.Default
@@ -44,7 +45,7 @@ public interface Dtt {
   public interface Hjj<H> {
     Map<String, H> ef();
 
-    @Nullable
+    @CustomNullableAnnotation
     H h();
 
     class Builder<H> extends ImmutableDtt.Hjj.Builder<H> {}

--- a/data/test/org/immutables/data/package-info.java
+++ b/data/test/org/immutables/data/package-info.java
@@ -1,0 +1,7 @@
+@Style(
+    nullableAnnotation = "org.immutables.data.CustomNullableAnnotation",
+    passAnnotations = CustomNullableAnnotation.class
+)
+package org.immutables.data;
+
+import org.immutables.value.Value.Style;

--- a/value-processor/src/org/immutables/value/processor/Datatypes.generator
+++ b/value-processor/src/org/immutables/value/processor/Datatypes.generator
@@ -319,7 +319,8 @@ private [tT] buildInstance() {
 [else if a.genericArgs or a.wholeTypeVariable.is]
   new [grefl].TypeToken<[a.type]>() {}
 [else]
-  [grefl].TypeToken.of([a.type].class)
+  [-- Use .rawType rather than .type to prevent including annotations in Type.class literals. ]
+  [grefl].TypeToken.of([a.rawType].class)
 [/if]
 [/output.trim][/template]
 


### PR DESCRIPTION
Fixes GH-1557, where the use of documented annotations such as those in JSpecify resulted in the type representation including annotation names. This resulted in invalid code being generated for `TypeToken.of($TYPE$.class)` as the output would erroneously become `TypeToken.of(@SomeAnnotationHere $TYPE$.class)`, which is invalid Java syntax.