### PR TITLE
Optimize mergeInternal generation with specialized methods per subtype

### DIFF
--- a/value-fixture/src/nonimmutables/huge/ChildOfHugeParents.java
+++ b/value-fixture/src/nonimmutables/huge/ChildOfHugeParents.java
@@ -1,0 +1,7 @@
+package nonimmutables.huge;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ChildOfHugeParents extends HugeParentOne, HugeParentTwo {
+}

--- a/value-fixture/src/nonimmutables/huge/HugeParentOne.java
+++ b/value-fixture/src/nonimmutables/huge/HugeParentOne.java
@@ -1,0 +1,163 @@
+package nonimmutables.huge;
+
+public interface HugeParentOne {
+  int getFirst();
+
+  int getSecond();
+
+  int getThird();
+
+  int getFourth();
+
+  int getFifth();
+
+  int getSixth();
+
+  int getSeventh();
+
+  int getEighth();
+
+  int getNinth();
+
+  int getTenth();
+
+  int getEleventh();
+
+  int getTwelfth();
+
+  int getThirteenth();
+
+  int getFourteenth();
+
+  int getFifteenth();
+
+  int getSixteenth();
+
+  int getSeventeenth();
+
+  int getEighteenth();
+
+  int getNineteenth();
+
+  int getTwentieth();
+
+  int getTwentyFirst();
+
+  int getTwentySecond();
+
+  int getTwentyThird();
+
+  int getTwentyFourth();
+
+  int getTwentyFifth();
+
+  int getTwentySixth();
+
+  int getTwentySeventh();
+
+  int getTwentyEighth();
+
+  int getTwentyNinth();
+
+  int getThirtieth();
+
+  int getThirtyFirst();
+
+  int getThirtySecond();
+
+  int getThirtyThird();
+
+  int getThirtyFourth();
+
+  int getThirtyFifth();
+
+  int getThirtySixth();
+
+  int getThirtySeventh();
+
+  int getThirtyEighth();
+
+  int getThirtyNinth();
+
+  int getFortieth();
+
+  int getFortyFirst();
+
+  int getFortySecond();
+
+  int getFortyThird();
+
+  int getFortyFourth();
+
+  int getFortyFifth();
+
+  int getFortySixth();
+
+  int getFortySeventh();
+
+  int getFortyEighth();
+
+  int getFortyNinth();
+
+  int getFiftieth();
+
+  int getFiftyFirst();
+
+  int getFiftySecond();
+
+  int getFiftyThird();
+
+  int getFiftyFourth();
+
+  int getFiftyFifth();
+
+  int getFiftySixth();
+
+  int getFiftySeventh();
+
+  int getFiftyEighth();
+
+  int getFiftyNinth();
+
+  int getSixtieth();
+
+  int getSixtyFirst();
+
+  int getSixtySecond();
+
+  int getSixtyThird();
+
+  int getSixtyFourth();
+
+  int getSixtyFifth();
+
+  int getSixtySixth();
+
+  int getSixtySeventh();
+
+  int getSixtyEighth();
+
+  int getSixtyNinth();
+
+  int getSeventieth();
+
+  int getSeventyFirst();
+
+  int getSeventySecond();
+
+  int getSeventyThird();
+
+  int getSeventyFourth();
+
+  int getSeventyFifth();
+
+  int getSeventySixth();
+
+  int getSeventySeventh();
+
+  int getSeventyEighth();
+
+  int getSeventyNinth();
+
+  int getEightieth();
+}

