### PR TITLE
Fix `.unset*()` for modifiable with primitive field and default value.

### DIFF
--- a/value-fixture/src/org/immutables/fixture/modifiable/Companion.java
+++ b/value-fixture/src/org/immutables/fixture/modifiable/Companion.java
@@ -111,6 +111,11 @@ public interface Companion {
     }
 
     @Value.Default
+    default int def2() {
+      return 0;
+    }
+
+    @Value.Default
     default String defs() {
       return "";
     }

--- a/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
+++ b/value-fixture/test/org/immutables/fixture/modifiable/ModifiablesTest.java
@@ -114,6 +114,32 @@ public class ModifiablesTest {
     check(!c1.integerIsSet());
     check(!c1.arrayIntsIsSet());
     check(!c1.stringIsSet());
+
+    ModifiableStandalone c2 = ModifiableStandalone.create();
+    check(!c2.defIsSet());
+    check(!c2.def2IsSet());
+    check(c2.def()).is(1);
+    check(c2.def2()).is(0);
+
+    c2.setDef(2);
+    check(c2.defIsSet());
+    check(!c2.def2IsSet());
+    check(c2.def()).is(2);
+
+    c2.setDef2(3);
+    check(c2.defIsSet());
+    check(c2.def2IsSet());
+    check(c2.def2()).is(3);
+
+    c2.unsetDef();
+    check(!c2.defIsSet());
+    check(c2.def2IsSet());
+    check(c2.def()).is(1);
+
+    c2.unsetDef2();
+    check(!c2.defIsSet());
+    check(!c2.def2IsSet());
+    check(c2.def2()).is(0);
   }
 
   @Test

--- a/value-processor/src/org/immutables/value/processor/Modifiables.generator
+++ b/value-processor/src/org/immutables/value/processor/Modifiables.generator
@@ -196,7 +196,7 @@ Use @Value.Modifiable cannot be used with @Value.Immutable which implements Ordi
    */
   [atCanIgnoreReturnValue type]
   public final [thisSetterReturnType type] [unset p]() {
-    [disambiguateField type 'optBits'][emptyIfZero pos.index] |= 0;
+    [disambiguateField type 'optBits'][emptyIfZero pos.index] &= ~OPT_BIT_[toConstant p.name];
     [clearField p true]
     [thisSetterReturn type]
   }


### PR DESCRIPTION
### Summary
Ensure modifiable with primitive field and default value returns the default value 
and `.*IsSet()` returns `false` after `.unset*()` is called.

### Description:
Currently a field such as:
```java
@Value.Modifiable
interface Standalone {

  @Value.Default
  default int def() {
    return 1;
  }
}
```

Would generate the following for the `.unset*()` method:
e.g.
```java
/**
 * Reset an attribute to its initial value.
 * @return {@code this} for use in a chained invocation
 */
@CanIgnoreReturnValue
public final ModifiableStandalone unsetDef() {
  optBits |= 0;
  def = 0;
  return this;
}
```
Having `optBits |= 0;` does nothing, and doesn't effectively unset the field.  Thus, subsequent calls to `.def()` would return `0`, instead of the value returned by the method annotated with `@Value.Default` (i.e. `1`).  Further, subsequent calls to `.defIsSet()` would return `true` when it should return `false`.

This change would instead generate the following for the `.unset*()` method:
e.g.

```java
/**
 * Reset an attribute to its initial value.
 * @return {@code this} for use in a chained invocation
 */
@CanIgnoreReturnValue
public final ModifiableStandalone unsetDef() {
  optBits &= ~OPT_BIT_DEF;
  def = 0;
  return this;
}
```

Having `optBits &= ~OPT_BIT_DEF` will cause subsequent calls to `.defIsSet()` to return `false`, and calls to `.def()` to invoke the method annotated with `@Value.Default` to get the value.