### PR TITLE
#1600 Stop infinite recursion for annotations applying to themselves

### DIFF
--- a/value-fixture/src/nonimmutables/SelfApplyingAnnotation.java
+++ b/value-fixture/src/nonimmutables/SelfApplyingAnnotation.java
@@ -1,0 +1,11 @@
+package nonimmutables;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@SelfApplyingAnnotation
+public @interface SelfApplyingAnnotation {}

--- a/value-fixture/src/org/immutables/fixture/annotation/ExampleModelWithSelfApplyingAnnotation.java
+++ b/value-fixture/src/org/immutables/fixture/annotation/ExampleModelWithSelfApplyingAnnotation.java
@@ -1,0 +1,14 @@
+package org.immutables.fixture.annotation;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import nonimmutables.SelfApplyingAnnotation;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableExampleModelWithSelfApplyingAnnotation.class)
+@JsonDeserialize(as = ImmutableExampleModelWithSelfApplyingAnnotation.class)
+public interface ExampleModelWithSelfApplyingAnnotation {
+  @SelfApplyingAnnotation
+  String attributeWithSelfApplyingAnnotations();
+}

--- a/value-fixture/src/org/immutables/fixture/annotation/ExampleModelWithSelfApplyingAnnotation.java
+++ b/value-fixture/src/org/immutables/fixture/annotation/ExampleModelWithSelfApplyingAnnotation.java
@@ -6,6 +6,7 @@ import nonimmutables.SelfApplyingAnnotation;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(passAnnotations = {SelfApplyingAnnotation.class})
 @JsonSerialize(as = ImmutableExampleModelWithSelfApplyingAnnotation.class)
 @JsonDeserialize(as = ImmutableExampleModelWithSelfApplyingAnnotation.class)
 public interface ExampleModelWithSelfApplyingAnnotation {

--- a/value-fixture/test/org/immutables/fixture/annotation/PassAnnotationTest.java
+++ b/value-fixture/test/org/immutables/fixture/annotation/PassAnnotationTest.java
@@ -60,4 +60,11 @@ public class PassAnnotationTest {
     check(m.getAnnotation(ChildAnnotationA.class)).notNull();
     check(m.getAnnotation(ChildAnnotationB.class)).notNull();
   }
+
+  @Test
+  public void selfApplyingAnnotationWorks() throws Exception {
+    Method m = ImmutableExampleModelWithSelfApplyingAnnotation.class.getDeclaredMethod(
+        "attributeWithSelfApplyingAnnotations");
+    check(m.getAnnotation(SelfApplyingAnnotation.class)).notNull();
+  }
 }

--- a/value-fixture/test/org/immutables/fixture/annotation/PassAnnotationTest.java
+++ b/value-fixture/test/org/immutables/fixture/annotation/PassAnnotationTest.java
@@ -24,6 +24,7 @@ import nonimmutables.C1;
 import nonimmutables.ChildAnnotationA;
 import nonimmutables.ChildAnnotationB;
 import nonimmutables.ImmutablePassAnnsTargeting;
+import nonimmutables.SelfApplyingAnnotation;
 import org.junit.jupiter.api.Test;
 import static org.immutables.check.Checkers.check;
 

--- a/value-processor/src/org/immutables/value/processor/meta/Annotations.java
+++ b/value-processor/src/org/immutables/value/processor/meta/Annotations.java
@@ -204,7 +204,7 @@ final class Annotations {
     if (includeJacksonAnnotations || !includeAnnotations.isEmpty()) {
       for (AnnotationMirror parentAnnotation : annotationElement.getAnnotationMirrors()) {
         TypeElement parentElement = (TypeElement) parentAnnotation.getAnnotationType().asElement();
-        Set<String> throwawaySeenForParent = new HashSet<>(1);
+        Set<String> throwawaySeenForParent = new HashSet<>(seenAnnotations);
         // This block of code can include annotation if it's parent annotation is included
         if (annotationTypeMatches(element,
             parentElement,


### PR DESCRIPTION
This fixes https://github.com/immutables/immutables/issues/1600 which was a bug introduced by https://github.com/immutables/immutables/commit/3da32c580d3526584bd0b909cf891639b2cf214f.

I'm honestly not too sure about where to put the test to reproduce the bug and validate it. Ultimately all that matters is that we test the compilation of the class, but I couldn't figure out where other examples of tests like this would live, so I pattern-matched from the test added in that same commit.

Happy to update the test to whatever makes sense!