### PR TITLE
#1655 Fix TYPE_USE @Nullable on concrete array types

### DIFF
--- a/value-fixture/src/org/immutables/fixture/nullable/typeuse/NullableArrays.java
+++ b/value-fixture/src/org/immutables/fixture/nullable/typeuse/NullableArrays.java
@@ -1,0 +1,41 @@
+package org.immutables.fixture.nullable.typeuse;
+
+import org.immutables.value.Value;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reproducer for TYPE_USE nullable annotations on arrays.
+ *
+ * Case 1: Parent declares the array methods, child overrides.
+ * Case 2: Parent does NOT declare array methods, child adds them.
+ */
+public interface NullableArrays {
+
+  // Parent has these
+  byte @Nullable [] primitiveArray();
+  String @Nullable [] referenceArray();
+
+  // Case 1: child overrides parent's array methods
+  @Value.Immutable
+  @Value.Style(jdkOnly = true)
+  interface ChildOverrides extends NullableArrays {
+    @Override
+    byte @Nullable [] primitiveArray();
+
+    @Override
+    String @Nullable [] referenceArray();
+  }
+
+  // A parent without array methods
+  interface EmptyParent {
+    String name();
+  }
+
+  // Case 2: child introduces array methods not in parent
+  @Value.Immutable
+  @Value.Style(jdkOnly = true)
+  interface ChildIntroduces extends EmptyParent {
+    byte @Nullable [] primitiveArray();
+    String @Nullable [] referenceArray();
+  }
+}

--- a/value-fixture/test/org/immutables/fixture/nullable/TypeuseAnnotationTest.java
+++ b/value-fixture/test/org/immutables/fixture/nullable/TypeuseAnnotationTest.java
@@ -2,11 +2,13 @@ package org.immutables.fixture.nullable;
 
 import java.util.Map;
 import org.immutables.fixture.nullable.typeuse.CusNull;
+import org.immutables.fixture.nullable.typeuse.ImmutableChildOverrides;
 import org.immutables.fixture.nullable.typeuse.ImmutableFirstChild;
 import org.immutables.fixture.nullable.typeuse.ImmutableLetsTryJSpecify;
 import org.immutables.fixture.nullable.typeuse.ImmutableMyField;
 import org.immutables.fixture.nullable.typeuse.ImmutableSecondChild;
 import org.immutables.fixture.nullable.typeuse.ImmutableTryCustomNullann;
+import org.immutables.fixture.nullable.typeuse.NullableArrays;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import static org.immutables.check.Checkers.check;
@@ -57,6 +59,29 @@ public class TypeuseAnnotationTest {
         .getParameters()[0]
         .getAnnotatedType()
         .getAnnotation(CusNull.class)).notNull();
+  }
+
+  @Test void nullableConcreteArraysFromSupertype() {
+    byte[] bytes = {1, 2, 3};
+    String[] strings = {"a", "b"};
+
+    NullableArrays.ChildOverrides original = ImmutableChildOverrides.builder()
+        .primitiveArray(bytes)
+        .referenceArray(strings)
+        .build();
+
+    // .from() supertype overload should copy nullable array attributes
+    NullableArrays.ChildOverrides copied = ImmutableChildOverrides.builder()
+        .from((NullableArrays) original)
+        .build();
+
+    check(copied.primitiveArray()).notNull();
+    check(copied.referenceArray()).notNull();
+
+    // null arrays should be accepted
+    NullableArrays.ChildOverrides withNulls = ImmutableChildOverrides.builder().build();
+    check(withNulls.primitiveArray()).isNull();
+    check(withNulls.referenceArray()).isNull();
   }
 
   @Test void typeuseInheritance() throws Exception {

--- a/value-processor/src/org/immutables/value/processor/encode/Type.java
+++ b/value-processor/src/org/immutables/value/processor/encode/Type.java
@@ -760,6 +760,11 @@ public interface Type {
                 t = terms.peek();
                 if (t.is("[")) {
                   type = array(type);
+                } else if (t.is("@")) {
+                  // consume TYPE_USE annotation before array brackets
+                  // e.g. byte @Nullable []
+                  terms.poll();
+                  consumeAnnotation();
                 } else {
                   break;
                 }

--- a/value-processor/src/org/immutables/value/processor/meta/TypeStringProvider.java
+++ b/value-processor/src/org/immutables/value/processor/meta/TypeStringProvider.java
@@ -320,7 +320,8 @@ class TypeStringProvider {
 
             if (typeKind == TypeKind.ARRAY) {
               String signature = sourceStructure.getSignature(accessorPath);
-              if (signature.contains("@" + nullableAnnotationName + "[]")) {
+              if (signature.contains("@" + nullableAnnotationName + "[]")
+                  || signature.contains("@" + nullableAnnotationName + " []")) {
                 nullableTypeAnnotation = true;
               }
               // Commented out lines doesn't produce any good impact for various


### PR DESCRIPTION
Fixes #1655

`byte @Nullable []` and `String @Nullable []` produced warnings because:

1. The type parser in `FromSupertypesModel` did not handle `@` annotations between the element type and array brackets
2. The source access workaround in `TypeStringProvider` checked for `@Nullable[]` (no space) but the valid Java syntax is `@Nullable []` (with space)

Generic type variables (`V @Nullable []`) already worked; this fixes concrete types.

### Changes
- `Type.java`: consume `@` annotations before `[]` in the array parsing loop
- `TypeStringProvider.java`: also match `@Nullable []` with a space
- Added `NullableArrays.java` test fixture with `ChildOverrides` (parent declares arrays, child overrides) and `ChildIntroduces` (child adds arrays not in parent)
- Added test in `TypeuseAnnotationTest` verifying `.from()` copies nullable arrays from supertype and null arrays are accepted

### Testing
`mvn clean test -pl value-fixture -am` — all 323 tests pass, no new warnings.