### PR TITLE
Name attribute builder helpers after the value type

### DIFF
--- a/processor-testlib/test/org/immutables/value/processor/meta/AttributeBuilderHelperNamingTest.java
+++ b/processor-testlib/test/org/immutables/value/processor/meta/AttributeBuilderHelperNamingTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 Immutables Authors and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.immutables.value.processor.meta;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+import org.immutables.value.Value;
+import org.immutables.value.processor.Processor;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.immutables.check.Checkers.check;
+
+/**
+ * Attribute builder helpers are emitted once per value type and named after it, so two attributes
+ * reaching one value type by different routes have to resolve to a single helper. Here {@code Foo}
+ * is reached through the abstract type and through the generated {@code ImmutableFoo}, which yields
+ * two descriptors carrying the same value type name. Deduplicating helper definitions on anything
+ * finer than that name emits both under one signature, and the generated source stops compiling.
+ * <p>
+ * {@code ImmutableFoo} is only detected as buildable once it exists as a class file, so the value
+ * type and its consumer are compiled in separate passes.
+ */
+public class AttributeBuilderHelperNamingTest {
+
+  private static final String FOO = ""
+      + "package repro;\n"
+      + "import org.immutables.value.Value;\n"
+      + "@Value.Immutable\n"
+      + "@Value.Style(toBuilder = \"toBuilder\")\n"
+      + "public interface Foo {\n"
+      + "  String v();\n"
+      + "}\n";
+
+  private static final String PARENT = ""
+      + "package repro;\n"
+      + "import org.immutables.value.Value;\n"
+      + "@Value.Immutable\n"
+      + "@Value.Style(attributeBuilderDetection = true)\n"
+      + "public interface Parent {\n"
+      + "  Foo abstractTyped();\n"
+      + "  ImmutableFoo immutableTyped();\n"
+      + "}\n";
+
+  @Rule
+  public final TemporaryFolder folder = new TemporaryFolder();
+
+  @Test
+  public void singleHelperPerValueTypeAcrossDetectionStrategies() throws IOException {
+    File annotations = codeSourceOf(Value.class);
+
+    File valueTypeClasses = folder.newFolder("value-type-classes");
+    List<String> valueTypeErrors = compile(FOO, "repro.Foo",
+        valueTypeClasses, folder.newFolder("value-type-sources"),
+        Collections.singletonList(annotations));
+    check(valueTypeErrors.toString(), valueTypeErrors.isEmpty());
+
+    List<String> consumerErrors = compile(PARENT, "repro.Parent",
+        folder.newFolder("consumer-classes"), folder.newFolder("consumer-sources"),
+        Arrays.asList(annotations, valueTypeClasses));
+    check(consumerErrors.toString(), consumerErrors.isEmpty());
+  }
+
+  /**
+   * Compiles a single source with the value processor attached.
+   * @return error diagnostics, empty when the source and everything generated from it compiled
+   */
+  private static List<String> compile(
+      String source,
+      String typeName,
+      File classOutput,
+      File sourceOutput,
+      List<File> classpath) throws IOException {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+
+    try (StandardJavaFileManager files = compiler.getStandardFileManager(diagnostics, null, null)) {
+      files.setLocation(StandardLocation.CLASS_OUTPUT, Collections.singleton(classOutput));
+      files.setLocation(StandardLocation.SOURCE_OUTPUT, Collections.singleton(sourceOutput));
+      files.setLocation(StandardLocation.CLASS_PATH, classpath);
+
+      JavaCompiler.CompilationTask task = compiler.getTask(null, files, diagnostics,
+          Collections.<String>emptyList(), null,
+          Collections.singletonList(new StringSource(typeName, source)));
+      task.setProcessors(Collections.singletonList(new Processor()));
+      task.call();
+    }
+
+    List<String> errors = new ArrayList<>();
+    for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
+      if (diagnostic.getKind() == Diagnostic.Kind.ERROR) {
+        errors.add(diagnostic.toString());
+      }
+    }
+    return errors;
+  }
+
+  private static File codeSourceOf(Class<?> type) {
+    try {
+      return new File(type.getProtectionDomain().getCodeSource().getLocation().toURI());
+    } catch (URISyntaxException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static final class StringSource extends SimpleJavaFileObject {
+    private final String source;
+
+    StringSource(String typeName, String source) {
+      super(URI.create("string:///" + typeName.replace('.', '/') + Kind.SOURCE.extension),
+          Kind.SOURCE);
+      this.source = source;
+    }
+
+    @Override
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+      return source;
+    }
+  }
+}

