### PR TITLE
Final stage builder methods' return value should be ignorable

### DIFF
--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -5115,7 +5115,7 @@ private static final long serialVersionUID = [literal serialVersion];
 [/for]
 [/template]
 
-[-- Usefull for annotations etc --]
+[-- Useful for annotations etc --]
 [template eachLine Object... lines][for l in lines]
 [l]
 [/for][/template]

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1432,6 +1432,7 @@ public interface [tb.nameBuildFinal][type.generics] {
    * @param element A [v.name] element
    * @return {@code this} builder for use in a chained invocation
    */
+  [atCanIgnoreReturnValue type]
   [deprecation v]
   [tb.nameBuildFinal][type.generics.args] [v.names.add]([v.unwrappedElementType] element);
 
@@ -1440,6 +1441,7 @@ public interface [tb.nameBuildFinal][type.generics] {
    * @param elements An array of [v.name] elements
    * @return {@code this} builder for use in a chained invocation
    */
+  [atCanIgnoreReturnValue type]
   [deprecation v]
   [tb.nameBuildFinal][type.generics.args] [v.names.addv]([tuNullParam v][v.unwrappedElementType]... elements);
 
@@ -1448,6 +1450,7 @@ public interface [tb.nameBuildFinal][type.generics] {
    * @param elements An iterable of [v.name] elements
    * @return {@code this} builder for use in a chained invocation
    */
+  [atCanIgnoreReturnValue type]
   [deprecation v]
   [tb.nameBuildFinal][type.generics.args] [v.names.addAll](Iterable<[qExtends v][tuNullParam v][v.wrappedElementType]> elements);
 [else if v.optionalType]
@@ -1457,6 +1460,7 @@ public interface [tb.nameBuildFinal][type.generics] {
    * @param [v.name] The value for [v.name][if v.optionalAcceptNullable], {@code null} is accepted as {@code [optionalEmpty v]}[/if]
    * @return {@code this} builder for chained invocation
    */
+  [atCanIgnoreReturnValue type]
   [deprecation v]
   [tb.nameBuildFinal][type.generics.args] [v.names.init]([unwrappedOptionalType v] [v.name]);
 
@@ -1465,6 +1469,7 @@ public interface [tb.nameBuildFinal][type.generics] {
    * @param [v.name] The value for [v.name]
    * @return {@code this} builder for use in a chained invocation
    */
+  [atCanIgnoreReturnValue type]
   [deprecation v]
   [tb.nameBuildFinal][type.generics.args] [v.names.init]([v.rawType][if not v.jdkSpecializedOptional]<[qExtends v][v.wrappedElementType]>[/if] [v.name]);
 [else if v.mapType]
@@ -1478,6 +1483,7 @@ public interface [tb.nameBuildFinal][type.generics] {
    * @param values The values for [v.name]
    * @return {@code this} builder for use in a chained invocation
    */
+  [atCanIgnoreReturnValue type]
   [deprecation v]
   [tb.nameBuildFinal][type.generics.args] [v.names.putv]([uK] key, [uV]... values);
 
@@ -1487,6 +1493,7 @@ public interface [tb.nameBuildFinal][type.generics] {
    * @param values The values for [v.name]
    * @return {@code this} builder for use in a chained invocation
    */
+  [atCanIgnoreReturnValue type]
   [deprecation v]
   [tb.nameBuildFinal][type.generics.args] [v.names.putAll]([uK] key, Iterable<? extends [wV]> values);
     [/if]
@@ -1497,6 +1504,7 @@ public interface [tb.nameBuildFinal][type.generics] {
    * @param value The associated value in the [v.name] map
    * @return {@code this} builder for use in a chained invocation
    */
+  [atCanIgnoreReturnValue type]
   [deprecation v]
   [tb.nameBuildFinal][type.generics.args] [v.names.put]([uK] key, [uV] value);
 
@@ -1505,6 +1513,7 @@ public interface [tb.nameBuildFinal][type.generics] {
    * @param entry The key and value entry
    * @return {@code this} builder for use in a chained invocation
    */
+  [atCanIgnoreReturnValue type]
   [deprecation v]
   [tb.nameBuildFinal][type.generics.args] [v.names.put](java.util.Map.Entry<[gE], ? extends [wV]> entry);
 
@@ -1513,6 +1522,7 @@ public interface [tb.nameBuildFinal][type.generics] {
    * @param entries The entries that will be added to the [v.name] map
    * @return {@code this} builder for use in a chained invocation
    */
+  [atCanIgnoreReturnValue type]
   [deprecation v]
   [tb.nameBuildFinal][type.generics.args] [v.names.putAll]([if v.multimapType][guava].collect.Multimap[else]java.util.Map[/if]<[gE], ? extends [wV]> entries);
   [/for]
@@ -1526,6 +1536,7 @@ public interface [tb.nameBuildFinal][type.generics] {
    * @param elements The elements for [v.name]
    * @return {@code this} builder for use in a chained invocation
    */
+  [atCanIgnoreReturnValue type]
   [deprecation v]
   [tb.nameBuildFinal][type.generics.args] [v.names.init]([v.elementType]... elements);
 [else]
@@ -1538,6 +1549,7 @@ public interface [tb.nameBuildFinal][type.generics] {
    * @param [v.name] The value for [v.name] [if v.nullable](can be {@code null})[/if]
    * @return {@code this} builder for use in a chained invocation
    */
+  [atCanIgnoreReturnValue type]
   [deprecation v]
   [tb.nameBuildFinal][type.generics.args] [v.names.init]([v.atNullability][v.type] [v.name]);
 [/if]


### PR DESCRIPTION
This change-set should annotate final stage builder interfaces (`BuildFinal`) with [CanIgnoreReturnValue](https://errorprone.info/api/latest/com/google/errorprone/annotations/CanIgnoreReturnValue.html), and allow downstream projects using Error Prone to use Staged Builders without method chaining or disabling the [CheckReturnValue](https://errorprone.info/bugpattern/CheckReturnValue) bug-checker. This aligns with the existing implementation and "normal" and strict builders.

---

Aside from this change, I have a broader question:

We encountered this while trying to propagate optional values to default primitive members in our immutable models. For example, the following model `Foo` will produce a single builder method for `Foo#bar`, `BuildFinal bar(int bar)`, which cannot be called with an `Optional<Integer>` with method chaining, only conditionally with the optional unwrapped.

```
interface Foo {
  default int bar() {
    return 99;
  }
}
```

Have you considered generating "optional" builder methods for default non-optional members? In this example, `BuildFinal bar(Optional<Integer> bar)`?

I've managed to implement this for object types, but not for primitives. I didn't yet find a way to map primitives to their boxed optional types.

If this feature would be welcome, I may give it a go, and ask for you input, pointers on it.

Thanks all!