### PR TITLE
#1668 ECJ: Skip Javadoc section when searching for `extends` keyword

### DIFF
--- a/generator/src/org/immutables/generator/SourceExtraction.java
+++ b/generator/src/org/immutables/generator/SourceExtraction.java
@@ -260,7 +260,7 @@ public final class SourceExtraction {
 
     private static CharSequence extractSuperclass(SourceTypeBinding binding) {
       CharSequence declaration = readSourceDeclaration(binding);
-      StringTokenizer tokenizer = new StringTokenizer(declaration.toString(), "<>, \t\n\r", true);
+      StringTokenizer tokenizer = new StringTokenizer(declaration.toString(), "<>{}, \t\n\r", true);
       int genericsOpened = 0;
       while (tokenizer.hasMoreTokens()) {
         String t = tokenizer.nextToken();
@@ -306,7 +306,7 @@ public final class SourceExtraction {
 
       // Use modifiersSourceStart as the start bound: skip past any Javadoc comment that
       // precedes the declaration.
-      // Use bodyStart as the end bound: it's the exact position of the '{' that opens
+      // Use bodyStart as the end bound: it's the position just after the '{' that opens
       // the class body.
       int start = referenceContext.modifiersSourceStart;
       int end = referenceContext.bodyStart;

--- a/generator/src/org/immutables/generator/SourceExtraction.java
+++ b/generator/src/org/immutables/generator/SourceExtraction.java
@@ -259,7 +259,11 @@ public final class SourceExtraction {
     }
 
     private static CharSequence extractSuperclass(SourceTypeBinding binding) {
-      CharSequence declaration = readSourceDeclaration(binding);
+      // Strip all comments before tokenizing so that '{', '}', or 'extends' inside
+      // or next to a Javadoc or line comment does not affect the scan.
+      CharSequence declaration = stripComments(readSourceDeclaration(binding));
+      // Include '{' and '}' as delimiters: declaration may point one past '{' causing it
+      // to appear in the slice whenever there's no whitespace before the class body.
       StringTokenizer tokenizer = new StringTokenizer(declaration.toString(), "<>{}, \t\n\r", true);
       int genericsOpened = 0;
       while (tokenizer.hasMoreTokens()) {
@@ -280,6 +284,33 @@ public final class SourceExtraction {
         }
       }
       return UNABLE_TO_EXTRACT;
+    }
+
+    /** Removes {@code /* ... *\/} block comments and {@code //} line comments. */
+    private static CharSequence stripComments(CharSequence text) {
+      String s = text.toString();
+      StringBuilder sb = new StringBuilder(s.length());
+      int i = 0;
+      while (i < s.length()) {
+        char c = s.charAt(i);
+        if (c == '/' && i + 1 < s.length()) {
+          char next = s.charAt(i + 1);
+          if (next == '*') {
+            // block comment - skip to closing */
+            int end = s.indexOf("*/", i + 2);
+            i = (end < 0) ? s.length() : end + 2;
+            continue;
+          } else if (next == '/') {
+            // line comment - skip to end of line
+            int end = s.indexOf('\n', i + 2);
+            i = (end < 0) ? s.length() : end + 1;
+            continue;
+          }
+        }
+        sb.append(c);
+        i++;
+      }
+      return sb;
     }
 
     private static CharSequence readSourceSuperclass(StringTokenizer tokenizer) {
@@ -304,8 +335,8 @@ public final class SourceExtraction {
       TypeDeclaration referenceContext = binding.scope.referenceContext;
       char[] content = referenceContext.compilationResult.compilationUnit.getContents();
 
-      // Use modifiersSourceStart as the start bound: skip past any Javadoc comment that
-      // precedes the declaration.
+      // Use modifiersSourceStart as the start bound: it's either the position of the start
+      // of the declaration or the position of the Javadoc comment that precedes the declaration.
       // Use bodyStart as the end bound: it's the position just after the '{' that opens
       // the class body.
       int start = referenceContext.modifiersSourceStart;

--- a/generator/src/org/immutables/generator/SourceExtraction.java
+++ b/generator/src/org/immutables/generator/SourceExtraction.java
@@ -303,18 +303,14 @@ public final class SourceExtraction {
     private static CharSequence readSourceDeclaration(SourceTypeBinding binding) {
       TypeDeclaration referenceContext = binding.scope.referenceContext;
       char[] content = referenceContext.compilationResult.compilationUnit.getContents();
-      int start = referenceContext.declarationSourceStart;
-      int end = referenceContext.declarationSourceEnd;
 
-      StringBuilder declaration = new StringBuilder();
-      for (int p = start; p <= end; p++) {
-        char c = content[p];
-        if (c == '{') {
-          break;
-        }
-        declaration.append(c);
-      }
-      return declaration;
+      // Use modifiersSourceStart as the start bound: skip past any Javadoc comment that
+      // precedes the declaration.
+      // Use bodyStart as the end bound: it's the exact position of the '{' that opens
+      // the class body.
+      int start = referenceContext.modifiersSourceStart;
+      int end = referenceContext.bodyStart;
+      return new String(content, start, end - start);
     }
 
     private static CharSequence getRawType(MethodBinding methodBinding) {

--- a/value-fixture/src/org/immutables/fixture/builder/JavadocParentOfBuilder.java
+++ b/value-fixture/src/org/immutables/fixture/builder/JavadocParentOfBuilder.java
@@ -3,15 +3,29 @@ package org.immutables.fixture.builder;
 import org.immutables.value.Value;
 
 /**
- * Immutable class using parent-of-builder pattern. The builder's parent has a bit of commonplace Javadoc that happens
- * to contain a '{' symbol.
+ * Contains immutable classes using parent-of-builder pattern. The builder's parent has a bit of commonplace Javadoc
+ * that happens to contain a '{' symbol.
  */
-@Value.Immutable
-public abstract class JavadocParentOfBuilder {
+public class JavadocParentOfBuilder {
 
-    /**
-     * Builder class for {@link JavadocParentOfBuilder}.
-     */
-    static class Builder extends ImmutableJavadocParentOfBuilder.Builder { }
+    @Value.Immutable
+    static class WithSpace {
+
+        /**
+         * Builder class for {@link WithSpace}.
+         */
+        static class Builder extends ImmutableWithSpace.Builder { }
+
+    }
+
+    @Value.Immutable
+    static class WithoutSpace {
+
+        /**
+         * Builder class for {@link WithoutSpace}.
+         */
+        static class Builder extends ImmutableWithoutSpace.Builder{}
+
+    }
 
 }

--- a/value-fixture/src/org/immutables/fixture/builder/JavadocParentOfBuilder.java
+++ b/value-fixture/src/org/immutables/fixture/builder/JavadocParentOfBuilder.java
@@ -12,9 +12,12 @@ public class JavadocParentOfBuilder {
     static class WithSpace {
 
         /**
-         * Builder class for {@link WithSpace}.
+         * Builder class for {@link WithSpace} which extends the generated builder.
          */
-        static class Builder extends ImmutableWithSpace.Builder { }
+        // Inline comment
+        static class Builder extends
+                /* Block comment */
+                ImmutableWithSpace.Builder { }
 
     }
 
@@ -24,7 +27,7 @@ public class JavadocParentOfBuilder {
         /**
          * Builder class for {@link WithoutSpace}.
          */
-        static class Builder extends ImmutableWithoutSpace.Builder{}
+        static class Builder extends/*comment*/ ImmutableWithoutSpace./*comment*/Builder{}
 
     }
 

--- a/value-fixture/src/org/immutables/fixture/builder/JavadocParentOfBuilder.java
+++ b/value-fixture/src/org/immutables/fixture/builder/JavadocParentOfBuilder.java
@@ -1,0 +1,17 @@
+package org.immutables.fixture.builder;
+
+import org.immutables.value.Value;
+
+/**
+ * Immutable class using parent-of-builder pattern. The builder's parent has a bit of commonplace Javadoc that happens
+ * to contain a '{' symbol.
+ */
+@Value.Immutable
+public abstract class JavadocParentOfBuilder {
+
+    /**
+     * Builder class for {@link JavadocParentOfBuilder}.
+     */
+    static class Builder extends ImmutableJavadocParentOfBuilder.Builder { }
+
+}

--- a/value-fixture/test/org/immutables/fixture/builder/AttributeBuilderTest.java
+++ b/value-fixture/test/org/immutables/fixture/builder/AttributeBuilderTest.java
@@ -70,6 +70,12 @@ public class AttributeBuilderTest {
   }
 
   @Test
+  public void javadocParentOfBuilder() {
+    // Mostly checking for successful compilation - must have worked if we made it this far
+    check(new JavadocParentOfBuilder.Builder()).notNull();
+  }
+
+  @Test
   public void basicApiForVanillaParent() {
     assertBasicApi(ImmutableVanillaAttributeBuilderParent.class,
         VanillaAttributeBuilderParent.class,

--- a/value-fixture/test/org/immutables/fixture/builder/AttributeBuilderTest.java
+++ b/value-fixture/test/org/immutables/fixture/builder/AttributeBuilderTest.java
@@ -72,7 +72,8 @@ public class AttributeBuilderTest {
   @Test
   public void javadocParentOfBuilder() {
     // Mostly checking for successful compilation - must have worked if we made it this far
-    check(new JavadocParentOfBuilder.Builder()).notNull();
+    check(new JavadocParentOfBuilder.WithSpace.Builder()).notNull();
+    check(new JavadocParentOfBuilder.WithoutSpace.Builder()).notNull();
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/immutables/immutables/issues/1668

### Problem

A typical parent-of-builder class declaration looks like:
```
static class Builder extends ImmutableParentOfBuilder.Builder { }
```

That means the generated `ImmutableParentOfBuilder.Builder` class can't be marked `final` or compilation will fail. 

In ECJ mode, we're searching for the `extends` keyword to decide if the generated `Builder` shouldn't be marked `final`. That normally works fine.

However, when the declaration looks like this, we were accidentally including the Javadoc as part of the search string, and stopping the search at the first `{`. 
```
    /**
     * Builder class for {@link ParentOfBuilder}.
     */
    static class Builder extends ImmutableParentOfBuilder.Builder { }
```

In this case, the `extends` keyword wouldn't get detected, and the `Builder` would get marked `final`, causing a compile error.


### Solution

This PR changes the approach from "start at the Javadoc, search for `extends`, stop at the first `{`" to "start at the Javadoc, stop at the start of the body, strip out comments and Javadoc, then search for `extends`".

### Testing

Added a unit test - the test fails without the fix (when using `-Pecj`), and the test passes with the fix

Using custom build of `2.12.3-SNAPSHOT` fixes the Eclipse JDTLS issue seen in https://github.com/immutables/immutables/issues/1668