### PR TITLE
Remove redundant cast of optional record property wither methods

### DIFF
--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -740,7 +740,7 @@ return new [type.typeValue.relativeRaw][type.generics.diamond]([output.linesShor
   default [type.typeAbstract.relative] [v.names.with]([v.rawType][if not v.jdkSpecializedOptional]<[qExtends v][v.wrappedElementType]>[/if] optional) {
     [let optType][v.rawType][if not v.jdkSpecializedOptional]<[v.wrappedElementType]>[/if][/let]
     [suppressCovariantCastForOptional v]
-    [optType] newValue = [requireNonNull type](([optType]) optional, "[v.name] optional");
+    [optType] newValue = [requireNonNull type]([if v.consumesWildcardExtends]([optType]) [/if]optional, "[v.name] optional");
     [recordSelf type]
     [if v.forceEqualsInWithers]
     if (self.[v.name]().equals(newValue)) return self;


### PR DESCRIPTION
## Context

This pull request can be seen as follow up of https://github.com/immutables/immutables/pull/1589 (cc @AndreiPurcaru) and tries to unblock using the neat record "wither" interface for optional values as introduced in https://github.com/immutables/immutables/releases/tag/2.11.0 when using strict checkstyle configuration.  

I didn't find referencing issues or pull requests. Since the solution looked feasible I just went for it. 🚀 

## Bug description

```java
import java.util.Optional;
import org.immutables.value.Value;

@Value.Builder
record MinimalExample(Optional<String> value) implements WithMinimalExample {}
```

generates (among other methods)
```java
  /**
   * Copy the record by setting an optional value for the {@code value} attribute.
   * An equality check is used on inner value to prevent copying of the same value by returning {@code this}.
   * @param optional An optional value for value
   * @return A modified copy of the record or {@code this} if not changed
   */
  default MinimalExample withValue(Optional<String> optional) {
    Optional<String> newValue = Objects.requireNonNull((Optional<String>) optional, "value optional");
    MinimalExample self = (MinimalExample) this;
    if (self.value().equals(newValue)) return self;
    return new MinimalExample(newValue);
  }
```

`optional` is however already of type `Optional<String>` so the strict checkstyle configuration in my project fails the build due to the redundant cast.

```
[WARNING] COMPILATION WARNING : 
[INFO] -------------------------------------------------------------
[WARNING] WithMinimalExample.java:[33,56] redundant cast to java.util.Optional<java.lang.String>
[INFO] 1 warning
[INFO] -------------------------------------------------------------
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] warnings found and -Werror specified
```

## Solution description

Conceptually simple: Only cast when strictly necessary. As stated by the [documentation](https://github.com/immutables/immutables/blob/c56f0829889dd2ec6fba2c25b6a9c088fe4e9d02/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java#L1198-L1199) of `org.immutables.value.processor.meta.ValueAttribute#isSafeUncheckedCovariantCast`:
> If we don't have an extends, then we don't need a cast, and we don't need to suppress any unchecked warnings.

So the diff for the minimal example above (where the cast is redundant) should look like:
```diff
diff a/WithMinimalExample.java b/WithMinimalExample.java
--- a/WithMinimalExample.java
+++ b/WithMinimalExample.java
@@ -30,7 +30,7 @@ public interface WithMinimalExample {
    * @return A modified copy of the record or {@code this} if not changed
    */
   default MinimalExample withValue(Optional<String> optional) {
-    Optional<String> newValue = Objects.requireNonNull((Optional<String>) optional, "value optional");
+    Optional<String> newValue = Objects.requireNonNull(optional, "value optional");
     MinimalExample self = (MinimalExample) this;
     if (self.value().equals(newValue)) return self;
     return new MinimalExample(newValue);
```
But for cases where the cast is necessary due to dealing with covariants we of course need to retain it:
```java
  default RecordOptionals withObj(Optional<? extends Object> optional) {
    @SuppressWarnings("unchecked") // safe covariant cast
    Optional<Object> newValue = Objects.requireNonNull((Optional<Object>) optional, "obj optional");
```

I opted to use `org.immutables.value.processor.meta.ValueAttribute#consumesWildcardExtends` for these reasons:
1. we're already in the context of an optional property
2. it's used in `suppressCovariantCastForOptional` (which is used to generate the unchecked cast warning suppression)
3. it's used for similar use-cases like [here](https://github.com/immutables/immutables/blob/c56f0829889dd2ec6fba2c25b6a9c088fe4e9d02/value-processor/src/org/immutables/value/processor/Immutables.generator#L2393-L2394) or [here](https://github.com/immutables/immutables/blob/c56f0829889dd2ec6fba2c25b6a9c088fe4e9d02/value-processor/src/org/immutables/value/processor/Immutables.generator#L3004-L3005) to avoid redundant casting already

Maybe there are better solutions?