--- a/value-fixture/src/org/immutables/fixture/builder/DerivedAttributeBuilderParent.java
+++ b/value-fixture/src/org/immutables/fixture/builder/DerivedAttributeBuilderParent.java
@@ -1,0 +1,27 @@
+package org.immutables.fixture.builder;
+
+import org.immutables.value.Value;
+
+@Value.Style(attributeBuilderDetection = true)
+public interface DerivedAttributeBuilderParent {
+
+  @Value.Immutable
+  interface Payload {
+    String name();
+  }
+
+  // Payload is reached under three attribute names, one of which is derived. Attribute builder
+  // helpers are emitted per type, so all three must resolve to the same helper.
+  @Value.Immutable
+  @Value.Style(attributeBuilderDetection = true)
+  interface Holder {
+    Payload primary();
+
+    Payload secondary();
+
+    @Value.Derived
+    default Payload computed() {
+      return ImmutablePayload.builder().name(primary().name() + secondary().name()).build();
+    }
+  }
+}

--- a/value-fixture/src/org/immutables/fixture/builder/DerivedAttributeBuilderParent.java
+++ b/value-fixture/src/org/immutables/fixture/builder/DerivedAttributeBuilderParent.java
@@ -2,7 +2,6 @@ package org.immutables.fixture.builder;
 
 import org.immutables.value.Value;
 
