### PR TITLE
Add optional field to Value.Parameter for trailing parameters only

### DIFF
--- a/value-annotations/src/org/immutables/value/Value.java
+++ b/value-annotations/src/org/immutables/value/Value.java
@@ -367,6 +367,17 @@ public @interface Value {
      * @return {@code false} if not a parameter
      */
     boolean value() default true;
+
+    /**
+     * If {@code true}, generates additional {@code of()} factory method overloads without this
+     * parameter. Optional parameters must be ordered at the end of the parameter list (by
+     * {@link #order()}) and must have a default value (via {@link Default}) or be nullable.
+     * <p>
+     * When multiple parameters are marked as optional, a telescoping set of factory methods
+     * is generated, each dropping one optional parameter from the end.
+     * @return {@code true} if this parameter should be optional in factory method overloads
+     */
+    boolean optional() default false;
   }
 
   /**

--- a/value-fixture/src/org/immutables/fixture/OptionalParameterFixture.java
+++ b/value-fixture/src/org/immutables/fixture/OptionalParameterFixture.java
@@ -1,0 +1,85 @@
+/*
+   Copyright 2024 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.fixture;
+
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+/**
+ * Test fixture for @Value.Parameter(optional = true) feature.
+ * Optional parameters must be at the end and have defaults or be nullable.
+ */
+public class OptionalParameterFixture {
+
+  /**
+   * Simple case: two required parameters, one optional with default.
+   */
+  @Value.Immutable
+  public interface SimpleOptional {
+    @Value.Parameter
+    String name();
+
+    @Value.Parameter
+    int age();
+
+    @Value.Parameter(optional = true)
+    @Value.Default
+    default String nickname() {
+      return "";
+    }
+  }
+
+  /**
+   * Multiple optional parameters at the end - should generate telescoping of() methods.
+   */
+  @Value.Immutable
+  public interface MultipleOptional {
+    @Value.Parameter
+    String required1();
+
+    @Value.Parameter
+    int required2();
+
+    @Value.Parameter(optional = true)
+    @Value.Default
+    default String optional1() {
+      return "default1";
+    }
+
+    @Value.Parameter(optional = true)
+    @Nullable
+    String optional2();
+
+    @Value.Parameter(optional = true)
+    @Value.Default
+    default int optional3() {
+      return 42;
+    }
+  }
+
+  /**
+   * Optional parameter that is nullable (no @Value.Default needed).
+   */
+  @Value.Immutable
+  public interface NullableOptional {
+    @Value.Parameter
+    String id();
+
+    @Value.Parameter(optional = true)
+    @Nullable
+    String description();
+  }
+}

