### PR TITLE
Optional with default

### DIFF
--- a/value-fixture/src/org/immutables/fixture/jdkonly/OptionalDefault.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/OptionalDefault.java
@@ -1,0 +1,28 @@
+/*
+   Copyright 2025 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.fixture.jdkonly;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface OptionalDefault {
+  @Value.Default
+  default Optional<String> text() {
+    return Optional.of("foo");
+  }
+}

--- a/value-fixture/src/org/immutables/fixture/jdkonly/OptionalDefault.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/OptionalDefault.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface OptionalDefault {
+public interface OptionalDefault extends WithOptionalDefault {
   @Value.Default
   default Optional<String> text() {
     return Optional.of("foo");

--- a/value-fixture/src/org/immutables/fixture/jdkonly/OptionalDoubleDefault.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/OptionalDoubleDefault.java
@@ -20,7 +20,7 @@ import java.util.OptionalDouble;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface OptionalDoubleDefault {
+public interface OptionalDoubleDefault extends WithOptionalDoubleDefault {
   @Value.Default
   default OptionalDouble magic() {
     return OptionalDouble.of(42);

--- a/value-fixture/src/org/immutables/fixture/jdkonly/OptionalDoubleDefault.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/OptionalDoubleDefault.java
@@ -1,0 +1,28 @@
+/*
+   Copyright 2025 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.fixture.jdkonly;
+
+import java.util.OptionalDouble;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface OptionalDoubleDefault {
+  @Value.Default
+  default OptionalDouble magic() {
+    return OptionalDouble.of(42);
+  }
+}

--- a/value-fixture/src/org/immutables/fixture/jdkonly/OptionalIntDefault.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/OptionalIntDefault.java
@@ -20,7 +20,7 @@ import java.util.OptionalInt;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface OptionalIntDefault {
+public interface OptionalIntDefault extends WithOptionalIntDefault {
   @Value.Default
   default OptionalInt magic() {
     return OptionalInt.of(42);

--- a/value-fixture/src/org/immutables/fixture/jdkonly/OptionalIntDefault.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/OptionalIntDefault.java
@@ -1,0 +1,28 @@
+/*
+   Copyright 2025 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.fixture.jdkonly;
+
+import java.util.OptionalInt;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface OptionalIntDefault {
+  @Value.Default
+  default OptionalInt magic() {
+    return OptionalInt.of(42);
+  }
+}

--- a/value-fixture/src/org/immutables/fixture/jdkonly/OptionalLongDefault.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/OptionalLongDefault.java
@@ -1,0 +1,28 @@
+/*
+   Copyright 2025 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.fixture.jdkonly;
+
+import java.util.OptionalLong;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface OptionalLongDefault {
+  @Value.Default
+  default OptionalLong magic() {
+    return OptionalLong.of(42);
+  }
+}

--- a/value-fixture/src/org/immutables/fixture/jdkonly/OptionalLongDefault.java
+++ b/value-fixture/src/org/immutables/fixture/jdkonly/OptionalLongDefault.java
@@ -20,7 +20,7 @@ import java.util.OptionalLong;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface OptionalLongDefault {
+public interface OptionalLongDefault extends WithOptionalLongDefault {
   @Value.Default
   default OptionalLong magic() {
     return OptionalLong.of(42);

--- a/value-fixture/test/org/immutables/fixture/jdkonly/JdkOptionalDefaultTest.java
+++ b/value-fixture/test/org/immutables/fixture/jdkonly/JdkOptionalDefaultTest.java
@@ -31,7 +31,11 @@ public class JdkOptionalDefaultTest {
     check(ImmutableOptionalDefault.builder().build().text()).is(Optional.of("foo"));
     check(ImmutableOptionalDefault.builder().text(Optional.empty()).build().text()).is(Optional.empty());
     check(ImmutableOptionalDefault.builder().text(Optional.of("bar")).build().text()).is(Optional.of("bar"));
-    check(ImmutableOptionalDefault.builder().text("bar").build().text()).is(Optional.of("bar"));
+    ImmutableOptionalDefault value = ImmutableOptionalDefault.builder().text("bar").build();
+    check(value.text()).is(Optional.of("bar"));
+    check(value.withText("blah").text()).is(Optional.of("blah"));
+    check(value.withText(Optional.of("blah")).text()).is(Optional.of("blah"));
+    check(value.withText(Optional.empty()).text()).is(Optional.empty());
   }
 
   @Test
@@ -39,7 +43,11 @@ public class JdkOptionalDefaultTest {
     check(ImmutableOptionalIntDefault.builder().build().magic()).is(OptionalInt.of(42));
     check(ImmutableOptionalIntDefault.builder().magic(OptionalInt.empty()).build().magic()).is(OptionalInt.empty());
     check(ImmutableOptionalIntDefault.builder().magic(OptionalInt.of(17)).build().magic()).is(OptionalInt.of(17));
-    check(ImmutableOptionalIntDefault.builder().magic(17).build().magic()).is(OptionalInt.of(17));
+    ImmutableOptionalIntDefault value = ImmutableOptionalIntDefault.builder().magic(17).build();
+    check(value.magic()).is(OptionalInt.of(17));
+    check(value.withMagic(99).magic()).is(OptionalInt.of(99));
+    check(value.withMagic(OptionalInt.of(99)).magic()).is(OptionalInt.of(99));
+    check(value.withMagic(OptionalInt.empty()).magic()).is(OptionalInt.empty());
   }
 
   @Test
@@ -47,7 +55,11 @@ public class JdkOptionalDefaultTest {
     check(ImmutableOptionalLongDefault.builder().build().magic()).is(OptionalLong.of(42));
     check(ImmutableOptionalLongDefault.builder().magic(OptionalLong.empty()).build().magic()).is(OptionalLong.empty());
     check(ImmutableOptionalLongDefault.builder().magic(OptionalLong.of(17)).build().magic()).is(OptionalLong.of(17));
-    check(ImmutableOptionalLongDefault.builder().magic(17).build().magic()).is(OptionalLong.of(17));
+    ImmutableOptionalLongDefault value = ImmutableOptionalLongDefault.builder().magic(17).build();
+    check(value.magic()).is(OptionalLong.of(17));
+    check(value.withMagic(99).magic()).is(OptionalLong.of(99));
+    check(value.withMagic(OptionalLong.of(99)).magic()).is(OptionalLong.of(99));
+    check(value.withMagic(OptionalLong.empty()).magic()).is(OptionalLong.empty());
   }
 
   @Test
@@ -55,6 +67,10 @@ public class JdkOptionalDefaultTest {
     check(ImmutableOptionalDoubleDefault.builder().build().magic()).is(OptionalDouble.of(42));
     check(ImmutableOptionalDoubleDefault.builder().magic(OptionalDouble.empty()).build().magic()).is(OptionalDouble.empty());
     check(ImmutableOptionalDoubleDefault.builder().magic(OptionalDouble.of(17)).build().magic()).is(OptionalDouble.of(17));
-    check(ImmutableOptionalDoubleDefault.builder().magic(17).build().magic()).is(OptionalDouble.of(17));
+    ImmutableOptionalDoubleDefault value = ImmutableOptionalDoubleDefault.builder().magic(17).build();
+    check(value.magic()).is(OptionalDouble.of(17));
+    check(value.withMagic(99).magic()).is(OptionalDouble.of(99));
+    check(value.withMagic(OptionalDouble.of(99)).magic()).is(OptionalDouble.of(99));
+    check(value.withMagic(OptionalDouble.empty()).magic()).is(OptionalDouble.empty());
   }
 }

--- a/value-fixture/test/org/immutables/fixture/jdkonly/JdkOptionalDefaultTest.java
+++ b/value-fixture/test/org/immutables/fixture/jdkonly/JdkOptionalDefaultTest.java
@@ -1,0 +1,60 @@
+/*
+   Copyright 2025 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.fixture.jdkonly;
+
+import static org.immutables.check.Checkers.check;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+import org.junit.jupiter.api.Test;
+
+public class JdkOptionalDefaultTest {
+
+  @Test
+  public void optionalDefault() {
+    check(ImmutableOptionalDefault.builder().build().text()).is(Optional.of("foo"));
+    check(ImmutableOptionalDefault.builder().text(Optional.empty()).build().text()).is(Optional.empty());
+    check(ImmutableOptionalDefault.builder().text(Optional.of("bar")).build().text()).is(Optional.of("bar"));
+    check(ImmutableOptionalDefault.builder().text("bar").build().text()).is(Optional.of("bar"));
+  }
+
+  @Test
+  public void optionalIntDefault() {
+    check(ImmutableOptionalIntDefault.builder().build().magic()).is(OptionalInt.of(42));
+    check(ImmutableOptionalIntDefault.builder().magic(OptionalInt.empty()).build().magic()).is(OptionalInt.empty());
+    check(ImmutableOptionalIntDefault.builder().magic(OptionalInt.of(17)).build().magic()).is(OptionalInt.of(17));
+    check(ImmutableOptionalIntDefault.builder().magic(17).build().magic()).is(OptionalInt.of(17));
+  }
+
+  @Test
+  public void optionalLongDefault() {
+    check(ImmutableOptionalLongDefault.builder().build().magic()).is(OptionalLong.of(42));
+    check(ImmutableOptionalLongDefault.builder().magic(OptionalLong.empty()).build().magic()).is(OptionalLong.empty());
+    check(ImmutableOptionalLongDefault.builder().magic(OptionalLong.of(17)).build().magic()).is(OptionalLong.of(17));
+    check(ImmutableOptionalLongDefault.builder().magic(17).build().magic()).is(OptionalLong.of(17));
+  }
+
+  @Test
+  public void optionalDoubleDefault() {
+    check(ImmutableOptionalDoubleDefault.builder().build().magic()).is(OptionalDouble.of(42));
+    check(ImmutableOptionalDoubleDefault.builder().magic(OptionalDouble.empty()).build().magic()).is(OptionalDouble.empty());
+    check(ImmutableOptionalDoubleDefault.builder().magic(OptionalDouble.of(17)).build().magic()).is(OptionalDouble.of(17));
+    check(ImmutableOptionalDoubleDefault.builder().magic(17).build().magic()).is(OptionalDouble.of(17));
+  }
+}

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -995,6 +995,15 @@ return new [type.typeValue.relativeRaw][type.generics.diamond]([output.linesShor
   [type.typeAbstract.relative] [v.names.with]([if v.multimapType][guava].collect.Multimap[else]java.util.Map[/if]<[gE], ? extends [wV]> entries);
       [/for]
       [else]
+      [if v.optionalWithDefault]
+  /**
+   * Copy the current immutable object by setting a <i>present</i> value for the optional [sourceDocRef v] attribute.
+   * @param value The value for [v.name][if v.optionalAcceptNullable], {@code null} is accepted as {@code [optionalEmpty v]}[/if]
+   * @return A modified copy of {@code this} object
+   */
+  [deprecation v]
+  [type.typeAbstract.relative] [v.names.with]([v.unwrappedElementType] value);
+      [/if]
 
   /**
    * Copy the current immutable object by setting a value for the [sourceDocRef v] attribute.
@@ -4341,6 +4350,25 @@ public final [type.typeImmutable.relative] [v.names.with]([v.atNullability][if v
 }
     [/for]
     [else]
+      [if v.optionalWithDefault]
+/**
+ * Copy the current immutable object by setting a <em>present</em> value for the optional [sourceDocRef v] attribute.
+ * @param value The value for [v.name][if v.optionalAcceptNullable], {@code null} is accepted as {@code [optionalEmpty v]}[/if]
+ * @return A modified copy or {@code this} if not changed
+ */
+[deprecation v]
+public final [type.typeImmutable.relative] [v.names.with]([v.unwrappedElementType] value) {
+  [immutableImplementationType v] newValue = [optionalOf v]([maybeCopyOf v]value[/maybeCopyOf]);
+  [if v.forceEqualsInWithers]
+  if ([objectsEqual type](this.[v.name], newValue)) return this;
+  [else if v.hasSimpleScalarElementType andnot v.enumType]
+  if ([objectsEqual type](this.[v.name], newValue)) return this;
+  [else]
+  if (this.[v.name] == newValue) return this;
+  [/if]
+  [generateReturnCopyContextual type v]
+}
+      [/if]
 
 /**
  * Copy the current immutable object by setting a value for the [sourceDocRef v] attribute.

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -2599,6 +2599,25 @@ checkNotIsSet([v.names.isSet](), "[v.names.raw]");
     [mandatorySetInBuilder v]
     return [builderReturnThis type];
   }
+
+  [if v.optionalWithDefault]
+    /**
+    * Initializes the optional value [sourceDocRef v] to [v.name].
+    * <p><em>If not set, this attribute will have a default value as returned by the initializer of [sourceDocRef v].</em>
+    * @param [v.name] The value for [v.name][if v.optionalAcceptNullable], {@code null} is accepted as {@code [optionalEmpty v]}[/if]
+    * @return {@code this} builder for chained invocation
+    */
+    [eachLine v.elementInitializerInjectedAnnotations]
+    [atCanIgnoreReturnValue type]
+    [deprecation v]
+    [builderInitAccess v]final [builderReturnType type] [v.names.init]([v.unwrappedElementType] [v.name]) {
+      [checkNotIsSet v]
+      this.[v.name] = [optionalOf v]([maybeCopyOf v][v.name][/maybeCopyOf]);
+      [nondefaultSetInBuilder v]
+      return [builderReturnThis type];
+    }
+  [/if]
+
   [if v.isAttributeBuilder]
 
   /**

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -82,6 +82,7 @@ public final class ValueAttribute extends TypeIntrospectionBase implements HasSt
 
   public AttributeNames names;
   public boolean isGenerateDefault;
+  public boolean isOptionalWithDefault;
   public @Nullable Object constantDefault;
   public boolean isGenerateDerived;
   public boolean isGenerateAbstract;
@@ -688,7 +689,7 @@ public final class ValueAttribute extends TypeIntrospectionBase implements HasSt
   }
 
   public String getUnwrappedElementType() {
-    return isContainerType() && nullElements.ban()
+    return (isContainerType() && nullElements.ban()) || isOptionalWithDefault
         ? unwrapType(firstTypeParameter())
         : getElementType();
   }
@@ -1628,9 +1629,7 @@ public final class ValueAttribute extends TypeIntrospectionBase implements HasSt
 
     if (isGenerateDefault && isOptionalType()) {
       typeKind = AttributeTypeKind.REGULAR;
-      report()
-          .annotationNamed(DefaultMirror.simpleName())
-          .warning(About.UNTYPE, "@Value.Default on a optional attribute make it lose its special treatment");
+      isOptionalWithDefault = true;
     }
 
     if (isContainerType() && containingType.isUseStrictBuilder()) {


### PR DESCRIPTION
Handles Optionals with default value, adds setter and wither methods with the unwrapped type and no longer prints warnings for this case.

Fixes #1432