-@Value.Style(attributeBuilderDetection = true)
 public interface DerivedAttributeBuilderParent {
 
   @Value.Immutable

--- a/value-fixture/test/org/immutables/fixture/builder/DerivedAttributeBuilderTest.java
+++ b/value-fixture/test/org/immutables/fixture/builder/DerivedAttributeBuilderTest.java
@@ -1,0 +1,35 @@
+package org.immutables.fixture.builder;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static org.immutables.check.Checkers.check;
+
+public class DerivedAttributeBuilderTest {
+
+  @Test
+  public void derivedAttributeOfABuildableTypeIsUsable() {
+    DerivedAttributeBuilderParent.Holder holder = ImmutableHolder.builder()
+        .primary(ImmutablePayload.builder().name("a").build())
+        .secondary(ImmutablePayload.builder().name("b").build())
+        .build();
+
+    check(holder.computed().name()).is("ab");
+  }
+
+  @Test
+  public void attributeBuilderHelpersAreNamedAfterTheType() {
+    Set<String> helpers = Stream.of(ImmutableHolder.class.getDeclaredMethods())
+        .map(Method::getName)
+        .filter(name -> name.endsWith("ValueOf") || name.endsWith("ToBuilder"))
+        .collect(Collectors.toSet());
+
+    check(!helpers.isEmpty());
+    for (String helper : helpers) {
+      check(helper).startsWith(ImmutablePayload.class.getName().replace('.', '_'));
+    }
+  }
+}

--- a/value-processor/src/org/immutables/value/processor/Immutables.generator
+++ b/value-processor/src/org/immutables/value/processor/Immutables.generator
@@ -4953,8 +4953,8 @@ private static java.util.List<[v.getAttributeBuilderDescriptor.getQualifiedBuild
 [/if]
 [/template]
 
-[template convertToBuilderType AttributeBuilder n][n.attributeName]ToBuilder[/template]
-[template convertToValueType AttributeBuilder n][n.attributeName]ValueOf[/template]
+[template convertToBuilderType AttributeBuilder n][n.getQualifiedValueTypeNameWithUnderscores]ToBuilder[/template]
+[template convertToValueType AttributeBuilder n][n.getQualifiedValueTypeNameWithUnderscores]ValueOf[/template]
 
 [template copyBuilderListBody Attribute v Boolean toValueType Boolean vargs String listToTransform]
 [let listType][if toValueType][if v.hasAttributeValue][v.attributeValueType.typeValue][else][v.getAttributeBuilderDescriptor.getQualifiedValueTypeName][/if][else][v.getAttributeBuilderDescriptor.getQualifiedBuilderTypeName][/if][/let]

--- a/value-processor/src/org/immutables/value/processor/meta/ValueAttributeFunctions.java
+++ b/value-processor/src/org/immutables/value/processor/meta/ValueAttributeFunctions.java
@@ -18,7 +18,6 @@ package org.immutables.value.processor.meta;
 import com.google.common.base.Predicate;
 import java.util.HashSet;
 import java.util.Set;
-import javax.annotation.Nullable;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -157,24 +156,19 @@ final class ValueAttributeFunctions {
     return new UniqueOnAttributeBuilderDescriptor();
   }
 
+  /**
+   * Attribute builder helpers are emitted once per value type and named after it, so the
+   * uniqueness key has to be the value type name. Keying on the whole descriptor lets two
+   * attributes that reach one value type by different routes - one declared with the abstract
+   * type, one with the generated immutable type - each emit a helper under the same name.
+   */
   private static class UniqueOnAttributeBuilderDescriptor implements Predicate<ValueAttribute> {
-    Set<AttributeBuilderDescriptor> uniqueSet;
+    private final Set<String> uniqueSet = new HashSet<>();
 
-    public UniqueOnAttributeBuilderDescriptor() {
-      uniqueSet = new HashSet<>();
-    }
-
-    @Nullable
     @Override
     public boolean apply(ValueAttribute valueAttribute) {
-
-      if (uniqueSet.contains(checkNotNull(valueAttribute.getAttributeBuilderDescriptor()))) {
-        return false;
-      }
-
-      uniqueSet.add(valueAttribute.getAttributeBuilderDescriptor());
-
-      return true;
+      return uniqueSet.add(checkNotNull(valueAttribute.getAttributeBuilderDescriptor())
+          .getQualifiedValueTypeName());
     }
 
     @Override


### PR DESCRIPTION
Fixes #1672.

Attribute builder helpers are emitted once per buildable type but named after an attribute, and which attribute wins depends on which one the processor analysed first — `AttributeBuilderReflection.analyzedReturnTypes` is a static cache keyed by the contained type and never cleared. Identical sources then generate different code between runs, and `ImmutableBeta` can end up with helpers named after an attribute of `Alpha`.

Naming them after the value type removes the ordering dependency. `AttributeBuilderDescriptor.getQualifiedValueTypeNameWithUnderscores()` already existed for this and was unreferenced.

The uniqueness filter had to move to the same key. It deduplicated on the whole descriptor, which is finer: an attribute declared with the abstract type and one declared with the generated immutable type keep separate descriptors, so both emit a helper under the same name and the generated source stops compiling. That shape compiles on master, so changing the name without changing the key would have broken it on upgrade.

Two tests — a fixture reaching one buildable type under three attribute names, one of them `@Value.Derived`; and a two-stage compilation test for the duplicate helper, because a type is only detected as buildable once its immutable exists as a class file. `value-fixture` passes with 327 tests.

Supersedes #1673, which added the attribute name to the cache key instead. That breaks value types with a `@Value.Derived` attribute of a buildable type: call sites are generated for every attribute-builder attribute, but definitions only for settable ones.
