### PR TITLE
Fix #1665: prevent synthetic nullability from leaking onto mandatory attributes

### DIFF
--- a/value-fixture/src/org/immutables/fixture/nullable/typeuse/MandatoryOnlyNullMarked.java
+++ b/value-fixture/src/org/immutables/fixture/nullable/typeuse/MandatoryOnlyNullMarked.java
@@ -1,0 +1,29 @@
+package org.immutables.fixture.nullable.typeuse;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Style.ValidationMethod;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reproduces immutables/immutables#1665: under {@code @NullMarked} (JSpecify) combined with
+ * {@code validationMethod = MANDATORY_ONLY}, mandatory reference attributes get an internal
+ * "synthetic" nullability which must NOT leak onto the generated field/accessor as a type-use
+ * {@code @Nullable}. Only attributes explicitly marked {@code @Nullable} should be nullable.
+ */
+@NullMarked
+@Value.Immutable
+@Value.Style(
+    jdkOnly = true,
+    defaultAsDefault = true,
+    get = {"get*", "is*"},
+    nullableAnnotation = "org.jspecify.annotations.Nullable",
+    validationMethod = ValidationMethod.MANDATORY_ONLY)
+public interface MandatoryOnlyNullMarked {
+  /** Mandatory attribute: must never be annotated {@code @Nullable} in generated code. */
+  String getMandatory();
+
+  /** Explicitly nullable attribute: must be annotated {@code @Nullable} in generated code. */
+  @Nullable
+  String getOptional();
+}

--- a/value-fixture/test/org/immutables/fixture/nullable/TypeuseAnnotationTest.java
+++ b/value-fixture/test/org/immutables/fixture/nullable/TypeuseAnnotationTest.java
@@ -5,6 +5,7 @@ import org.immutables.fixture.nullable.typeuse.CusNull;
 import org.immutables.fixture.nullable.typeuse.ImmutableChildOverrides;
 import org.immutables.fixture.nullable.typeuse.ImmutableFirstChild;
 import org.immutables.fixture.nullable.typeuse.ImmutableLetsTryJSpecify;
+import org.immutables.fixture.nullable.typeuse.ImmutableMandatoryOnlyNullMarked;
 import org.immutables.fixture.nullable.typeuse.ImmutableMyField;
 import org.immutables.fixture.nullable.typeuse.ImmutableSecondChild;
 import org.immutables.fixture.nullable.typeuse.ImmutableTryCustomNullann;
@@ -82,6 +83,22 @@ public class TypeuseAnnotationTest {
     NullableArrays.ChildOverrides withNulls = ImmutableChildOverrides.builder().build();
     check(withNulls.primitiveArray()).isNull();
     check(withNulls.referenceArray()).isNull();
+  }
+
+  @Test void mandatoryOnlyDoesNotLeakNullableOnMandatory() throws Exception {
+    // Explicitly @Nullable attribute SHOULD be annotated.
+    check(ImmutableMandatoryOnlyNullMarked.class.getDeclaredField("optional")
+        .getAnnotatedType().getAnnotation(Nullable.class)).notNull();
+
+    check(ImmutableMandatoryOnlyNullMarked.class.getDeclaredMethod("getOptional")
+        .getAnnotatedReturnType().getAnnotation(Nullable.class)).notNull();
+
+    // Mandatory attribute must NOT be annotated @Nullable.
+    check(ImmutableMandatoryOnlyNullMarked.class.getDeclaredField("mandatory")
+        .getAnnotatedType().getAnnotation(Nullable.class)).isNull();
+
+    check(ImmutableMandatoryOnlyNullMarked.class.getDeclaredMethod("getMandatory")
+        .getAnnotatedReturnType().getAnnotation(Nullable.class)).isNull();
   }
 
   @Test void typeuseInheritance() throws Exception {

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttribute.java
@@ -1950,7 +1950,7 @@ public final class ValueAttribute extends TypeIntrospectionBase implements HasSt
   }
 
   public boolean whenTypeuseFallbackNullable() {
-    return isNullable() && fallbackNullableKind().isTypeuse();
+    return isNullable() && !isNullabilitySynthetic() && fallbackNullableKind().isTypeuse();
   }
 
   public boolean whenTypeuseNullableElement() {


### PR DESCRIPTION
### What was happening
Under `@NullMarked` (JSpecify) combined with `validationMethod = MANDATORY_ONLY`, mandatory reference attributes were being generated with a typeuse `@Nullable` on both the field and the accessor even though they aren't actually nullable. This tripped up NullAway with false positives.

### Why
Mandatory attributes get an internal "synthetic" nullability that's only meant for builder/validation logic. That synthetic marker was slipping through into the generated code as a real `@Nullable` annotation.

### The fix
Guarded `whenTypeuseFallbackNullable()` with `!isNullabilitySynthetic()`, so only attributes that are *explicitly* marked `@Nullable` emit the type-use annotation. Synthetic-only nullability stays internal, where it belongs.

### Tests
Added a regression test that verifies:
- mandatory attributes are **not** annotated `@Nullable`
- explicitly nullable attributes **still are**