### PR TITLE
JDK 23+.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21'  ]
+        java: [ '8', '11', '17', '21', '25'  ]
         compiler: [ 'javac', 'ecj' ]
         extra: [ 'none', 'errorprone' ]
+        exclude:
+          - java: 25
+            compiler: ecj
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK

--- a/criteria/pom.xml
+++ b/criteria/pom.xml
@@ -54,16 +54,9 @@
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <compilerArgs combine.children="append">
-                        <arg>-XDcompilePolicy=simple</arg>
-                        <arg>-Xplugin:ErrorProne -Xep:CheckReturnValue:ERROR -Xep:MethodCanBeStatic:ERROR -Xep:BadImport:ERROR -Xep:MissingOverride:ERROR -Xep:OrphanedFormatString:ERROR -Xep:RedundantOverride:ERROR -Xep:RedundantThrows:ERROR -Xep:RemoveUnusedImports:ERROR -Xep:UnusedMethod:ERROR</arg>
                         <arg>-Xlint:unchecked</arg>
                     </compilerArgs>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>com.google.errorprone</groupId>
-                            <artifactId>error_prone_core</artifactId>
-                            <version>${errorprone.version}</version>
-                        </path>
+                    <annotationProcessorPaths combine.children="append">
                         <path>
                             <groupId>org.immutables</groupId>
                             <artifactId>value</artifactId>
@@ -76,6 +69,35 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>errorprone</id>
+            <activation>
+                <jdk>[1.8,23)</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${maven-compiler-plugin.version}</version>
+                        <configuration>
+                            <compilerArgs combine.children="append">
+                                <arg>-XDcompilePolicy=simple</arg>
+                                <arg>-Xplugin:ErrorProne -Xep:CheckReturnValue:ERROR -Xep:MethodCanBeStatic:ERROR -Xep:BadImport:ERROR -Xep:MissingOverride:ERROR -Xep:OrphanedFormatString:ERROR -Xep:RedundantOverride:ERROR -Xep:RedundantThrows:ERROR -Xep:RemoveUnusedImports:ERROR -Xep:UnusedMethod:ERROR</arg>
+                            </compilerArgs>
+                            <annotationProcessorPaths combine.children="append">
+                                <path>
+                                    <groupId>com.google.errorprone</groupId>
+                                    <artifactId>error_prone_core</artifactId>
+                                    <version>${errorprone.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>jdk8</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -383,11 +383,22 @@
     <profile>
       <id>jdk11</id>
       <activation>
-        <jdk>[11,)</jdk>
+        <jdk>[11,23)</jdk>
       </activation>
 
       <properties>
         <eclipse-compiler.version>3.33.0</eclipse-compiler.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>jdk23</id>
+      <activation>
+        <jdk>[23,)</jdk>
+      </activation>
+
+      <properties>
+        <maven.compiler.proc>full</maven.compiler.proc>
+        <maven.compiler.release>8</maven.compiler.release>
       </properties>
     </profile>
   </profiles>

--- a/value-fixture/pom.xml
+++ b/value-fixture/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
+<!--
    Copyright 2014-2018 Immutables Authors and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -318,7 +318,7 @@
     <profile>
       <id>jdk16-errorprone</id>
       <activation>
-        <jdk>[16,)</jdk>
+        <jdk>[16,23)</jdk>
         <property>
           <name>extra</name>
           <value>errorprone</value>


### PR DESCRIPTION
Enable immutable compilation on JDK 23+

All the learnings from this work:

- Since Java 23 unless specified explicitly in `<annotationProcessor>` configuration section annotation processors won't be located on classpath and executed without providing `-proc:full` compiler flag. This change was made in JDK 23.

- error prone can't compile JDK 25 target without an upgrade. But upgrade brings backward incompatible changes to error prone configuration. So I've disable error prone for JDK targets beyond JDK 23. Once immutables will bump minimum supported JDK version, error prone can be updated and enabled again for JDKs past 23.

- ecj compiler is not running annotation processors. I recon the issue is similar to `-proc:full` flag in my point 1 in findings, except I have no clue how to provide this to `ecj`. I tried to look up any info on that, no luck. So I've excluded `ecj` from build matrix until I can figure out how to bring it back.