--- a/value-fixture/src/nonimmutables/huge/HugeParentTwo.java
+++ b/value-fixture/src/nonimmutables/huge/HugeParentTwo.java
@@ -1,0 +1,43 @@
+package nonimmutables.huge;
+
+public interface HugeParentTwo {
+  String getAlpha();
+
+  String getBeta();
+
+  String getGamma();
+
+  String getDelta();
+
+  String getEpsilon();
+
+  String getZeta();
+
+  String getEta();
+
+  String getTheta();
+
+  String getIota();
+
+  String getKappa();
+
+  String getLambda();
+
+  String getMu();
+
+  String getNu();
+
+  String getXi();
+
+  String getOmicron();
+
+  String getPi();
+
+  String getRho();
+
+  String getSigma();
+
+  String getTau();
+
+  String getUpsilon();
+}

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1792,29 +1792,71 @@ public interface [tb.nameBuildFinal][type.generics] {
 [/if]
   private void mergeInternal(Object object) {
     [dynamicFromModifiableCheck type 'object' 'return;']
-    [for l in bs.positions.longs]
-    [atVar type]long bits[emptyIfZero l.index] = 0;
-    [/for]
-  [for s in bs.supertypes if s.attributes]
+    [if bs.positions.hasMultipleLongs]
+    [atVar type]long['[]'] bits = new long['['][bs.positions.longs.size][']'];
+    [for s in bs.supertypes if s.attributes]
     if (object instanceof [s.wildcard]) {
-      [s.type] instance = ([s.type]) object;
-      [for v in s.attributes, BitPosition pos = bs.positions v.name]
-      [if pos]
-      if ((bits[emptyIfZero pos.index] & [literal.hex pos.mask]) == 0) {
-        [if v.nullableInSupertype]
-        [buildFromAttributeNullableSupertype v]
-        [else]
-        [buildFromAttribute v]
-        [/if]
-        bits[emptyIfZero pos.index] |= [literal.hex pos.mask];
-      }
+      mergeFrom[toSafeIdentifier s.simpleName](bits, ([s.type]) object);
+    }
+    [/for]
+    [else]
+    [atVar type]long bits = 0;
+    [for s in bs.supertypes if s.attributes]
+    if (object instanceof [s.wildcard]) {
+      bits = mergeFrom[toSafeIdentifier s.simpleName](bits, ([s.type]) object);
+    }
+    [/for]
+    [/if]
+  }
+
+[-- Generate specialized merge methods per subtype --]
+[for s in bs.supertypes if s.attributes]
+[if bs.positions.hasMultipleLongs]
+  private void mergeFrom[toSafeIdentifier s.simpleName](long['[]'] bits, [s.type] instance) {
+    [-- Read array values into named variables --]
+    [for l in bs.positions.longs]
+    long bitMask[emptyIfZero l.index] = bits['['][l.index][']'];
+    [/for]
+    [for v in s.attributes, BitPosition pos = bs.positions v.name]
+    [if pos]
+    if ((bitMask[emptyIfZero pos.index] & [literal.hex pos.mask]) == 0) {
+      [if v.nullableInSupertype]
+      [buildFromAttributeNullableSupertype v]
       [else]
       [buildFromAttribute v]
       [/if]
-      [/for]
+      bitMask[emptyIfZero pos.index] |= [literal.hex pos.mask];
     }
-  [/for]
+    [else]
+    [buildFromAttribute v]
+    [/if]
+    [/for]
+    [-- Write named variables back to array --]
+    [for l in bs.positions.longs]
+    bits['['][l.index][']'] = bitMask[emptyIfZero l.index];
+    [/for]
   }
+[else]
+  private long mergeFrom[toSafeIdentifier s.simpleName](long bits, [s.type] instance) {
+    [for v in s.attributes, BitPosition pos = bs.positions v.name]
+    [if pos]
+    if ((bits & [literal.hex pos.mask]) == 0) {
+      [if v.nullableInSupertype]
+      [buildFromAttributeNullableSupertype v]
+      [else]
+      [buildFromAttribute v]
+      [/if]
+      bits |= [literal.hex pos.mask];
+    }
+    [else]
+    [buildFromAttribute v]
+    [/if]
+    [/for]
+    return bits;
+  }
+[/if]
+
+[/for]
 [/for]
     [else]
 

--- a/value-processor/src/org/immutables/value/processor/meta/FromSupertypesModel.java
+++ b/value-processor/src/org/immutables/value/processor/meta/FromSupertypesModel.java
@@ -40,7 +40,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
-import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 import org.immutables.generator.SourceTypes;
@@ -74,6 +73,10 @@ public final class FromSupertypesModel {
               Collections.nCopies(withArgs.getValue().size(), "?")))
           : type;
       this.attributes = ImmutableList.copyOf(attribute);
+    }
+
+    public String simpleName() {
+      return raw.substring(raw.lastIndexOf('.') + 1);
     }
 
     @Override

--- a/value-processor/src/org/immutables/value/processor/meta/LongBits.java
+++ b/value-processor/src/org/immutables/value/processor/meta/LongBits.java
@@ -79,6 +79,10 @@ public final class LongBits implements Function<Iterable<? extends Object>, Long
       return longPositions.values();
     }
 
+    public boolean hasMultipleLongs() {
+      return longPositions.size() > 1;
+    }
+
     @Nullable
     @Override
     public BitPosition apply(Object input) {


### PR DESCRIPTION
This hopes to address #1572 by shortening the `mergeInternal` method by using methods, while maintaining the performance of the bit masking operators, especially for smaller data models.

Prior to this commit, our mergeInternal function that is created when a derived class is used as an Immutables target would check the possible types in a series of if blocks. However, this can lead to an explosion in the length of this method, especially for target classes with multiple parents. Long methods are concerning because it can exceed the JVM's default 8 KB limit for method compilation, forcing calls to remain interpreted.

Instead, generate specialized methods for each relevant subtype. This helps break up the monolithic mergeInternal method while not introducing too many method hops.

This approach, however, requires special handling of our bit masks, since we may have more than one long value to represent cases where the model has >64 fields. To deal with this, introduce a specialized case where we use a long[] of values, in order for each specialized method to easily update the overall state. This approach balances optimizing the simple case (<= 64 fields) for performance on small models, while allowing for larger models with only introducing a minimal amount of overhead in the allocation and access of the array values.