### PR TITLE
Fix @param for wither for optional within a record

### DIFF
--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -722,10 +722,10 @@ return new [type.typeValue.relativeRaw][type.generics.diamond]([output.linesShor
    * @return A modified copy of the record or {@code this} if not changed
    */
   [deprecation v]
-  default [type.typeAbstract.relative] [v.names.with]([v.rawType][if not v.jdkSpecializedOptional]<[qExtends v][v.wrappedElementType]>[/if] [v.name]) {
+  default [type.typeAbstract.relative] [v.names.with]([v.rawType][if not v.jdkSpecializedOptional]<[qExtends v][v.wrappedElementType]>[/if] optional) {
     [let optType][v.rawType][if not v.jdkSpecializedOptional]<[v.wrappedElementType]>[/if][/let]
     [suppressCovariantCastForOptional v]
-    [optType] newValue = [requireNonNull type](([optType]) [v.name], "[v.name]");
+    [optType] newValue = [requireNonNull type](([optType]) optional, "[v.name] optional");
     [recordSelf type]
     [if v.forceEqualsInWithers]
     if (self.[v.name]().equals(newValue)) return self;


### PR DESCRIPTION
The compiler config in my current project is a bit sensitive and the file generated by the generator currently triggers an error. I think this change also makes the naming align with the overall format of the other generators from what I was able to gather. Not sure if anything else needs to be changed, but tested it locally and this did make the two align and all checks to pass.