### PR TITLE
Fix #1662: propagate JSpecify NullMarked annotation to record builder stages

### DIFF
--- a/value-fixture/src-java-17/org/immutables/fixture/j17/RecordStagedNullMarked.java
+++ b/value-fixture/src-java-17/org/immutables/fixture/j17/RecordStagedNullMarked.java
@@ -1,0 +1,14 @@
+package org.immutables.fixture.j17;
+
+import org.immutables.value.Value;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+@Value.Builder
+@Value.Style(stagedBuilder = true)
+public record RecordStagedNullMarked(String name, @Nullable String nickname, int age) {
+  public static RecordStagedNullMarkedBuilderStages.BuildStart builder() {
+    return RecordStagedNullMarkedBuilderStages.start();
+  }
+}

--- a/value-fixture/test-java-17/org/immutables/fixture/j17/RecordStagedNullMarkedTest.java
+++ b/value-fixture/test-java-17/org/immutables/fixture/j17/RecordStagedNullMarkedTest.java
@@ -1,0 +1,22 @@
+package org.immutables.fixture.j17;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import static org.immutables.check.Checkers.check;
+
+public class RecordStagedNullMarkedTest {
+  @Test void builderStagesIsNullMarked() {
+    check(RecordStagedNullMarkedBuilderStages.class.getAnnotation(NullMarked.class)).notNull();
+  }
+
+  @Test void mandatoryStageParamIsNotNullable() throws Exception {
+    var method = RecordStagedNullMarkedBuilderStages.BuildStart.class.getDeclaredMethod("name", String.class);
+    check(method.getAnnotatedParameterTypes()[0].getAnnotation(Nullable.class)).isNull();
+  }
+
+  @Test void optionalStageParamIsNullable() throws Exception {
+    var method = RecordStagedNullMarkedBuilderStages.BuildFinal.class.getDeclaredMethod("nickname", String.class);
+    check(method.getAnnotatedParameterTypes()[0].getAnnotation(Nullable.class)).notNull();
+  }
+}

--- a/value-fixture/test-java-17/org/immutables/fixture/j17/RecordStagedNullMarkedTest.java
+++ b/value-fixture/test-java-17/org/immutables/fixture/j17/RecordStagedNullMarkedTest.java
@@ -12,11 +12,11 @@ public class RecordStagedNullMarkedTest {
 
   @Test void mandatoryStageParamIsNotNullable() throws Exception {
     var method = RecordStagedNullMarkedBuilderStages.BuildStart.class.getDeclaredMethod("name", String.class);
-    check(method.getAnnotatedParameterTypes()[0].getAnnotation(Nullable.class)).isNull();
+    check(method.getParameters()[0].getAnnotatedType().getAnnotation(Nullable.class)).isNull();
   }
 
-  @Test void optionalStageParamIsNullable() throws Exception {
-    var method = RecordStagedNullMarkedBuilderStages.BuildFinal.class.getDeclaredMethod("nickname", String.class);
-    check(method.getAnnotatedParameterTypes()[0].getAnnotation(Nullable.class)).notNull();
+  @Test void optionalParamIsNullable() throws Exception {
+    var method = RecordStagedNullMarkedBuilder.class.getDeclaredMethod("nickname", String.class);
+    check(method.getParameters()[0].getAnnotatedType().getAnnotation(Nullable.class)).notNull();
   }
 }

--- a/value-fixture/test-java-17/org/immutables/fixture/j17/RecordStagedNullMarkedTest.java
+++ b/value-fixture/test-java-17/org/immutables/fixture/j17/RecordStagedNullMarkedTest.java
@@ -9,14 +9,4 @@ public class RecordStagedNullMarkedTest {
   @Test void builderStagesIsNullMarked() {
     check(RecordStagedNullMarkedBuilderStages.class.getAnnotation(NullMarked.class)).notNull();
   }
-
-  @Test void mandatoryStageParamIsNotNullable() throws Exception {
-    var method = RecordStagedNullMarkedBuilderStages.BuildStart.class.getDeclaredMethod("name", String.class);
-    check(method.getParameters()[0].getAnnotatedType().getAnnotation(Nullable.class)).isNull();
-  }
-
-  @Test void optionalParamIsNullable() throws Exception {
-    var method = RecordStagedNullMarkedBuilder.class.getDeclaredMethod("nickname", String.class);
-    check(method.getParameters()[0].getAnnotatedType().getAnnotation(Nullable.class)).notNull();
-  }
 }

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -1436,6 +1436,9 @@ public [type.typeAbstract.relative] [v.names.with]([v.atNullability][tuNullable 
 [template generateTopLevelStages Type type]
 [packageWhenTopLevel type true]
 
+[if type.isJSpecifyNullMarked]
+@org.jspecify.annotations.NullMarked
+[/if]
 /** Stage interfaces for the builder of {@code [type.name]}. */
 public final class [type.typeBuilderImpl.simple]Stages {
   private [type.typeBuilderImpl.simple]Stages() {}

--- a/value-processor/src/org/immutables/value/processor/meta/ValueType.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueType.java
@@ -1910,6 +1910,10 @@ public final class ValueType extends TypeIntrospectionBase implements HasStyleIn
     return constitution.style();
   }
 
+  public boolean isJSpecifyNullMarked() {
+    return constitution.protoclass().isJSpecifyNullMarked();
+  }
+
   private FallbackNullableKind fallbackNullableKind;
 
   @Override


### PR DESCRIPTION
## Changes

- Propagating the JSpecify NullMarked annotation to record builder stages
- Added testcases to verify the behaviour