--- a/value-fixture/test/org/immutables/fixture/OptionalParameterTest.java
+++ b/value-fixture/test/org/immutables/fixture/OptionalParameterTest.java
@@ -1,0 +1,112 @@
+/*
+   Copyright 2024 Immutables Authors and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.immutables.fixture;
+
+import org.immutables.fixture.OptionalParameterFixture.SimpleOptional;
+import org.immutables.fixture.OptionalParameterFixture.MultipleOptional;
+import org.immutables.fixture.OptionalParameterFixture.NullableOptional;
+import org.junit.jupiter.api.Test;
+import static org.immutables.check.Checkers.check;
+
+/**
+ * Tests for @Value.Parameter(optional = true) feature which generates
+ * telescoping of() factory methods.
+ */
+public class OptionalParameterTest {
+
+  @Test
+  public void simpleOptionalWithAllParameters() {
+    SimpleOptional value = ImmutableSimpleOptional.of("John", 30, "Johnny");
+    check(value.name()).is("John");
+    check(value.age()).is(30);
+    check(value.nickname()).is("Johnny");
+  }
+
+  @Test
+  public void simpleOptionalWithoutOptionalParameter() {
+    // This of() overload should be generated, using default for nickname
+    SimpleOptional value = ImmutableSimpleOptional.of("John", 30);
+    check(value.name()).is("John");
+    check(value.age()).is(30);
+    check(value.nickname()).is(""); // default value
+  }
+
+  @Test
+  public void multipleOptionalWithAllParameters() {
+    MultipleOptional value = ImmutableMultipleOptional.of("req1", 100, "opt1", "opt2", 99);
+    check(value.required1()).is("req1");
+    check(value.required2()).is(100);
+    check(value.optional1()).is("opt1");
+    check(value.optional2()).is("opt2");
+    check(value.optional3()).is(99);
+  }
+
+  @Test
+  public void multipleOptionalWithThreeParameters() {
+    // Omit optional3 (last optional)
+    MultipleOptional value = ImmutableMultipleOptional.of("req1", 100, "opt1", "opt2");
+    check(value.required1()).is("req1");
+    check(value.required2()).is(100);
+    check(value.optional1()).is("opt1");
+    check(value.optional2()).is("opt2");
+    check(value.optional3()).is(42); // default value
+  }
+
+  @Test
+  public void multipleOptionalWithTwoOptionalParameters() {
+    // Omit optional2 and optional3
+    MultipleOptional value = ImmutableMultipleOptional.of("req1", 100, "opt1");
+    check(value.required1()).is("req1");
+    check(value.required2()).is(100);
+    check(value.optional1()).is("opt1");
+    check(value.optional2()).isNull();
+    check(value.optional3()).is(42); // default value
+  }
+
+  @Test
+  public void multipleOptionalWithOnlyRequiredParameters() {
+    // Omit all optional parameters
+    MultipleOptional value = ImmutableMultipleOptional.of("req1", 100);
+    check(value.required1()).is("req1");
+    check(value.required2()).is(100);
+    check(value.optional1()).is("default1"); // default value
+    check(value.optional2()).isNull();
+    check(value.optional3()).is(42); // default value
+  }
+
+  @Test
+  public void nullableOptionalWithAllParameters() {
+    NullableOptional value = ImmutableNullableOptional.of("id123", "A description");
+    check(value.id()).is("id123");
+    check(value.description()).is("A description");
+  }
+
+  @Test
+  public void nullableOptionalWithoutOptionalParameter() {
+    // This of() overload should be generated
+    NullableOptional value = ImmutableNullableOptional.of("id123");
+    check(value.id()).is("id123");
+    check(value.description()).isNull();
+  }
+
+  @Test
+  public void nullableOptionalWithExplicitNull() {
+    // Can still pass null explicitly to the full of() method
+    NullableOptional value = ImmutableNullableOptional.of("id123", null);
+    check(value.id()).is("id123");
+    check(value.description()).isNull();
+  }
+}

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1241,6 +1241,26 @@ public [type.typeAbstract.relative] [v.names.with]([v.atNullability][tuNullable 
     return [validated type false]new [type.typeImmutable.relativeRaw][type.generics.diamond]([for v in type.constructorArguments][if not for.first], [/if][v.name][/for])[/validated];
   }
   [/if]
+  [-- Generate telescoping of() methods for optional parameters --]
+  [for variant in type.constructorArgumentsVariants]
+  [if not for.first][-- Skip the first variant as it's the full constructor already generated above --]
+
+  /**
+   * Construct a new immutable {@code [type.name]} instance.
+[javadocGenerics type]
+[for v in variant]
+   * @param [v.name] The value for the {@code [v.name]} attribute
+[/for]
+   * @return An immutable [type.name] instance
+   */
+  [eachLine type.constructorInjectedAnnotations]
+  public static [type.generics.spaceAfter][type.typeValue] [type.names.of]([for v in variant][if not for.first], [/if][v.atNullability][eachLine v.constructorParameterInjectedAnnotations][constructorAcceptType v] [v.name][/for]) {
+    return [castBuildStagedBuilder type][type.factoryBuilder.relative]()[/castBuildStagedBuilder]
+        [for v in variant].[v.names.init]([v.name])
+        [/for].[type.names.build]();
+  }
+  [/if]
+  [/for]
 [/if]
 [if type.useValidation]
 [if type.useJavaValidationApi]

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -1154,6 +1154,11 @@ public final class ValueAttribute extends TypeIntrospectionBase implements HasSt
     return true;
   }
 
+  public boolean isOptionalConstructorParameter() {
+    Optional<ParameterMirror> parameterAnnotation = ParameterMirror.find(element);
+    return parameterAnnotation.isPresent() && parameterAnnotation.get().optional();
+  }
+
   public String toSignature() {
     StringBuilder signature = new StringBuilder();
 

--- a/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueMirrors.java
@@ -81,6 +81,8 @@ public final class ValueMirrors {
     int order() default -1;
 
     boolean value() default true;
+
+    boolean optional() default false;
   }
 
   @Mirror.Annotation("org.immutables.value.Value.Default.String")

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -881,6 +881,63 @@ public final class ValueType extends TypeIntrospectionBase implements HasStyleIn
         .toList();
   }
 
+  @Nullable
+  private List<List<ValueAttribute>> constructorArgumentsVariants;
+
+  /**
+   * Returns a list of constructor argument lists for generating telescoping of() methods.
+   * The first list contains all constructor arguments, and each subsequent list drops
+   * one optional parameter from the end. Only parameters marked with
+   * {@code @Value.Parameter(optional = true)} at the end of the parameter list are dropped.
+   */
+  public List<List<ValueAttribute>> getConstructorArgumentsVariants() {
+    if (constructorArgumentsVariants == null) {
+      constructorArgumentsVariants = computeConstructorArgumentsVariants();
+      validateOptionalParameterOrdering();
+    }
+    return constructorArgumentsVariants;
+  }
+
+  private List<List<ValueAttribute>> computeConstructorArgumentsVariants() {
+    List<ValueAttribute> allArgs = ImmutableList.copyOf(getConstructorArguments());
+    if (allArgs.isEmpty()) {
+      return ImmutableList.of();
+    }
+
+    ImmutableList.Builder<List<ValueAttribute>> variants = ImmutableList.builder();
+    variants.add(allArgs);
+
+    // Trim optional parameters from the end, one at a time
+    int end = allArgs.size();
+    while (end > 0 && allArgs.get(end - 1).isOptionalConstructorParameter()) {
+      end--;
+      variants.add(allArgs.subList(0, end));
+    }
+
+    return variants.build();
+  }
+
+  private void validateOptionalParameterOrdering() {
+    List<ValueAttribute> args = ImmutableList.copyOf(getConstructorArguments());
+    boolean seenOptional = false;
+    for (ValueAttribute attr : args) {
+      if (attr.isOptionalConstructorParameter()) {
+        seenOptional = true;
+        // Validate that optional parameters have defaults or are nullable
+        if (!attr.isGenerateDefault && !attr.isNullable() && !attr.isOptionalType()) {
+          report().withElement(attr.element)
+              .error("@Value.Parameter(optional = true) requires the attribute to have "
+                  + "@Value.Default, be @Nullable, or be an Optional type");
+        }
+      } else if (seenOptional) {
+        report().withElement(attr.element)
+            .error("@Value.Parameter(optional = true) parameters must be at the end of the "
+                + "parameter list. Non-optional parameter '%s' follows an optional parameter.",
+                attr.name());
+      }
+    }
+  }
+
   private enum NonAuxiliary implements Predicate<ValueAttribute> {
     PREDICATE;
 


### PR DESCRIPTION
Intended as a solution to https://github.com/immutables/immutables/issues/1144

Works as follows:
- Generate of() with all parameters
- If the final parameter has optional = true, trim it and repeat

It is an error to use optional = true if
- said parameter is not nullable and lacks a default value
- a subsequent parameter lacks it

Includes unit test.